### PR TITLE
fix: use eigh instead of eig in tensorLogarithmEig to avoid spurious …

### DIFF
--- a/edelweissfe/utils/plasticityutils.py
+++ b/edelweissfe/utils/plasticityutils.py
@@ -68,21 +68,28 @@ def deviatoricNorm(devStress):
 
 
 def tensorLogarithmEig(A):
-    """Computes the logarithm of a tensor using eigenvalues and eigenvectors.
+    """Computes the logarithm of a symmetric positive-definite tensor using eigenvalues and eigenvectors.
+
+    Uses ``numpy.linalg.eigh`` (symmetric eigendecomposition) to guarantee
+    real eigenvalues and orthogonal eigenvectors. This avoids spurious
+    imaginary parts that ``numpy.linalg.eig`` can introduce due to
+    floating-point rounding for symmetric matrices such as the left
+    Cauchy-Green tensor.
 
     Parameters
     ----------
     A
-        The tensor, the logarithm should be computed of.
+        The symmetric positive-definite tensor whose logarithm should be
+        computed.
 
     Returns
     -------
     np.ndarray
         The tensor logarithm of A."""
 
-    (x, V) = lin.eig(A)
+    (x, V) = lin.eigh(A)
     A_ = np.diag(np.log(x))
-    return V @ A_ @ lin.inv(V)
+    return V @ A_ @ V.T
 
 
 def tensorExp(A):


### PR DESCRIPTION
…complex eigenvalues

For symmetric positive-definite tensors (e.g. the left Cauchy-Green tensor Btrial), numpy.linalg.eig can introduce tiny imaginary parts due to floating-point rounding, causing the logarithm to return complex128 values. These then fail when assigned back into float64 state arrays with: 'Cannot cast ufunc add output from dtype complex128 to dtype float64 with casting rule same_kind'.

Fix: use numpy.linalg.eigh (symmetric/Hermitian eigendecomposition) which guarantees real eigenvalues and orthogonal eigenvectors, and reconstruct via V @ diag @ V.T instead of V @ diag @ inv(V). This resolves the CantileverBeamQuad8NeoHookeWaPlastic, WbPlastic and WcPlastic test failures in the CI pipeline.