### PR TITLE
chore: update element internal force sign and remove pNewDT and stepTime

### DIFF
--- a/edelweissfe/elements/base/baseelement.py
+++ b/edelweissfe/elements/base/baseelement.py
@@ -144,7 +144,7 @@ class BaseElement(BaseNodeCouplingEntity, VIJEntityBase):
         faceID: int,
         load: np.ndarray,
         U: np.ndarray,
-        time: np.ndarray,
+        time: float,
         dT: float,
     ):
         """Evaluate residual and stiffness for given time, field, and field increment due to a surface load.
@@ -164,19 +164,19 @@ class BaseElement(BaseNodeCouplingEntity, VIJEntityBase):
         U
             The current solution vector.
         time
-            Array of step time and total time.
+            The current time.
         dTime
             The time increment.
         """
 
     @abstractmethod
-    def computeYourself(
+    def computeKernels(
         self,
         P: np.ndarray,
         K: np.ndarray,
         U: np.ndarray,
         dU: np.ndarray,
-        time: np.ndarray,
+        time: float,
         dT: float,
     ):
         """Evaluate the internal forces and stiffness for given time, field, and field increment.
@@ -192,18 +192,18 @@ class BaseElement(BaseNodeCouplingEntity, VIJEntityBase):
         dU
             The current solution vector increment.
         time
-            Array of step time and total time.
+            The current time.
         dTime
             The time increment.
         """
 
     @abstractmethod
-    def computeYourselfExplicit(
+    def computeKernelsExplicit(
         self,
         P: np.ndarray,
         U: np.ndarray,
         dU: np.ndarray,
-        time: np.ndarray,
+        time: float,
         dT: float,
     ):
         """Evaluate the internal forces for given time, field, and field increment.
@@ -217,7 +217,7 @@ class BaseElement(BaseNodeCouplingEntity, VIJEntityBase):
         dU
             The current solution vector increment.
         time
-            Array of step time and total time.
+            The current time.
         dTime
             The time increment.
         """
@@ -269,7 +269,7 @@ class BaseElement(BaseNodeCouplingEntity, VIJEntityBase):
         K: np.ndarray,
         load: np.ndarray,
         U: np.ndarray,
-        time: np.ndarray,
+        time: float,
         dTime: float,
     ):
         """Evaluate residual and stiffness for given time, field, and field increment due to a body force load.
@@ -285,7 +285,7 @@ class BaseElement(BaseNodeCouplingEntity, VIJEntityBase):
         U
             The current solution vector.
         time
-            Array of step time and total time.
+            The current time.
         dTime
             The time increment.
         """

--- a/edelweissfe/elements/displacementelement/element.py
+++ b/edelweissfe/elements/displacementelement/element.py
@@ -343,7 +343,7 @@ class DisplacementElement(BaseElement):
             # get stiffness matrix for element j in point i
             K += B.T @ C @ B * detJ * self._t * self._weight[i]
             # calculate P
-            P -= B.T @ stress[self._activeVoigtIndices] * detJ * self._weight[i] * self._t
+            P += B.T @ stress[self._activeVoigtIndices] * detJ * self._weight[i] * self._t
             # update strain in stateVars
             self._stateVarsTemp[i][6:12] += self._dStrain[i]
 
@@ -388,7 +388,7 @@ class DisplacementElement(BaseElement):
             # Jacobi determinant
             detJ = lin.det(self.J[i])
             # calculate P
-            P -= B.T @ stress[self._activeVoigtIndices] * detJ * self._weight[i] * self._t
+            P += B.T @ stress[self._activeVoigtIndices] * detJ * self._weight[i] * self._t
             # update strain in stateVars
             self._stateVarsTemp[i][6:12] += self._dStrain[i]
 

--- a/edelweissfe/elements/displacementelement/element.py
+++ b/edelweissfe/elements/displacementelement/element.py
@@ -262,7 +262,7 @@ class DisplacementElement(BaseElement):
         faceID: int,
         load: np.ndarray,
         U: np.ndarray,
-        time: np.ndarray,
+        time: float,
         dTime: float,
     ):
         """Evaluate residual and stiffness for given time, field, and field increment due to a surface load.
@@ -282,20 +282,20 @@ class DisplacementElement(BaseElement):
         U
             The current solution vector.
         time
-            Array of step time and total time.
+            The current time.
         dTime
             The time increment.
         """
 
         raise Exception("Applying a distributed load is currently not possible with this element provider.")
 
-    def computeYourself(
+    def computeKernels(
         self,
         K_: np.ndarray,
         P: np.ndarray,
         U: np.ndarray,
         dU: np.ndarray,
-        time: np.ndarray,
+        time: float,
         dTime: float,
     ):
         """Evaluate the residual and stiffness matrix for given time, field, and field increment due to a displacement or load.
@@ -311,7 +311,7 @@ class DisplacementElement(BaseElement):
         dU
             The current solution vector increment.
         time
-            Array of step time and total time.
+            The current time.
         dTime
             The time increment.
         """
@@ -347,12 +347,12 @@ class DisplacementElement(BaseElement):
             # update strain in stateVars
             self._stateVarsTemp[i][6:12] += self._dStrain[i]
 
-    def computeYourselfExplicit(
+    def computeKernelsExplicit(
         self,
         P: np.ndarray,
         U: np.ndarray,
         dU: np.ndarray,
-        time: np.ndarray,
+        time: float,
         dTime: float,
     ):
         """Evaluate the residual for given time, field, and field increment due to a displacement or load.
@@ -366,7 +366,7 @@ class DisplacementElement(BaseElement):
         dU
             The current solution vector increment.
         time
-            Array of step time and total time.
+            The current time.
         dTime
             The time increment.
         """
@@ -393,7 +393,7 @@ class DisplacementElement(BaseElement):
             self._stateVarsTemp[i][6:12] += self._dStrain[i]
 
     def computeBodyForce(
-        self, P: np.ndarray, K: np.ndarray, load: np.ndarray, U: np.ndarray, time: np.ndarray, dTime: float
+        self, P: np.ndarray, K: np.ndarray, load: np.ndarray, U: np.ndarray, time: float, dTime: float
     ):
         """Evaluate residual and stiffness for given time, field, and field increment due to a body force load.
 
@@ -408,7 +408,7 @@ class DisplacementElement(BaseElement):
         U
             The current solution vector.
         time
-            Array of step time and total time.
+            The current time.
         dTime
             The time increment.
         """

--- a/edelweissfe/elements/displacementtlelement/element.py
+++ b/edelweissfe/elements/displacementtlelement/element.py
@@ -412,7 +412,7 @@ class DisplacementTLElement(BaseElement):
                     dim,
                 )
                 # compute inner forces
-                P -= (self.nablaN[i].T @ PK1[:dim, :dim]).flatten() * detJ * self._t * self._weight[i]
+                P += (self.nablaN[i].T @ PK1[:dim, :dim]).flatten() * detJ * self._t * self._weight[i]
             else:  # for non-hyperelastic materials
                 self._dStrain[i, self._activeVoigtIndices] = doVoigtStrain(dim, self._E[i] - self._Eold[i])
                 if not self.planeStrain and dim == 2:
@@ -423,7 +423,7 @@ class DisplacementTLElement(BaseElement):
                 Cm = self._dStress_dStrain[i][self._matrixVoigtIndices][:, self._matrixVoigtIndices]
                 Hk = B[i].T @ Cm @ B[i] + Hgeo(self.nablaN[i], stress, dim)
                 # compute inner forces
-                P -= B[i].T @ stress[self._matrixVoigtIndices] * detJ * self._weight[i] * self._t
+                P += B[i].T @ stress[self._matrixVoigtIndices] * detJ * self._weight[i] * self._t
             # calculate complete stiffness matrix
             K += Hk * detJ * self._t * self._weight[i]
 
@@ -485,7 +485,7 @@ class DisplacementTLElement(BaseElement):
                 # update strain in stateVars
                 self._stateVarsTemp[i][6:12] = self._strain[i]
                 # compute inner forces
-                P -= (self.nablaN[i].T @ PK1[:dim, :dim]).flatten() * detJ * self._t * self._weight[i]
+                P += (self.nablaN[i].T @ PK1[:dim, :dim]).flatten() * detJ * self._t * self._weight[i]
             else:  # for non-hyperelastic materials
                 self._dStrain[i, self._activeVoigtIndices] = doVoigtStrain(dim, self._E[i] - self._Eold[i])
                 if not self.planeStrain and dim == 2:
@@ -494,7 +494,7 @@ class DisplacementTLElement(BaseElement):
                     self.material.computeStress(stress, self._dStress_dStrain[i], self._dStrain[i], time, dTime)
                 self._stateVarsTemp[i][6:12] += self._dStrain[i]
                 # compute inner forces
-                P -= B[i].T @ stress[self._matrixVoigtIndices] * detJ * self._weight[i] * self._t
+                P += B[i].T @ stress[self._matrixVoigtIndices] * detJ * self._weight[i] * self._t
 
     def computeBodyForce(
         self, P: np.ndarray, K: np.ndarray, load: np.ndarray, U: np.ndarray, time: np.ndarray, dTime: float

--- a/edelweissfe/elements/displacementtlelement/element.py
+++ b/edelweissfe/elements/displacementtlelement/element.py
@@ -317,7 +317,7 @@ class DisplacementTLElement(BaseElement):
         faceID: int,
         load: np.ndarray,
         U: np.ndarray,
-        time: np.ndarray,
+        time: float,
         dTime: float,
     ):
         """Evaluate residual and stiffness for given time, field, and field increment due to a surface load.
@@ -337,20 +337,20 @@ class DisplacementTLElement(BaseElement):
         U
             The current solution vector.
         time
-            Array of step time and total time.
+            The current time.
         dTime
             The time increment.
         """
 
         raise Exception("Applying a distributed load is currently not possible with this element provider.")
 
-    def computeYourself(
+    def computeKernels(
         self,
         K_: np.ndarray,
         P: np.ndarray,
         U: np.ndarray,
         dU: np.ndarray,
-        time: np.ndarray,
+        time: float,
         dTime: float,
     ):
         """Evaluate the residual and stiffness matrix for given time, field, and field increment due to a displacement or load.
@@ -366,7 +366,7 @@ class DisplacementTLElement(BaseElement):
         dU
             The current solution vector increment.
         time
-            Array of step time and total time.
+            The current time.
         dTime
             The time increment.
         """
@@ -427,12 +427,12 @@ class DisplacementTLElement(BaseElement):
             # calculate complete stiffness matrix
             K += Hk * detJ * self._t * self._weight[i]
 
-    def computeYourselfExplicit(
+    def computeKernelsExplicit(
         self,
         P: np.ndarray,
         U: np.ndarray,
         dU: np.ndarray,
-        time: np.ndarray,
+        time: float,
         dTime: float,
     ):
         """Evaluate the residual for given time, field, and field increment due to a displacement or load.
@@ -446,7 +446,7 @@ class DisplacementTLElement(BaseElement):
         dU
             The current solution vector increment.
         time
-            Array of step time and total time.
+            The current time.
         dTime
             The time increment.
         """
@@ -497,7 +497,7 @@ class DisplacementTLElement(BaseElement):
                 P += B[i].T @ stress[self._matrixVoigtIndices] * detJ * self._weight[i] * self._t
 
     def computeBodyForce(
-        self, P: np.ndarray, K: np.ndarray, load: np.ndarray, U: np.ndarray, time: np.ndarray, dTime: float
+        self, P: np.ndarray, K: np.ndarray, load: np.ndarray, U: np.ndarray, time: float, dTime: float
     ):
         """Evaluate residual and stiffness for given time, field, and field increment due to a body force load.
 
@@ -512,7 +512,7 @@ class DisplacementTLElement(BaseElement):
         U
             The current solution vector.
         time
-            Array of step time and total time.
+            The current time.
         dTime
             The time increment.
         """

--- a/edelweissfe/elements/marmotelement/element.pxd
+++ b/edelweissfe/elements/marmotelement/element.pxd
@@ -93,15 +93,13 @@ cdef extern from "Marmot/MarmotElement.h":
                              double* Pe,
                              double* Ke,
                              const double* time,
-                             double dT,
-                             double& pNewdT) except +ValueError
+                             double dT) except +
 
         void computeYourselfExplicit(const double* QTotal,
                                      const double* dQ,
                                      double* Pe,
                                      const double* time,
-                                     double dT,
-                                     double& pNewdT) except +ValueError
+                                     double dT) except +
 
         void setInitialConditions(StateTypes state,
                                   const double* values)

--- a/edelweissfe/elements/marmotelement/element.pxd
+++ b/edelweissfe/elements/marmotelement/element.pxd
@@ -88,18 +88,18 @@ cdef extern from "Marmot/MarmotElement.h":
 
         void initializeYourself()
 
-        void computeYourself(const double* QTotal,
-                             const double* dQ,
-                             double* Pe,
-                             double* Ke,
-                             const double* time,
-                             double dT) except +
+        void computeKernels(const double* QTotal,
+                            const double* dQ,
+                            double* Pe,
+                            double* Ke,
+                            double time,
+                            double dT) except +
 
-        void computeYourselfExplicit(const double* QTotal,
-                                     const double* dQ,
-                                     double* Pe,
-                                     const double* time,
-                                     double dT) except +
+        void computeKernelsExplicit(const double* QTotal,
+                                    const double* dQ,
+                                    double* Pe,
+                                    double time,
+                                    double dT) except +
 
         void setInitialConditions(StateTypes state,
                                   const double* values)
@@ -111,7 +111,7 @@ cdef extern from "Marmot/MarmotElement.h":
                                 int faceID,
                                 const double* load,
                                 const double* QTotal,
-                                const double* time,
+                                double time,
                                 double dT)
 
         void computeBodyForce(
@@ -119,7 +119,7 @@ cdef extern from "Marmot/MarmotElement.h":
                         double* K,
                         const double* load,
                         const double* QTotal,
-                        const double* time,
+                        double time,
                         double dT)
 
         void computeLumpedInertia(double* M)
@@ -170,17 +170,17 @@ cdef class MarmotElementWrapper:
 
     cpdef void _initializeStateVarsTemp(self, ) noexcept  nogil
 
-    cpdef void computeYourself(self,
-                               double[::1] Ke,
-                               double[::1] Pe,
-                               const double[::1] U,
-                               const double[::1] dU,
-                               const double[::1] time,
-                               double dTime) except * nogil
+    cpdef void computeKernels(self,
+                              double[::1] Ke,
+                              double[::1] Pe,
+                              const double[::1] U,
+                              const double[::1] dU,
+                              double time,
+                              double dTime) except *
 
-    cpdef void computeYourselfExplicit(self,
-                                       double[::1] Pe,
-                                       const double[::1] U,
-                                       const double[::1] dU,
-                                       const double[::1] time,
-                                       double dTime) except * nogil
+    cpdef void computeKernelsExplicit(self,
+                                      double[::1] Pe,
+                                      const double[::1] U,
+                                      const double[::1] dU,
+                                      double time,
+                                      double dTime) except *

--- a/edelweissfe/elements/marmotelement/element.pyx
+++ b/edelweissfe/elements/marmotelement/element.pyx
@@ -35,6 +35,8 @@ cimport cython
 cimport libcpp.cast
 cimport numpy as np
 
+from edelweissfe.utils.exceptions import CutbackRequest
+
 cimport edelweissfe.elements.marmotelement.element
 
 mapLoadTypes={
@@ -206,47 +208,53 @@ cdef class MarmotElementWrapper:
         self.marmotElement.setInitialConditions(mapStateTypes[stateType], &values[0])
         self.acceptLastState()
 
-    cpdef void computeYourself(self,
-                               double[::1] Ke,
-                               double[::1] Pe,
-                               const double[::1] U,
-                               const double[::1] dU,
-                               const double[::1] time,
-                               double dTime) except * nogil:
+    cpdef void computeKernels(self,
+                              double[::1] Ke,
+                              double[::1] Pe,
+                              const double[::1] U,
+                              const double[::1] dU,
+                              double time,
+                              double dTime) except *:
         """Evaluate residual and stiffness for given time, field, and field increment."""
 
         if not self._hasMaterial:
             raise Exception("Element {:} has no material assigned!".format(self._elNumber))
 
-        with nogil:
-            self._initializeStateVarsTemp()
+        try:
+            with nogil:
+                self._initializeStateVarsTemp()
 
-            self.marmotElement.computeYourself(&U[0],
-                                               &dU[0],
-                                               &Pe[0],
-                                               &Ke[0],
-                                               &time[0],
-                                               dTime)
+                self.marmotElement.computeKernels(&U[0],
+                                                  &dU[0],
+                                                  &Pe[0],
+                                                  &Ke[0],
+                                                  time,
+                                                  dTime)
+        except (RuntimeError, ValueError) as e:
+            raise CutbackRequest(str(e), 0.5)
 
-    cpdef void computeYourselfExplicit(self,
-                                       double[::1] Pe,
-                                       const double[::1] U,
-                                       const double[::1] dU,
-                                       const double[::1] time,
-                                       double dTime) except * nogil:
+    cpdef void computeKernelsExplicit(self,
+                                      double[::1] Pe,
+                                      const double[::1] U,
+                                      const double[::1] dU,
+                                      double time,
+                                      double dTime) except *:
         """Evaluate residual and stiffness for given time, field, and field increment."""
 
         if not self._hasMaterial:
             raise Exception("Element {:} has no material assigned!".format(self._elNumber))
 
-        with nogil:
-            self._initializeStateVarsTemp()
+        try:
+            with nogil:
+                self._initializeStateVarsTemp()
 
-            self.marmotElement.computeYourselfExplicit(&U[0],
-                                                       &dU[0],
-                                                       &Pe[0],
-                                                       &time[0],
-                                                       dTime)
+                self.marmotElement.computeKernelsExplicit(&U[0],
+                                                          &dU[0],
+                                                          &Pe[0],
+                                                          time,
+                                                          dTime)
+        except (RuntimeError, ValueError) as e:
+            raise CutbackRequest(str(e), 0.5)
 
     def computeDistributedLoad(self,
                                str loadType,
@@ -255,7 +263,7 @@ cdef class MarmotElementWrapper:
                                int faceID,
                                const double[::1] load,
                                const double[::1] U,
-                               const double[::1] time,
+                               double time,
                                double dTime):
         """Evaluate residual and stiffness for given time, field, and field increment due to a surface load."""
 
@@ -265,7 +273,7 @@ cdef class MarmotElementWrapper:
                                                   faceID,
                                                   &load[0],
                                                   &U[0],
-                                                  &time[0],
+                                                  time,
                                                   dTime)
 
     def computeBodyForce(self,
@@ -273,7 +281,7 @@ cdef class MarmotElementWrapper:
                          double[::1] K,
                          const double[::1] load,
                          const double[::1] U,
-                         const double[::1] time,
+                         double time,
                          double dTime):
         """Evaluate residual and stiffness for given time, field, and field increment due to a volume load."""
 
@@ -282,7 +290,7 @@ cdef class MarmotElementWrapper:
                                     &K[0],
                                     &load[0],
                                     &U[0],
-                                    &time[0],
+                                    time,
                                     dTime)
 
     def computeLumpedInertia(self, double[::1] M):

--- a/edelweissfe/elements/marmotelement/element.pyx
+++ b/edelweissfe/elements/marmotelement/element.pyx
@@ -37,8 +37,6 @@ cimport numpy as np
 
 cimport edelweissfe.elements.marmotelement.element
 
-from edelweissfe.utils.exceptions import CutbackRequest
-
 mapLoadTypes={
         "pressure" : DistributedLoadTypes.Pressure,
         "surface torsion" : DistributedLoadTypes.SurfaceTorsion,
@@ -220,21 +218,15 @@ cdef class MarmotElementWrapper:
         if not self._hasMaterial:
             raise Exception("Element {:} has no material assigned!".format(self._elNumber))
 
-        cdef double pNewDT
         with nogil:
             self._initializeStateVarsTemp()
-
-            pNewDT = 1e36
 
             self.marmotElement.computeYourself(&U[0],
                                                &dU[0],
                                                &Pe[0],
                                                &Ke[0],
                                                &time[0],
-                                               dTime,
-                                               pNewDT)
-            if pNewDT < 1.0:
-                raise CutbackRequest("Element {:} requests for a cutback!".format(self.elNumber), pNewDT)
+                                               dTime)
 
     cpdef void computeYourselfExplicit(self,
                                        double[::1] Pe,
@@ -247,20 +239,14 @@ cdef class MarmotElementWrapper:
         if not self._hasMaterial:
             raise Exception("Element {:} has no material assigned!".format(self._elNumber))
 
-        cdef double pNewDT
         with nogil:
             self._initializeStateVarsTemp()
-
-            pNewDT = 1e36
 
             self.marmotElement.computeYourselfExplicit(&U[0],
                                                        &dU[0],
                                                        &Pe[0],
                                                        &time[0],
-                                                       dTime,
-                                                       pNewDT)
-            if pNewDT < 1.0:
-                raise CutbackRequest("Element {:} requests for a cutback!".format(self.elNumber), pNewDT)
+                                                       dTime)
 
     def computeDistributedLoad(self,
                                str loadType,

--- a/edelweissfe/elements/marmotsingleqpelement/element.py
+++ b/edelweissfe/elements/marmotsingleqpelement/element.py
@@ -196,8 +196,6 @@ class MarmotMaterialWrappingElement(BaseElement):
 
         self._marmotMaterialWrapper.computeYourself(Ke, Pe, U, dU, time, dTime)
 
-        Pe *= -1
-
     def computeYourselfExplicit(
         self,
         Pe,
@@ -209,8 +207,6 @@ class MarmotMaterialWrappingElement(BaseElement):
         self._initializeStateVarsTemp()
 
         self._marmotMaterialWrapper.computeYourselfExplicit(Pe, U, dU, time, dTime)
-
-        Pe *= -1
 
     def computeLumpedInertia(self, Me):
         """Not implemented for this wrapper."""

--- a/edelweissfe/elements/marmotsingleqpelement/element.py
+++ b/edelweissfe/elements/marmotsingleqpelement/element.py
@@ -183,52 +183,70 @@ class MarmotMaterialWrappingElement(BaseElement):
 
         self.acceptLastState()
 
-    def computeYourself(
+    def computeKernels(
         self,
-        Ke,
-        Pe,
-        U,
-        dU,
-        time,
-        dTime,
+        Ke: np.ndarray,
+        Pe: np.ndarray,
+        U: np.ndarray,
+        dU: np.ndarray,
+        time: float,
+        dTime: float,
     ):
         self._initializeStateVarsTemp()
 
-        self._marmotMaterialWrapper.computeYourself(Ke, Pe, U, dU, time, dTime)
+        self._marmotMaterialWrapper.computeKernels(Ke, Pe, U, dU, time, dTime)
 
-    def computeYourselfExplicit(
+    def computeKernelsExplicit(
         self,
-        Pe,
-        U,
-        dU,
-        time,
-        dTime,
+        Pe: np.ndarray,
+        U: np.ndarray,
+        dU: np.ndarray,
+        time: float,
+        dTime: float,
     ):
         self._initializeStateVarsTemp()
 
-        self._marmotMaterialWrapper.computeYourselfExplicit(Pe, U, dU, time, dTime)
+        self._marmotMaterialWrapper.computeKernelsExplicit(Pe, U, dU, time, dTime)
 
-    def computeLumpedInertia(self, Me):
+    def computeLumpedInertia(self, Me: np.ndarray):
         """Not implemented for this wrapper."""
 
         raise ValueError("This should not be called for this wrapper.")
 
-    def computeCriticalTimeStepForExplicitDynamics(self, Q):
+    def computeCriticalTimeStepForExplicitDynamics(self, Q: np.ndarray):
         """Not implemented for this wrapper."""
 
         raise ValueError("This should not be called for this wrapper.")
 
-    def computeDistributedLoad(self, loadType, P, K, faceID, load, U, time, dTime):
+    def computeDistributedLoad(
+        self,
+        loadType: str,
+        P: np.ndarray,
+        K: np.ndarray,
+        faceID: int,
+        load: np.ndarray,
+        U: np.ndarray,
+        time: float,
+        dTime: float,
+    ):
         """Not implemented for this wrapper."""
 
         raise ValueError("This should not be called for this wrapper.")
 
-    def computeInternalEnergy(self):
+    def computeInternalEnergy(self) -> float:
         """Not implemented for this wrapper."""
 
         raise ValueError("This should not be called for this wrapper.")
 
-    def computeBodyForce(self, P, K, load, U, time, dTime):
+    def computeBodyForce(
+        self,
+        P: np.ndarray,
+        K: np.ndarray,
+        load: np.ndarray,
+        U: np.ndarray,
+        time: float,
+        dTime: float,
+    ):
         """Not implemented for this wrapper."""
 
         raise ValueError("This should not be called for this wrapper.")

--- a/edelweissfe/elements/marmotsingleqpelement/marmotmaterialgradientenhancedhypoelasticwrapper.pyx
+++ b/edelweissfe/elements/marmotsingleqpelement/marmotmaterialgradientenhancedhypoelasticwrapper.pyx
@@ -75,13 +75,13 @@ cdef class MarmotMaterialGradientEnhancedHypoElasticWrapper:
     def setCharacteristicElementLength(self, double length):
         pass
 
-    def computeYourself(self,
-                        double[::1] Ke,
-                        double[::1] Pe,
-                        const double[::1] QTotal,
-                        const double[::1] dQ,
-                        const double[::1] time,
-                        double dTime):
+    def computeKernels(self,
+                       double[::1] Ke,
+                       double[::1] Pe,
+                       const double[::1] QTotal,
+                       const double[::1] dQ,
+                       double time,
+                       double dTime):
 
         cdef double pNewDT
         pNewDT = 1e36
@@ -100,19 +100,24 @@ cdef class MarmotMaterialGradientEnhancedHypoElasticWrapper:
         S[:] = self.stressLikeInStateVars[0:6]
         cdef double KLocal = self.stressLikeInStateVars[self.nU-1]
 
-        self.marmotMaterialGradientEnhancedHypoElastic.computeStress(
-                &S[0],
-                KLocal,
-                nonLocalRadius,
-                &C[0],
-                &dKLocal_dDE[0],
-                &dS_dK[0],
-                &dStrain[0],
-                KOld,
-                dK,
-                &time[0],
-                dTime,
-                pNewDT)
+        cdef double[2] time_arr = [0.0, time]
+
+        try:
+            self.marmotMaterialGradientEnhancedHypoElastic.computeStress(
+                    &S[0],
+                    KLocal,
+                    nonLocalRadius,
+                    &C[0],
+                    &dKLocal_dDE[0],
+                    &dS_dK[0],
+                    &dStrain[0],
+                    KOld,
+                    dK,
+                    &time_arr[0],
+                    dTime,
+                    pNewDT)
+        except (ValueError, RuntimeError) as e:
+            raise CutbackRequest(str(e), 0.25)
 
         Pe[0:6] = S
         Pe[6] = - KLocal + QTotal[6]

--- a/edelweissfe/elements/marmotsingleqpelement/marmotmaterialhypoelasticwrapper.pyx
+++ b/edelweissfe/elements/marmotsingleqpelement/marmotmaterialhypoelasticwrapper.pyx
@@ -73,13 +73,13 @@ cdef class MarmotMaterialHypoElasticWrapper:
     def setCharacteristicElementLength(self, double[::1] values):
         self.marmotMaterialHypoElastic.setCharacteristicElementLength(values[0])
 
-    def computeYourself(self,
-                        double[::1] Ke,
-                        double[::1] Pe,
-                        const double[::1] U,
-                        const double[::1] dU,
-                        const double[::1] time,
-                        double dTime):
+    def computeKernels(self,
+                       double[::1] Ke,
+                       double[::1] Pe,
+                       const double[::1] U,
+                       const double[::1] dU,
+                       double time,
+                       double dTime):
 
         cdef Matrix6d dStress_dStrain = Matrix6d(&Ke[0])
         cdef Vector6d dStrain = Vector6d(&dU[0])
@@ -89,7 +89,7 @@ cdef class MarmotMaterialHypoElasticWrapper:
         state3D.stress = Vector6d(&self.stressInStateVars[0])
 
         cdef MarmotMaterialHypoElastic.timeInfo timeInfo
-        timeInfo.time = time[1]
+        timeInfo.time = time
         timeInfo.dT = dTime
 
         try:
@@ -98,8 +98,8 @@ cdef class MarmotMaterialHypoElasticWrapper:
                 dStress_dStrain,
                 dStrain,
                 timeInfo)
-        except ValueError:
-            raise CutbackRequest("Material requests for a cutback!", 0.25)
+        except (ValueError, RuntimeError) as e:
+            raise CutbackRequest(str(e), 0.25)
 
         cdef int i = 0
         for i in range(6):

--- a/edelweissfe/solvers/base/parallelelementcomputation.py
+++ b/edelweissfe/solvers/base/parallelelementcomputation.py
@@ -30,8 +30,6 @@
 import concurrent.futures
 import itertools
 
-import numpy as np
-
 from edelweissfe.elements.base.baseelement import BaseElement
 from edelweissfe.numerics.dofmanager import DofVector, VIJSystemMatrix
 from edelweissfe.numerics.parallelizationutilities import (
@@ -78,7 +76,7 @@ def computeElementsInParallel(
         P.createScatterVector()
     )  # make a scatter vector; which gives 1) contiguous memory access and 2) thread safety
 
-    time = np.array([timeStep.stepTime, timeStep.totalTime])
+    time = timeStep.totalTime
     dT = timeStep.timeIncrement
 
     def computeElementsWorker(element: BaseElement):
@@ -86,7 +84,7 @@ def computeElementsInParallel(
         Ue = Un1[element]
         dUe = dU[element]
         Ke = K[element]
-        element.computeYourself(Ke, Pe, Ue, dUe, time, dT)
+        element.computeKernels(Ke, Pe, Ue, dUe, time, dT)
 
     numThreads = getNumberOfThreads() if isFreeThreadingSupported() else 1
 
@@ -114,7 +112,7 @@ def computeElementsInParallelForExplicit(
 ) -> tuple[DofVector, float]:
 
     scatter_P = P.createScatterVector()
-    time = np.array([timeStep.stepTime, timeStep.totalTime])
+    time = timeStep.totalTime
     dT = timeStep.timeIncrement
 
     # Define the worker to process a CHUNK of elements, not just one.
@@ -125,7 +123,7 @@ def computeElementsInParallelForExplicit(
             Ue = Un1[element]
             dUe = dU[element]
 
-            element.computeYourselfExplicit(Pe, Ue, dUe, time, dT)
+            element.computeKernelsExplicit(Pe, Ue, dUe, time, dT)
             chunk_psi += element.computeInternalEnergy()
 
         return chunk_psi

--- a/edelweissfe/solvers/nonlinearexplicitdynamic.py
+++ b/edelweissfe/solvers/nonlinearexplicitdynamic.py
@@ -252,7 +252,7 @@ class NED(NonlinearSolverBase):
                         prevTimeStep,
                     )
 
-                except (CutbackRequest, RuntimeError) as e:
+                except CutbackRequest as e:
                     self.journal.message(str(e), self.identification, 1)
                     cutback = getattr(e, "cutbackSize", 0.25)
                     step.discardAndChangeIncrement(max(cutback, 0.25))
@@ -434,7 +434,7 @@ class NED(NonlinearSolverBase):
             The augmented load vector.
         """
 
-        time = np.array([timeStep.stepTime, timeStep.totalTime])
+        time = timeStep.totalTime
         dT = timeStep.timeIncrement
 
         for dLoad in distributedLoads:
@@ -477,7 +477,7 @@ class NED(NonlinearSolverBase):
             The augmented load vector and system matrix.
         """
 
-        time = np.array([timeStep.stepTime, timeStep.totalTime])
+        time = timeStep.totalTime
         dT = timeStep.timeIncrement
 
         for bForce in bodyForces:
@@ -525,13 +525,13 @@ class NED(NonlinearSolverBase):
             - The modified accumulated flux vector.
         """
 
-        time = np.array([timeStep.stepTime, timeStep.totalTime])
+        time = timeStep.totalTime
         dT = timeStep.timeIncrement
         P[:] = 0.0
         psi = 0.0
         for el in elements.values():
             Pe = np.zeros(el.nDof)
-            el.computeYourselfExplicit(Pe, U_np[el], dU[el], time, dT)
+            el.computeKernelsExplicit(Pe, U_np[el], dU[el], time, dT)
             psi += el.computeInternalEnergy()
             P[el] += Pe
 

--- a/edelweissfe/solvers/nonlinearexplicitdynamic.py
+++ b/edelweissfe/solvers/nonlinearexplicitdynamic.py
@@ -252,9 +252,10 @@ class NED(NonlinearSolverBase):
                         prevTimeStep,
                     )
 
-                except CutbackRequest as e:
+                except (CutbackRequest, RuntimeError) as e:
                     self.journal.message(str(e), self.identification, 1)
-                    step.discardAndChangeIncrement(max(e.cutbackSize, 0.25))
+                    cutback = getattr(e, "cutbackSize", 0.25)
+                    step.discardAndChangeIncrement(max(cutback, 0.25))
                     prevTimeStep = None
 
                     for man in outputmanagers:
@@ -389,6 +390,7 @@ class NED(NonlinearSolverBase):
 
         P[:] = 0.0
         P, psi = self.computeElements(elements, U_n, dU, P, timeStep)
+        P[:] = -P[:]
         P = self.assembleLoads(nodeforces, distributedLoads, bodyForces, U_n, P, timeStep)
 
         if timeStep.number % self.options["output-frequency"] == 0:

--- a/edelweissfe/solvers/nonlinearexplicitstatic.py
+++ b/edelweissfe/solvers/nonlinearexplicitstatic.py
@@ -300,9 +300,10 @@ class NEST(NIST):
 
                     step.changeIncrementSize(incScaleFactor)
 
-                except CutbackRequest as e:
+                except (CutbackRequest, RuntimeError) as e:
                     self.journal.message(str(e), self.identification, 1)
-                    step.discardAndChangeIncrement(max(e.cutbackSize, 0.25))
+                    cutback = getattr(e, "cutbackSize", 0.25)
+                    step.discardAndChangeIncrement(max(cutback, 0.25))
                     prevTimeStep = None
 
                     statusInfoDict["notes"] = str(e)
@@ -435,7 +436,7 @@ class NEST(NIST):
             PExt, K = self.assembleLoads(nodeforces, distributedLoads, bodyForces, U_np, PExt, K, timeStep)
             PExt, K = self.assembleConstraints(constraints, U_np, dU_[k], PExt, K, timeStep)
 
-            R[:] = P
+            R[:] = -P
             R += PExt
 
             R = self.applyDirichlet(timeStep, R, dirichlets)

--- a/edelweissfe/solvers/nonlinearexplicitstatic.py
+++ b/edelweissfe/solvers/nonlinearexplicitstatic.py
@@ -300,7 +300,7 @@ class NEST(NIST):
 
                     step.changeIncrementSize(incScaleFactor)
 
-                except (CutbackRequest, RuntimeError) as e:
+                except CutbackRequest as e:
                     self.journal.message(str(e), self.identification, 1)
                     cutback = getattr(e, "cutbackSize", 0.25)
                     step.discardAndChangeIncrement(max(cutback, 0.25))

--- a/edelweissfe/solvers/nonlinearimplicitstatic.py
+++ b/edelweissfe/solvers/nonlinearimplicitstatic.py
@@ -229,7 +229,7 @@ class NIST(NonlinearSolverBase):
                         maxGrowingIter,
                     )
 
-                except (CutbackRequest, RuntimeError) as e:
+                except CutbackRequest as e:
                     self.journal.message(str(e), self.identification, 1)
                     cutback = getattr(e, "cutbackSize", cutbackFactor)
                     step.discardAndChangeIncrement(max(cutback, cutbackFactor))
@@ -460,7 +460,7 @@ class NIST(NonlinearSolverBase):
             The augmented load vector and system matrix.
         """
 
-        time = np.array([timeStep.stepTime, timeStep.totalTime])
+        time = timeStep.totalTime
         dT = timeStep.timeIncrement
 
         for dLoad in distributedLoads:
@@ -507,7 +507,7 @@ class NIST(NonlinearSolverBase):
             The augmented load vector and system matrix.
         """
 
-        time = np.array([timeStep.stepTime, timeStep.totalTime])
+        time = timeStep.totalTime
         dT = timeStep.timeIncrement
 
         for bForce in bodyForces:
@@ -565,14 +565,14 @@ class NIST(NonlinearSolverBase):
             - The modified accumulated flux vector.
         """
 
-        time = np.array([timeStep.stepTime, timeStep.totalTime])
+        time = timeStep.totalTime
         dT = timeStep.timeIncrement
 
         for el in elements.values():
             Ke = K[el]
             Pe = np.zeros(el.nDof)
 
-            el.computeYourself(Ke, Pe, U_np[el], dU[el], time, dT)
+            el.computeKernels(Ke, Pe, U_np[el], dU[el], time, dT)
 
             P[el] += Pe
             F[el] += abs(Pe)

--- a/edelweissfe/solvers/nonlinearimplicitstatic.py
+++ b/edelweissfe/solvers/nonlinearimplicitstatic.py
@@ -229,9 +229,10 @@ class NIST(NonlinearSolverBase):
                         maxGrowingIter,
                     )
 
-                except CutbackRequest as e:
+                except (CutbackRequest, RuntimeError) as e:
                     self.journal.message(str(e), self.identification, 1)
-                    step.discardAndChangeIncrement(max(e.cutbackSize, cutbackFactor))
+                    cutback = getattr(e, "cutbackSize", cutbackFactor)
+                    step.discardAndChangeIncrement(max(cutback, cutbackFactor))
                     prevTimeStep = None
 
                     statusInfoDict["iters"] = np.inf
@@ -393,7 +394,7 @@ class NIST(NonlinearSolverBase):
             PExt, K = self.assembleLoads(nodeforces, distributedLoads, bodyForces, U_np, PExt, K, timeStep)
             PExt, K = self.assembleConstraints(constraints, U_np, dU, PExt, K, timeStep)
 
-            R[:] = P
+            R[:] = -P
             R += PExt
 
             if iterationCounter == 0 and not isExtrapolatedIncrement and dirichlets:

--- a/edelweissfe/solvers/nonlinearimplicitstaticparallelarclength.py
+++ b/edelweissfe/solvers/nonlinearimplicitstaticparallelarclength.py
@@ -260,7 +260,7 @@ class NISTPArcLength(NISTParallel):
             K_f -= K_0
 
             # Dead and Reference load ..
-            R_0[:] = P_0 + (Lambda + dLambda) * P_f + P
+            R_0[:] = P_0 + (Lambda + dLambda) * P_f - P
             R_f[:] = P_f
 
             # add stiffness contribution


### PR DESCRIPTION
- Modified python elements (DisplacementElement, DisplacementTLElement, MarmotMaterialWrappingElement) to accumulate internal forces with a positive sign.
- Updated solvers to compute the residual as R = P_ext - P_int.
- Removed outdated pNewDT / pNewdT reference parameters from Cython element.pxd and element.pyx wrappers.
- Enabled standard exception translation (+except) and modified Python solvers to catch RuntimeError to trigger step cutbacks.