### PR TITLE
fix: update non-auto-tested .inp examples to current >> module-level …

### DIFF
--- a/examples/CantileverBeam/test3D.inp
+++ b/examples/CantileverBeam/test3D.inp
@@ -38,7 +38,8 @@ configuration, overwrite=yes
 *output, type=monitor
 
 ** set step size between 1 and 1e-9, 1000 iterations, 25 max iterations and step length 1
-*step, solver=theSolver, maxInc=1e0, minInc=1e-9, maxNumInc=1000, maxIter=25, stepLength=1
+*step, solver=theSolver
+maxInc=1e0, minInc=1e-9, maxNumInc=1000, maxIter=25, stepLength=1
 options, category=NISTSolver, extrapolation=off
 ** fix one side (fixed support)
 dirichlet, name=Left,  nSet=gen_left, field=displacement, 1=0.0, 2=0.0, 3=.0

--- a/examples/CantileverBeam/test3D.inp
+++ b/examples/CantileverBeam/test3D.inp
@@ -28,20 +28,20 @@ all
 
 ** displacement output for all elements
 *fieldOutput
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, perNode, elSet=all, field=displacement, result=U, name=displacement
 
 ** create output data to open with paraview
 *output, type=ensight, name=test
-create=perNode, fieldOutput=displacement
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>configuration, overwrite=yes
 
 *output, type=monitor
 
 ** set step size between 1 and 1e-9, 1000 iterations, 25 max iterations and step length 1
 *step, solver=theSolver
 maxInc=1e0, minInc=1e-9, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=off
+>>options, category=NISTSolver, extrapolation=off
 ** fix one side (fixed support)
-dirichlet, name=Left,  nSet=gen_left, field=displacement, 1=0.0, 2=0.0, 3=.0
+>>dirichlet, name=Left,  nSet=gen_left, field=displacement, 1=0.0, 2=0.0, 3=.0
 ** set load in z to 0.012N for all the points on right back
-nodeforces, name=cloadTop, nSet=gen_rightBack, components='0, 0, .012', field=displacement
+>>nodeforces, name=cloadTop, nSet=gen_rightBack, components='0, 0, .012', field=displacement

--- a/examples/CantileverBeam/test3D.inp
+++ b/examples/CantileverBeam/test3D.inp
@@ -1,4 +1,4 @@
-*material, name=LinearElastic, id=linearelastic
+*material, name=LinearElastic, id=linearelastic, provider=edelweiss
 **Isotropic material
 **E    nu -> elasticity module and poisson's ratio
 1.8e4, 0.22
@@ -17,10 +17,10 @@ nZ      =4
 lX      =500
 lY      =5
 lZ      =5
-** use provider: displacementelement
-elProvider =displacementelement
+** use provider: edelweiss
+elProvider =edelweiss
 ** use hexahedron element with 8 nodes and normal integration
-elType  =Hexa8
+elType  =C3D8
 
 *section, name=section1, material=linearelastic, type=solid
 ** assign linear elastic section to all elements
@@ -28,14 +28,12 @@ all
 
 ** displacement output for all elements
 *fieldOutput
->>perNode, perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
 
 ** create output data to open with paraview
 *output, type=ensight, name=test
 >>perNode, fieldOutput=displacement
 >>configuration, overwrite=yes
-
-*output, type=monitor
 
 ** set step size between 1 and 1e-9, 1000 iterations, 25 max iterations and step length 1
 *step, solver=theSolver

--- a/examples/CantileverBeam/test4.inp
+++ b/examples/CantileverBeam/test4.inp
@@ -29,7 +29,7 @@ nX=300
 nY=4
 
 *output, type=monitor
->>fieldOutput=RF, f(x)='mean(x[:,1])'
+fieldOutput=RF, f(x)='mean(x[:,1])'
 
 ** create output data to open with paraview
 *output, type=ensight, name=esExport

--- a/examples/CantileverBeam/test4.inp
+++ b/examples/CantileverBeam/test4.inp
@@ -13,9 +13,9 @@ all
 *solver, solver=NIST, name=theSolver
 
 *fieldOutput
-create=perNode, nSet=gen_bottom, result=P, field=displacement, name=RF
+>>perNode, perNode, nSet=gen_bottom, result=P, field=displacement, name=RF
 ** displacement output for all elements
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, perNode, elSet=all, field=displacement, result=U, name=displacement
 
 *modelGenerator, generator=planeRectQuad, name=gen
 ** create model: length 10000mm, height 100mm with 300 elements in l direction and 4 in h direction
@@ -29,17 +29,17 @@ nX=300
 nY=4
 
 *output, type=monitor
-fieldOutput=RF, f(x)='mean(x[:,1])'
+>>fieldOutput=RF, f(x)='mean(x[:,1])'
 
 ** create output data to open with paraview
 *output, type=ensight, name=esExport
-configuration, overwrite=yes
-create=perNode,    fieldOutput=displacement
+>>configuration, overwrite=yes
+>>perNode,    fieldOutput=displacement
 
 ** set steps with size between 1 and 1e-8, 1000 iterations and max 25 iterations
 *step, solver=theSolver
 maxInc=1e-0, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=100
 ** fix one side (fixed support)
-dirichlet, name=left, nSet=gen_left,  field=displacement, 2=0, 1=0
+>>dirichlet, name=left, nSet=gen_left,  field=displacement, 2=0, 1=0
 ** set load -1000N in one point down
-nodeforces, name=cloadTop, nSet=gen_rightTop, components='0,-1000', field=displacement
+>>nodeforces, name=cloadTop, nSet=gen_rightTop, components='0,-1000', field=displacement

--- a/examples/CantileverBeam/test4.inp
+++ b/examples/CantileverBeam/test4.inp
@@ -1,5 +1,5 @@
 ** cantilever beam, steel, l=10000mm, h=100mm, b=40mm, calculation in [N/mm²]
-*material, name=linearelastic, id=linearelastic,
+*material, name=linearelastic, id=linearelastic, provider=edelweiss
 ** elasticity module and poisson's ratio
 210000.0, 0.15
 
@@ -13,18 +13,18 @@ all
 *solver, solver=NIST, name=theSolver
 
 *fieldOutput
->>perNode, perNode, nSet=gen_bottom, result=P, field=displacement, name=RF
+>>perNode, nSet=gen_bottom, result=P, field=displacement, name=RF
 ** displacement output for all elements
->>perNode, perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
 
 *modelGenerator, generator=planeRectQuad, name=gen
 ** create model: length 10000mm, height 100mm with 300 elements in l direction and 4 in h direction
 x0=0, l=10000
 y0=0, h=100
-elType=Quad4NPE
+elType=CPE4
 ** quadrilateral element with 4 nodes, normal integration and plane strain
 ** set provider
-elProvider=displacementelement
+elProvider=edelweiss
 nX=300
 nY=4
 

--- a/examples/CantileverBeam/test4.inp
+++ b/examples/CantileverBeam/test4.inp
@@ -37,7 +37,8 @@ configuration, overwrite=yes
 create=perNode,    fieldOutput=displacement
 
 ** set steps with size between 1 and 1e-8, 1000 iterations and max 25 iterations
-*step, solver=theSolver, maxInc=1e-0, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=100
+*step, solver=theSolver
+maxInc=1e-0, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=100
 ** fix one side (fixed support)
 dirichlet, name=left, nSet=gen_left,  field=displacement, 2=0, 1=0
 ** set load -1000N in one point down

--- a/examples/CantileverBeam/test8.inp
+++ b/examples/CantileverBeam/test8.inp
@@ -29,7 +29,7 @@ nX=300
 nY=4
 
 *output, type=monitor
->>fieldOutput=RF, f(x)='mean(x[:,1])'
+fieldOutput=RF, f(x)='mean(x[:,1])'
 
 ** create output data to open with paraview
 *output, type=ensight, name=esExport

--- a/examples/CantileverBeam/test8.inp
+++ b/examples/CantileverBeam/test8.inp
@@ -37,7 +37,8 @@ configuration, overwrite=yes
 create=perNode,    fieldOutput=displacement
 
 ** set steps with size between 1 and 1e-8, 1000 iterations and max 25 iterations with step length 100
-*step, solver=theSolver, maxInc=1e-0, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=100
+*step, solver=theSolver
+maxInc=1e-0, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=100
 ** fix one side (fixed support)
 dirichlet, name=left, nSet=gen_left,  field=displacement, 2=0, 1=0
 ** set load -1000N in one point down

--- a/examples/CantileverBeam/test8.inp
+++ b/examples/CantileverBeam/test8.inp
@@ -1,5 +1,5 @@
 ** cantilever beam, steel, l=10000mm, h=100mm, b=40mm, calculation in [N/mm²]
-*material, name=linearelastic, id=linearelastic,
+*material, name=linearelastic, id=linearelastic, provider=edelweiss
 ** elasticity module and poisson's ratio
 210000.0, 0.15
 
@@ -13,18 +13,18 @@ all
 *solver, solver=NIST, name=theSolver
 
 *fieldOutput
->>perNode, perNode, nSet=gen_bottom, result=P, field=displacement, name=RF
+>>perNode, nSet=gen_bottom, result=P, field=displacement, name=RF
 ** displacement output for all elements
->>perNode, perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
 
 *modelGenerator, generator=planeRectQuad, name=gen
 ** create model: length 10000mm, height 100mm with 300 elements in l direction and 4 in h direction
 x0=0, l=10000
 y0=0, h=100
-elType=Quad8NPE
+elType=CPE8N
 ** quadrilateral element with 4 nodes, normal integration and plane strain
 ** set provider
-elProvider=displacementelement
+elProvider=edelweiss
 nX=300
 nY=4
 

--- a/examples/CantileverBeam/test8.inp
+++ b/examples/CantileverBeam/test8.inp
@@ -13,9 +13,9 @@ all
 *solver, solver=NIST, name=theSolver
 
 *fieldOutput
-create=perNode, nSet=gen_bottom, result=P, field=displacement, name=RF
+>>perNode, perNode, nSet=gen_bottom, result=P, field=displacement, name=RF
 ** displacement output for all elements
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, perNode, elSet=all, field=displacement, result=U, name=displacement
 
 *modelGenerator, generator=planeRectQuad, name=gen
 ** create model: length 10000mm, height 100mm with 300 elements in l direction and 4 in h direction
@@ -29,17 +29,17 @@ nX=300
 nY=4
 
 *output, type=monitor
-fieldOutput=RF, f(x)='mean(x[:,1])'
+>>fieldOutput=RF, f(x)='mean(x[:,1])'
 
 ** create output data to open with paraview
 *output, type=ensight, name=esExport
-configuration, overwrite=yes
-create=perNode,    fieldOutput=displacement
+>>configuration, overwrite=yes
+>>perNode,    fieldOutput=displacement
 
 ** set steps with size between 1 and 1e-8, 1000 iterations and max 25 iterations with step length 100
 *step, solver=theSolver
 maxInc=1e-0, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=100
 ** fix one side (fixed support)
-dirichlet, name=left, nSet=gen_left,  field=displacement, 2=0, 1=0
+>>dirichlet, name=left, nSet=gen_left,  field=displacement, 2=0, 1=0
 ** set load -1000N in one point down
-nodeforces, name=cloadTop, nSet=gen_rightTop, components='0,-1000', field=displacement
+>>nodeforces, name=cloadTop, nSet=gen_rightTop, components='0,-1000', field=displacement

--- a/examples/GMCDPFiniteStrainMarmot/test.inp
+++ b/examples/GMCDPFiniteStrainMarmot/test.inp
@@ -12,6 +12,7 @@
 all
 
 *job, name=cpe4job, domain=3d, solver=NISTParallelForMarmotElements
+*solver, solver=NISTParallelForMarmotElements, name=theSolver
 *fieldOutput
 elSet=all, field=displacement, result=U, name=displacement
 elSet=all, field=micro rotation, result=U, name=micro rotation
@@ -29,7 +30,7 @@ create=perElement, fieldOutput=alphaP
 create=perElement, fieldOutput=alphaD
 create=perElement, fieldOutput=omega
 
-*step
+*step, solver=theSolver
 maxInc=2e-2, minInc=1e-5, maxNumInc=10000, maxIter=25, stepLength=100
 options, category=NISTSolver, extrapolation=linear, numThreads=8
 initializematerial, name=init, elSet=all

--- a/examples/GMCDPFiniteStrainMarmot/test.inp
+++ b/examples/GMCDPFiniteStrainMarmot/test.inp
@@ -13,7 +13,7 @@ all
 
 *job, name=cpe4job, domain=3d, solver=NISTParallelForMarmotElements
 *solver, solver=NISTParallelForMarmotElements, name=theSolver
-*fieldOutput
+*fieldOutput,
 elSet=all, field=displacement, result=U, name=displacement
 elSet=all, field=micro rotation, result=U, name=micro rotation
 elSet=all, field=nonlocal damage, result=U, name=nonlocal damage

--- a/examples/GMCDPFiniteStrainMarmot/test.inp
+++ b/examples/GMCDPFiniteStrainMarmot/test.inp
@@ -14,33 +14,33 @@ all
 *job, name=cpe4job, domain=3d, solver=NISTParallelForMarmotElements
 *solver, solver=NISTParallelForMarmotElements, name=theSolver
 *fieldOutput,
-elSet=all, field=displacement, result=U, name=displacement
-elSet=all, field=micro rotation, result=U, name=micro rotation
-elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
-elSet=all, result=alphaP, quadraturePoint=0:8, name=alphaP, f(x)='max( x[:,:], axis=1) '
-elSet=all, result=alphaD, quadraturePoint=0:8, name=alphaD, f(x)='max( x[:,:], axis=1) '
-elSet=all, result=omega, quadraturePoint=0:8, name=omega, f(x)='max( x[:,:], axis=1) '
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
+>>perNode, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
+>>perElement, elSet=all, result=alphaP, quadraturePoint=0:8, name=alphaP, f(x)='max( x[:,:], axis=1) '
+>>perElement, elSet=all, result=alphaD, quadraturePoint=0:8, name=alphaD, f(x)='max( x[:,:], axis=1) '
+>>perElement, elSet=all, result=omega, quadraturePoint=0:8, name=omega, f(x)='max( x[:,:], axis=1) '
 
 *output, type=ensight, name=esExport
-configuration,     overwrite=True
-create=perNode,    fieldOutput=displacement
-create=perNode,    fieldOutput=micro rotation
-create=perNode,    fieldOutput=nonlocal damage
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
+>>configuration,     overwrite=True
+>>perNode,    fieldOutput=displacement
+>>perNode,    fieldOutput=micro rotation
+>>perNode,    fieldOutput=nonlocal damage
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
 
 *step, solver=theSolver
 maxInc=2e-2, minInc=1e-5, maxNumInc=10000, maxIter=25, stepLength=100
-options, category=NISTSolver, extrapolation=linear, numThreads=8
-initializematerial, name=init, elSet=all
-dirichlet, name=front, nSet=front_face,    field=displacement, 3=0
-dirichlet, name=frontr, nSet=front_face,    field=micro rotation, 1=0, 2=0
+>>options, category=NISTSolver, extrapolation=linear, numThreads=8
+>>initializematerial, name=init, elSet=all
+>>dirichlet, name=front, nSet=front_face,    field=displacement, 3=0
+>>dirichlet, name=frontr, nSet=front_face,    field=micro rotation, 1=0, 2=0
 
-dirichlet, name=back,  nSet=back_face,    field=displacement, 3=0
-dirichlet, name=backr, nSet=back_face,    field=micro rotation, 1=0, 2=0
+>>dirichlet, name=back,  nSet=back_face,    field=displacement, 3=0
+>>dirichlet, name=backr, nSet=back_face,    field=micro rotation, 1=0, 2=0
 
-dirichlet, name=left,  nSet=left_side,    field=displacement, 1=0, 2=0
-dirichlet, name=right, nSet=right_side,    field=displacement, 1=-10, 2=-20
+>>dirichlet, name=left,  nSet=left_side,    field=displacement, 1=0, 2=0
+>>dirichlet, name=right, nSet=right_side,    field=displacement, 1=-10, 2=-20
 
 *include, input=marmot6.inp

--- a/examples/GMCDPFiniteStrainMarmot/test.inp
+++ b/examples/GMCDPFiniteStrainMarmot/test.inp
@@ -11,8 +11,8 @@
 *section, name=section1, thickness=1.0, material=GMCDPFiniteStrain, type=plane
 all
 
-*job, name=cpe4job, domain=3d, solver=NISTParallelForMarmotElements
-*solver, solver=NISTParallelForMarmotElements, name=theSolver
+*job, name=cpe4job, domain=3d, solver=NISTParallel
+*solver, solver=NISTParallel, name=theSolver
 *fieldOutput,
 >>perNode, elSet=all, field=displacement, result=U, name=displacement
 >>perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
@@ -32,7 +32,7 @@ all
 
 *step, solver=theSolver
 maxInc=2e-2, minInc=1e-5, maxNumInc=10000, maxIter=25, stepLength=100
->>options, category=NISTSolver, extrapolation=linear, numThreads=8
+>>options, category=NISTSolver, extrapolation=linear
 >>initializematerial, name=init, elSet=all
 >>dirichlet, name=front, nSet=front_face,    field=displacement, 3=0
 >>dirichlet, name=frontr, nSet=front_face,    field=micro rotation, 1=0, 2=0

--- a/examples/GMCDPFiniteStrainMarmot/test.inp
+++ b/examples/GMCDPFiniteStrainMarmot/test.inp
@@ -29,7 +29,8 @@ create=perElement, fieldOutput=alphaP
 create=perElement, fieldOutput=alphaD
 create=perElement, fieldOutput=omega
 
-*step, maxInc=2e-2, minInc=1e-5, maxNumInc=10000, maxIter=25, stepLength=100
+*step
+maxInc=2e-2, minInc=1e-5, maxNumInc=10000, maxIter=25, stepLength=100
 options, category=NISTSolver, extrapolation=linear, numThreads=8
 initializematerial, name=init, elSet=all
 dirichlet, name=front, nSet=front_face,    field=displacement, 3=0

--- a/examples/SchlangenTest/penalty/test_penalty.inp
+++ b/examples/SchlangenTest/penalty/test_penalty.inp
@@ -28,22 +28,22 @@ steel
 *solver, solver=NISTParallelForMarmotElements, name=theSolver
 
 *fieldOutput,
-elSet=all,  name=displacement,  field=displacement, result=U
-elSet=concrete,  name=nonlocal damage,  field=nonlocal damage, result=U
-name=RF, nSet=all_bc, field=displacement, result=P, f(x)='np.sum(x[:,1], axis=0)', saveHistory=True, export=RF
-name=CMOD, nSet=cmod, field=displacement, result=U, f(x)='x[0,0] - x[1,0]', export=CMOD, saveHistory=True
-name=CMSD, nSet=cmod, field=displacement, result=U, f(x)='x[0,1] - x[1,1]', export=CMOD, saveHistory=True
-elSet=concrete,  name=damage,  result=omega, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
+>>perNode, elSet=all,  name=displacement,  field=displacement, result=U
+>>perNode, elSet=concrete,  name=nonlocal damage,  field=nonlocal damage, result=U
+>>perNode, name=RF, nSet=all_bc, field=displacement, result=P, f(x)='np.sum(x[:,1], axis=0)', saveHistory=True, export=RF
+>>perNode, name=CMOD, nSet=cmod, field=displacement, result=U, f(x)='x[0,0] - x[1,0]', export=CMOD, saveHistory=True
+>>perNode, name=CMSD, nSet=cmod, field=displacement, result=U, f(x)='x[0,1] - x[1,1]', export=CMOD, saveHistory=True
+>>perElement, elSet=concrete,  name=damage,  result=omega, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
 *output, type=monitor, name=monitor
-fieldOutput=RF
-fieldOutput=CMOD
-fieldOutput=CMSD
+>>fieldOutput=RF
+>>fieldOutput=CMOD
+>>fieldOutput=CMSD
 
 *output, type=ensight, name=esExport
-create=perNode,     fieldOutput=displacement
-create=perNode,     fieldOutput=nonlocal damage
-create=perElement,  fieldOutput=damage
-configuration, overwrite=yes
+>>perNode,     fieldOutput=displacement
+>>perNode,     fieldOutput=nonlocal damage
+>>perElement,  fieldOutput=damage
+>>configuration, overwrite=yes
 
 *constraint, type=penaltyindirectcontrol, name=pc1
 field=displacement,
@@ -67,11 +67,11 @@ offset=0
 
 *step, solver=theSolver
 maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
-initializematerial, name=init, elSet=concrete
+>>initializematerial, name=init, elSet=concrete
 
-dirichlet, name=sym, nSet=face_back_concrete, field=displacement, 3=0
-dirichlet, name=sym_r, nSet=face_back_concrete, field=micro rotation, 1=0, 2=0
-dirichlet, name=sym_s, nSet=face_back_steel, field=displacement, 3=0
+>>dirichlet, name=sym, nSet=face_back_concrete, field=displacement, 3=0
+>>dirichlet, name=sym_r, nSet=face_back_concrete, field=micro rotation, 1=0, 2=0
+>>dirichlet, name=sym_s, nSet=face_back_steel, field=displacement, 3=0
 
-dirichlet, name=fixed, nSet=fixed_bc, field=displacement, 1=0., 2=0., 3=0.
-dirichlet, name=supp, nSet=supp_y, field=displacement, 2=0, 3=0
+>>dirichlet, name=fixed, nSet=fixed_bc, field=displacement, 1=0., 2=0., 3=0.
+>>dirichlet, name=supp, nSet=supp_y, field=displacement, 2=0, 3=0

--- a/examples/SchlangenTest/penalty/test_penalty.inp
+++ b/examples/SchlangenTest/penalty/test_penalty.inp
@@ -24,8 +24,8 @@ concrete
 *section, name=sec_steel, material=steel, type=solid
 steel
 
-*job, name=SchlangenTest, domain=3d, solver=NISTParallelForMarmotElements
-*solver, solver=NISTParallelForMarmotElements, name=theSolver
+*job, name=SchlangenTest, domain=3d, solver=NISTParallel
+*solver, solver=NISTParallel, name=theSolver
 
 *fieldOutput,
 >>perNode, elSet=all,  name=displacement,  field=displacement, result=U
@@ -35,9 +35,9 @@ steel
 >>perNode, name=CMSD, nSet=cmod, field=displacement, result=U, f(x)='x[0,1] - x[1,1]', export=CMOD, saveHistory=True
 >>perElement, elSet=concrete,  name=damage,  result=omega, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
 *output, type=monitor, name=monitor
->>fieldOutput=RF
->>fieldOutput=CMOD
->>fieldOutput=CMSD
+fieldOutput=RF
+fieldOutput=CMOD
+fieldOutput=CMSD
 
 *output, type=ensight, name=esExport
 >>perNode,     fieldOutput=displacement

--- a/examples/SchlangenTest/penalty/test_penalty.inp
+++ b/examples/SchlangenTest/penalty/test_penalty.inp
@@ -25,6 +25,7 @@ concrete
 steel
 
 *job, name=SchlangenTest, domain=3d, solver=NISTParallelForMarmotElements
+*solver, solver=NISTParallelForMarmotElements, name=theSolver
 
 *fieldOutput,
 elSet=all,  name=displacement,  field=displacement, result=U
@@ -64,7 +65,7 @@ length=+.5
 penaltyStiffness=1e6
 offset=0
 
-*step
+*step, solver=theSolver
 maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
 initializematerial, name=init, elSet=concrete
 

--- a/examples/SchlangenTest/penalty/test_penalty.inp
+++ b/examples/SchlangenTest/penalty/test_penalty.inp
@@ -64,7 +64,8 @@ length=+.5
 penaltyStiffness=1e6
 offset=0
 
-*step, maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
+*step
+maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
 initializematerial, name=init, elSet=concrete
 
 dirichlet, name=sym, nSet=face_back_concrete, field=displacement, 3=0

--- a/examples/SchlangenTest/test.inp
+++ b/examples/SchlangenTest/test.inp
@@ -26,6 +26,7 @@ steel
 
 
 *job, name=SchlangenTest, domain=3d, solver=NISTPArcLength
+*solver, solver=NISTPArcLength, name=theSolver
 
 *fieldOutput,
 elSet=all,  name=displacement,  field=displacement, result=U
@@ -45,7 +46,7 @@ create=perNode,     fieldOutput=nonlocal damage
 create=perElement,  fieldOutput=damage
 configuration, overwrite=yes
 
-*step
+*step, solver=theSolver
 maxInc=1e-0, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
 options, category=NISTArcLength, arcLengthController=off
 initializematerial, name=init, elSet=concrete
@@ -57,7 +58,7 @@ dirichlet, name=sym_s, nSet=face_back_steel, field=displacement, 3=0
 dirichlet, name=fixed, nSet=fixed_bc, field=displacement, 1=0., 2=0., 3=0.
 dirichlet, name=supp, nSet=supp_y, field=displacement, 2=0, 3=0
 
-*step
+*step, solver=theSolver
 maxInc=1e-2, minInc=1e-6, maxNumInc=1000, maxIter=10, stepLength=1
 options, category=NISTArcLength, arcLengthController=indirectcontrol,
 

--- a/examples/SchlangenTest/test.inp
+++ b/examples/SchlangenTest/test.inp
@@ -29,40 +29,40 @@ steel
 *solver, solver=NISTPArcLength, name=theSolver
 
 *fieldOutput,
-elSet=all,  name=displacement,  field=displacement, result=U
-elSet=concrete,  name=nonlocal damage,  field=nonlocal damage, result=U
-name=RF, nSet=all_bc, field=displacement, result=P, f(x)='np.sum(x[:,1], axis=0)', saveHistory=True, export=RF
-name=CMOD, nSet=cmod, field=displacement, result=U, f(x)='x[0,0] - x[1,0]', export=CMOD, saveHistory=True
-name=CMSD, nSet=cmod, field=displacement, result=U, f(x)='x[0,1] - x[1,1]', export=CMOD, saveHistory=True
-elSet=concrete,  name=damage,  result=omega, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
+>>perNode, elSet=all,  name=displacement,  field=displacement, result=U
+>>perNode, elSet=concrete,  name=nonlocal damage,  field=nonlocal damage, result=U
+>>perNode, name=RF, nSet=all_bc, field=displacement, result=P, f(x)='np.sum(x[:,1], axis=0)', saveHistory=True, export=RF
+>>perNode, name=CMOD, nSet=cmod, field=displacement, result=U, f(x)='x[0,0] - x[1,0]', export=CMOD, saveHistory=True
+>>perNode, name=CMSD, nSet=cmod, field=displacement, result=U, f(x)='x[0,1] - x[1,1]', export=CMOD, saveHistory=True
+>>perElement, elSet=concrete,  name=damage,  result=omega, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
 *output, type=monitor, name=monitor
-fieldOutput=RF
-fieldOutput=CMOD
-fieldOutput=CMSD
+>>fieldOutput=RF
+>>fieldOutput=CMOD
+>>fieldOutput=CMSD
 
 *output, type=ensight, name=esExport
-create=perNode,     fieldOutput=displacement
-create=perNode,     fieldOutput=nonlocal damage
-create=perElement,  fieldOutput=damage
-configuration, overwrite=yes
+>>perNode,     fieldOutput=displacement
+>>perNode,     fieldOutput=nonlocal damage
+>>perElement,  fieldOutput=damage
+>>configuration, overwrite=yes
 
 *step, solver=theSolver
 maxInc=1e-0, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTArcLength, arcLengthController=off
-initializematerial, name=init, elSet=concrete
+>>options, category=NISTArcLength, arcLengthController=off
+>>initializematerial, name=init, elSet=concrete
 
-dirichlet, name=sym, nSet=face_back_concrete, field=displacement, 3=0
-dirichlet, name=sym_r, nSet=face_back_concrete, field=micro rotation, 1=0, 2=0
-dirichlet, name=sym_s, nSet=face_back_steel, field=displacement, 3=0
+>>dirichlet, name=sym, nSet=face_back_concrete, field=displacement, 3=0
+>>dirichlet, name=sym_r, nSet=face_back_concrete, field=micro rotation, 1=0, 2=0
+>>dirichlet, name=sym_s, nSet=face_back_steel, field=displacement, 3=0
 
-dirichlet, name=fixed, nSet=fixed_bc, field=displacement, 1=0., 2=0., 3=0.
-dirichlet, name=supp, nSet=supp_y, field=displacement, 2=0, 3=0
+>>dirichlet, name=fixed, nSet=fixed_bc, field=displacement, 1=0., 2=0., 3=0.
+>>dirichlet, name=supp, nSet=supp_y, field=displacement, 2=0, 3=0
 
 *step, solver=theSolver
 maxInc=1e-2, minInc=1e-6, maxNumInc=1000, maxIter=10, stepLength=1
-options, category=NISTArcLength, arcLengthController=indirectcontrol,
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol,
 
-indirectcontrol, dof1=' nodeSets["cmod_left"][0].fields["displacement"][1] ', dof2='nodeSets["cmod_right"][0].fields["displacement"][1] ' , L=+0.5,
+>>indirectcontrol, dof1=' nodeSets["cmod_left"][0].fields["displacement"][1] ', dof2='nodeSets["cmod_right"][0].fields["displacement"][1] ' , L=+0.5,
 
-nodeforces, name=low_p, nSet=low_p, field=displacement, 2=1
-nodeforces, name=high_p, nSet=high_p, field=displacement, 2=10
+>>nodeforces, name=low_p, nSet=low_p, field=displacement, 2=1
+>>nodeforces, name=high_p, nSet=high_p, field=displacement, 2=10

--- a/examples/SchlangenTest/test.inp
+++ b/examples/SchlangenTest/test.inp
@@ -36,9 +36,9 @@ steel
 >>perNode, name=CMSD, nSet=cmod, field=displacement, result=U, f(x)='x[0,1] - x[1,1]', export=CMOD, saveHistory=True
 >>perElement, elSet=concrete,  name=damage,  result=omega, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
 *output, type=monitor, name=monitor
->>fieldOutput=RF
->>fieldOutput=CMOD
->>fieldOutput=CMSD
+fieldOutput=RF
+fieldOutput=CMOD
+fieldOutput=CMSD
 
 *output, type=ensight, name=esExport
 >>perNode,     fieldOutput=displacement
@@ -62,7 +62,7 @@ maxInc=1e-0, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
 maxInc=1e-2, minInc=1e-6, maxNumInc=1000, maxIter=10, stepLength=1
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol,
 
->>indirectcontrol, dof1=' nodeSets["cmod_left"][0].fields["displacement"][1] ', dof2='nodeSets["cmod_right"][0].fields["displacement"][1] ' , L=+0.5,
+>>indirectcontrol, dof1=' nodeSets["cmod_left"][0].fields["displacement"][1] ', dof2='nodeSets["cmod_right"][0].fields["displacement"][1] ' , L=+0.5, cVector1='[-1]', cVector2='[1]',
 
 >>nodeforces, name=low_p, nSet=low_p, field=displacement, 2=1
 >>nodeforces, name=high_p, nSet=high_p, field=displacement, 2=10

--- a/examples/SchlangenTest/test.inp
+++ b/examples/SchlangenTest/test.inp
@@ -45,7 +45,8 @@ create=perNode,     fieldOutput=nonlocal damage
 create=perElement,  fieldOutput=damage
 configuration, overwrite=yes
 
-*step, maxInc=1e-0, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
+*step
+maxInc=1e-0, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
 options, category=NISTArcLength, arcLengthController=off
 initializematerial, name=init, elSet=concrete
 
@@ -56,7 +57,8 @@ dirichlet, name=sym_s, nSet=face_back_steel, field=displacement, 3=0
 dirichlet, name=fixed, nSet=fixed_bc, field=displacement, 1=0., 2=0., 3=0.
 dirichlet, name=supp, nSet=supp_y, field=displacement, 2=0, 3=0
 
-*step, maxInc=1e-2, minInc=1e-6, maxNumInc=1000, maxIter=10, stepLength=1
+*step
+maxInc=1e-2, minInc=1e-6, maxNumInc=1000, maxIter=10, stepLength=1
 options, category=NISTArcLength, arcLengthController=indirectcontrol,
 
 indirectcontrol, dof1=' nodeSets["cmod_left"][0].fields["displacement"][1] ', dof2='nodeSets["cmod_right"][0].fields["displacement"][1] ' , L=+0.5,

--- a/examples/WinklerL/test.inp
+++ b/examples/WinklerL/test.inp
@@ -58,7 +58,7 @@ secSteelBottom
 >>perElement, elSet=secConc, name=damage, result=omega, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
 
 *output, type=monitor, name=monitor
->>fieldOutput=RF
+fieldOutput=RF
 
 *output, type=ensight, name=esExport
 >>perNode, fieldOutput=displacement

--- a/examples/WinklerL/test.inp
+++ b/examples/WinklerL/test.inp
@@ -65,7 +65,8 @@ create=perNode, fieldOutput=nonlocal damage
 create=perElement, fieldOutput=damage
 configuration, overwrite=yes
 
-*step, maxInc=1e-2, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=100
+*step
+maxInc=1e-2, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=100
 options, category=NISTSolver, extrapolation=linear
 dirichlet, name=bottom, nSet=setBottom, field=displacement, 2=0, 1=0, 3=0
 dirichlet, name=load, nSet=setLoad, field=displacement, 2=+1

--- a/examples/WinklerL/test.inp
+++ b/examples/WinklerL/test.inp
@@ -35,6 +35,8 @@
 .99,
 ** derivativeMethod (0 ..  AD, 1 ..  CD)
 0
+** dTThresholdElasticStiffness
+0
 
 *material, name=linearElastic, id=steelLoad
 37000.0, 0.3
@@ -43,9 +45,9 @@
 
 *section, name=sectConc, material=GCDP, type=solid
 secConc
-*section, name=secSteel, material=steelLoad, type=solid
+*section, name=secSteelLoad, material=steelLoad, type=solid
 secSteelLoad
-*section, name=secSteel, material=steelBottom, type=solid
+*section, name=secSteelBottom, material=steelBottom, type=solid
 secSteelBottom
 
 *job, domain=3d, solver=NISTParallel

--- a/examples/WinklerL/test.inp
+++ b/examples/WinklerL/test.inp
@@ -49,6 +49,7 @@ secSteelLoad
 secSteelBottom
 
 *job, domain=3d, solver=NISTParallel
+*solver, solver=NISTParallel, name=theSolver
 
 *fieldOutput,
 elSet=secConc, name=displacement, field=displacement, result=U
@@ -65,7 +66,7 @@ create=perNode, fieldOutput=nonlocal damage
 create=perElement, fieldOutput=damage
 configuration, overwrite=yes
 
-*step
+*step, solver=theSolver
 maxInc=1e-2, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=100
 options, category=NISTSolver, extrapolation=linear
 dirichlet, name=bottom, nSet=setBottom, field=displacement, 2=0, 1=0, 3=0

--- a/examples/WinklerL/test.inp
+++ b/examples/WinklerL/test.inp
@@ -52,22 +52,22 @@ secSteelBottom
 *solver, solver=NISTParallel, name=theSolver
 
 *fieldOutput,
-elSet=secConc, name=displacement, field=displacement, result=U
-elSet=secConc, name=nonlocal damage, field=nonlocal damage, result=U
-name=RF, nSet=setLoad, field=displacement, result=P, f(x)='np.sum(x[:,1], axis=0)', saveHistory=True, export=RF
-elSet=secConc, name=damage, result=omega, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
+>>perNode, elSet=secConc, name=displacement, field=displacement, result=U
+>>perNode, elSet=secConc, name=nonlocal damage, field=nonlocal damage, result=U
+>>perNode, name=RF, nSet=setLoad, field=displacement, result=P, f(x)='np.sum(x[:,1], axis=0)', saveHistory=True, export=RF
+>>perElement, elSet=secConc, name=damage, result=omega, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
 
 *output, type=monitor, name=monitor
-fieldOutput=RF
+>>fieldOutput=RF
 
 *output, type=ensight, name=esExport
-create=perNode, fieldOutput=displacement
-create=perNode, fieldOutput=nonlocal damage
-create=perElement, fieldOutput=damage
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perNode, fieldOutput=nonlocal damage
+>>perElement, fieldOutput=damage
+>>configuration, overwrite=yes
 
 *step, solver=theSolver
 maxInc=1e-2, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=100
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=bottom, nSet=setBottom, field=displacement, 2=0, 1=0, 3=0
-dirichlet, name=load, nSet=setLoad, field=displacement, 2=+1
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=bottom, nSet=setBottom, field=displacement, 2=0, 1=0, 3=0
+>>dirichlet, name=load, nSet=setLoad, field=displacement, 2=+1

--- a/testfiles/edelweiss-only/CantileverBeamHexa8/testGenerator.inp
+++ b/testfiles/edelweiss-only/CantileverBeamHexa8/testGenerator.inp
@@ -26,8 +26,6 @@ all
 >>perNode, fieldOutput=displacement
 >>configuration, overwrite=yes
 
-*output, type=monitor
-
 *step, solver=theSolver
 maxInc=1e0, minInc=1e-9, maxNumInc=1000, maxIter=25, stepLength=1
 >>options, category=NISTSolver, extrapolation=off

--- a/testfiles/edelweiss-only/CantileverBeamHexa8/testGenerator.inp
+++ b/testfiles/edelweiss-only/CantileverBeamHexa8/testGenerator.inp
@@ -20,15 +20,15 @@ elType  =C3D8N
 all
 
 *fieldOutput
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
 
 *output, type=ensight, name=test
-create=perNode, fieldOutput=displacement
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>configuration, overwrite=yes
 
 *output, type=monitor
 
 *step, solver=theSolver, maxInc=1e0, minInc=1e-9, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=off
-dirichlet, name=Left,  nSet=gen_left, field=displacement, 1=0.0, 2=0.0, 3=.0
-nodeforces, name=cloadTop, nSet=gen_rightBack, components='0, 0, .02', field=displacement
+>>options, category=NISTSolver, extrapolation=off
+>>dirichlet, name=Left,  nSet=gen_left, field=displacement, 1=0.0, 2=0.0, 3=.0
+>>nodeforces, name=cloadTop, nSet=gen_rightBack, components='0, 0, .02', field=displacement

--- a/testfiles/edelweiss-only/CantileverBeamHexa8/testGenerator.inp
+++ b/testfiles/edelweiss-only/CantileverBeamHexa8/testGenerator.inp
@@ -28,7 +28,8 @@ all
 
 *output, type=monitor
 
-*step, solver=theSolver, maxInc=1e0, minInc=1e-9, maxNumInc=1000, maxIter=25, stepLength=1
+*step, solver=theSolver
+maxInc=1e0, minInc=1e-9, maxNumInc=1000, maxIter=25, stepLength=1
 >>options, category=NISTSolver, extrapolation=off
 >>dirichlet, name=Left,  nSet=gen_left, field=displacement, 1=0.0, 2=0.0, 3=.0
 >>nodeforces, name=cloadTop, nSet=gen_rightBack, components='0, 0, .02', field=displacement

--- a/testfiles/edelweiss-only/CantileverBeamHexa8/testMesh.inp
+++ b/testfiles/edelweiss-only/CantileverBeamHexa8/testMesh.inp
@@ -12,13 +12,13 @@ all
 *solver, solver=NIST, name=theSolver
 
 *fieldOutput
-create=perNode, name=displacement, elSet=all, field=displacement, result=U
+>>perNode, name=displacement, elSet=all, field=displacement, result=U
 
 *output, type=ensight, name=ensightExport
-configuration, overwrite=yes
-create=perNode,    fieldOutput=displacement
+>>configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
 
 *step, solver=theSolver, maxInc=1e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
 **options, category=NISTSolver, extrapolation=linear
-dirichlet, name=top,  nSet=leftbottom, field=displacement, 1=0.0, 2=0.0, 3=.0
-nodeforces, name=cloadTop, nSet=righttop, components='0, 0, 300', field=displacement
+>>dirichlet, name=top,  nSet=leftbottom, field=displacement, 1=0.0, 2=0.0, 3=.0
+>>nodeforces, name=cloadTop, nSet=righttop, components='0, 0, 300', field=displacement

--- a/testfiles/edelweiss-only/CantileverBeamHexa8/testMesh.inp
+++ b/testfiles/edelweiss-only/CantileverBeamHexa8/testMesh.inp
@@ -18,7 +18,8 @@ all
 >>configuration, overwrite=yes
 >>perNode, fieldOutput=displacement
 
-*step, solver=theSolver, maxInc=1e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
+*step, solver=theSolver
+maxInc=1e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
 **options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=top,  nSet=leftbottom, field=displacement, 1=0.0, 2=0.0, 3=.0
 >>nodeforces, name=cloadTop, nSet=righttop, components='0, 0, 300', field=displacement

--- a/testfiles/edelweiss-only/WallShearHexa8VonMises/testLong.inp
+++ b/testfiles/edelweiss-only/WallShearHexa8VonMises/testLong.inp
@@ -19,7 +19,7 @@ elType  =C3D8
 *section, name=section1, material=vonmises, type=solid
 all
 
-*fieldOutput
+*fieldOutput,
 >>perNode, elSet=all, field=displacement, result=U, name=displacement
 >>perElement, elSet=all, result=strain, name=strain, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
 >>perElement, elSet=all, result=stress, name=stress, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
@@ -45,8 +45,6 @@ all
 >>perElement, fieldOutput=stress5
 >>perElement, fieldOutput=stress6
 >>perElement, fieldOutput=stress7
-
-*output, type=monitor
 
 *step, solver=theSolver
 maxInc=0.1, minInc=1e-9, maxNumInc=1000, maxIter=25, stepLength=1

--- a/testfiles/edelweiss-only/WallShearHexa8VonMises/testLong.inp
+++ b/testfiles/edelweiss-only/WallShearHexa8VonMises/testLong.inp
@@ -48,7 +48,8 @@ all
 
 *output, type=monitor
 
-*step, solver=theSolver, maxInc=0.1, minInc=1e-9, maxNumInc=1000, maxIter=25, stepLength=1
+*step, solver=theSolver
+maxInc=0.1, minInc=1e-9, maxNumInc=1000, maxIter=25, stepLength=1
 >>options, category=NISTSolver, extrapolation=off
 >>dirichlet, name=Bottom,  nSet=gen_bottom, field=displacement, 1=0.0, 2=0.0, 3=.0
 >>nodeforces, name=cloadTop, nSet=gen_top, components='10000., 0, 0', field=displacement

--- a/testfiles/edelweiss-only/WallShearHexa8VonMises/testLong.inp
+++ b/testfiles/edelweiss-only/WallShearHexa8VonMises/testLong.inp
@@ -20,36 +20,36 @@ elType  =C3D8
 all
 
 *fieldOutput
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
-create=perElement, elSet=all, result=strain, name=strain, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
-create=perElement, elSet=all, result=stress, name=stress, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
-create=perElement, elSet=all, result=stress, name=stress0, quadraturePoint=0
-create=perElement, elSet=all, result=stress, name=stress1, quadraturePoint=1
-create=perElement, elSet=all, result=stress, name=stress2, quadraturePoint=2
-create=perElement, elSet=all, result=stress, name=stress3, quadraturePoint=3
-create=perElement, elSet=all, result=stress, name=stress4, quadraturePoint=4
-create=perElement, elSet=all, result=stress, name=stress5, quadraturePoint=5
-create=perElement, elSet=all, result=stress, name=stress6, quadraturePoint=6
-create=perElement, elSet=all, result=stress, name=stress7, quadraturePoint=7
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perElement, elSet=all, result=strain, name=strain, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
+>>perElement, elSet=all, result=stress, name=stress, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
+>>perElement, elSet=all, result=stress, name=stress0, quadraturePoint=0
+>>perElement, elSet=all, result=stress, name=stress1, quadraturePoint=1
+>>perElement, elSet=all, result=stress, name=stress2, quadraturePoint=2
+>>perElement, elSet=all, result=stress, name=stress3, quadraturePoint=3
+>>perElement, elSet=all, result=stress, name=stress4, quadraturePoint=4
+>>perElement, elSet=all, result=stress, name=stress5, quadraturePoint=5
+>>perElement, elSet=all, result=stress, name=stress6, quadraturePoint=6
+>>perElement, elSet=all, result=stress, name=stress7, quadraturePoint=7
 
 *output, type=ensight, name=test
-create=perNode, fieldOutput=displacement
-configuration, overwrite=yes
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-create=perElement, fieldOutput=stress0
-create=perElement, fieldOutput=stress1
-create=perElement, fieldOutput=stress2
-create=perElement, fieldOutput=stress3
-create=perElement, fieldOutput=stress4
-create=perElement, fieldOutput=stress5
-create=perElement, fieldOutput=stress6
-create=perElement, fieldOutput=stress7
+>>perNode, fieldOutput=displacement
+>>configuration, overwrite=yes
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>perElement, fieldOutput=stress0
+>>perElement, fieldOutput=stress1
+>>perElement, fieldOutput=stress2
+>>perElement, fieldOutput=stress3
+>>perElement, fieldOutput=stress4
+>>perElement, fieldOutput=stress5
+>>perElement, fieldOutput=stress6
+>>perElement, fieldOutput=stress7
 
 *output, type=monitor
 
 *step, solver=theSolver, maxInc=0.1, minInc=1e-9, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=off
-dirichlet, name=Bottom,  nSet=gen_bottom, field=displacement, 1=0.0, 2=0.0, 3=.0
-nodeforces, name=cloadTop, nSet=gen_top, components='10000., 0, 0', field=displacement
-bodyforce, name=bforce, elSet=all, forceVector='0.0, -0.77, 0'
+>>options, category=NISTSolver, extrapolation=off
+>>dirichlet, name=Bottom,  nSet=gen_bottom, field=displacement, 1=0.0, 2=0.0, 3=.0
+>>nodeforces, name=cloadTop, nSet=gen_top, components='10000., 0, 0', field=displacement
+>>bodyforce, name=bforce, elSet=all, forceVector='0.0, -0.77, 0'

--- a/testfiles/marmot/AnalyticalFieldsFromVtk/_test.inp
+++ b/testfiles/marmot/AnalyticalFieldsFromVtk/_test.inp
@@ -40,9 +40,11 @@ all
 file="./HNEA01-01-16b-cleaned-210.0-voidRatio.vtk",
 result="voidRatioBinary",
 
-*step, maxInc=1e0, minInc=1e0, maxNumInc=100, maxIter=25, stepLength=1, solver=theSolver
+*step, solver=theSolver
+maxInc=1e0, minInc=1e0, maxNumInc=100, maxIter=25, stepLength=1
 setfield,   name=sf,  fieldOutput=kappa, type=analyticalField, value=AnalyticalField-01
 >>dirichlet,  name=z0u, nSet=gen_back,      field=displacement, 1=0., 2=0., 3=0.
 
-*step, maxInc=1e-1, minInc=1e-6, maxNumInc=100, maxIter=25, stepLength=1, solver=theSolver
+*step, solver=theSolver
+maxInc=1e-1, minInc=1e-6, maxNumInc=100, maxIter=25, stepLength=1
 >>dirichlet,  name=y1u, nSet=gen_front,    field=displacement, 3=-50.

--- a/testfiles/marmot/AnalyticalFieldsFromVtk/_test.inp
+++ b/testfiles/marmot/AnalyticalFieldsFromVtk/_test.inp
@@ -20,19 +20,19 @@ elType  =C3D8
 all
 
 *fieldOutput
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
-create=perElement, elSet=all, result=strain, name=strain, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
-create=perElement, elSet=all, result=stress, name=stress, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perElement, elSet=all, result=strain, name=strain, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
+>>perElement, elSet=all, result=stress, name=stress, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
 
-create=perElement, elSet=all, result=kappa, name=kappa, quadraturePoint=0:8
-create=perElement, elSet=all, result=kappa, name=kappaMax, quadraturePoint=0:8, f(x)='np.max(x, axis=1)'
+>>perElement, elSet=all, result=kappa, name=kappa, quadraturePoint=0:8
+>>perElement, elSet=all, result=kappa, name=kappaMax, quadraturePoint=0:8, f(x)='np.max(x, axis=1)'
 
 *output, type=ensight, name=test
-create=perNode, fieldOutput=displacement
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-create=perElement, fieldOutput=kappaMax
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>perElement, fieldOutput=kappaMax
+>>configuration, overwrite=yes
 
 ***output, type=monitor
 
@@ -42,7 +42,7 @@ result="voidRatioBinary",
 
 *step, maxInc=1e0, minInc=1e0, maxNumInc=100, maxIter=25, stepLength=1, solver=theSolver
 setfield,   name=sf,  fieldOutput=kappa, type=analyticalField, value=AnalyticalField-01
-dirichlet,  name=z0u, nSet=gen_back,      field=displacement, 1=0., 2=0., 3=0.
+>>dirichlet,  name=z0u, nSet=gen_back,      field=displacement, 1=0., 2=0., 3=0.
 
 *step, maxInc=1e-1, minInc=1e-6, maxNumInc=100, maxIter=25, stepLength=1, solver=theSolver
-dirichlet,  name=y1u, nSet=gen_front,    field=displacement, 3=-50.
+>>dirichlet,  name=y1u, nSet=gen_front,    field=displacement, 3=-50.

--- a/testfiles/marmot/Barodesy/test_.inp
+++ b/testfiles/marmot/Barodesy/test_.inp
@@ -13,6 +13,7 @@ h=0.1
 all
 
 *job, name=cpe4job, domain=2d, solver=NISTParallel
+*solver, solver=NISTParallel, name=theSolver
 
 *fieldOutput, jobName=cpe4job
 >>perElement, name=q,            elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,1])', saveHistory=True
@@ -33,7 +34,7 @@ all
 >>perElement, elSet=all, fieldOutput=dNorm
 >>configuration, overwrite=yes
 
-*step
+*step, solver=theSolver
 maxInc=1e0, minInc=1e-5, maxNumInc=100000, maxIter=25, stepLength=1
 >>options,         category=NISTSolver, extrapolation=on0
 >>dirichlet,       name=bottom, nSet=gen_bottom,      field=displacement, 2=0.0
@@ -46,17 +47,17 @@ maxInc=1e0, minInc=1e-5, maxNumInc=100000, maxIter=25, stepLength=1
 
 
 
-*step
+*step, solver=theSolver
 maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
 >>dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.003
 >>sdvini,    name=ini, elSet=all, sdv=0, val=0.40
 >>sdvini,    name=ini2, elSet=gen_shearBandCenter, sdv=0, val=0.43
 
-*step
+*step, solver=theSolver
 maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
 >>dirichlet, name=top, nSet=gen_top,  field=displacement, 2=0.002
 
-*step
+*step, solver=theSolver
 maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
 >>dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.003
 

--- a/testfiles/marmot/Barodesy/test_.inp
+++ b/testfiles/marmot/Barodesy/test_.inp
@@ -9,29 +9,29 @@ h=0.1
 ** phiC N lambda* kappa* sigma* (1 when calculating in kpa) numericalCohesion
 24, 0.8, 0.059, 0.018, 1, 0.1
 
-*section, name=section1, thickness=1.0, material=wealdClay, type=plane
+*section, name=section1, material=wealdClay, type=plane
 all
 
 *job, name=cpe4job, domain=2d, solver=NISTParallel
 *solver, solver=NISTParallel, name=theSolver
 
-*fieldOutput, jobName=cpe4job
+*fieldOutput,
 >>perElement, name=q,            elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,1])', saveHistory=True
 >>perElement, name=eq,           elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,2])', saveHistory=True
 >>perElement, name=voidRatio,    elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,0]'
 >>perElement, name=dNorm,        elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,3]'
->>perNode, name=Displacement, elSet=all, field=displacement, result=U,
+>>perNode, name=Displacement, elSet=all, field=displacement, result=U
 >>perElement, name=Stress,       elSet=all, result=stress, quadraturePoint=1
 >>perElement, name=Strain,       elSet=all, result=strain, quadraturePoint=1
 >>perNode, name=uTop,         nSet=gen_top,          field=displacement, result=U,    f(x)='mean(x[:, 1])', saveHistory=True
 >>perNode, name=sumRFNodes,   nSet=gen_top,          field=displacement, result=P,    f(x)='sum(x[:,  1])', saveHistory=True
 
 *output, type=ensight, name=barodesy
->>perNode, elSet=all, fieldOutput=Displacement
->>perElement, elSet=all, fieldOutput=Stress
->>perElement, elSet=all, fieldOutput=Strain
->>perElement, elSet=all, fieldOutput=voidRatio
->>perElement, elSet=all, fieldOutput=dNorm
+>>perNode, fieldOutput=Displacement
+>>perElement, fieldOutput=Stress
+>>perElement, fieldOutput=Strain
+>>perElement, fieldOutput=voidRatio
+>>perElement, fieldOutput=dNorm
 >>configuration, overwrite=yes
 
 *step, solver=theSolver
@@ -50,8 +50,8 @@ maxInc=1e0, minInc=1e-5, maxNumInc=100000, maxIter=25, stepLength=1
 *step, solver=theSolver
 maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
 >>dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.003
->>sdvini,    name=ini, elSet=all, sdv=0, val=0.40
->>sdvini,    name=ini2, elSet=gen_shearBandCenter, sdv=0, val=0.43
+>>setinitialconditions, elSet=all, property='sdvini', values='0, 0.40'
+>>setinitialconditions, elSet=gen_shearBandCenter, property='sdvini', values='0, 0.43'
 
 *step, solver=theSolver
 maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
@@ -62,7 +62,7 @@ maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
 >>dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.003
 
 *output, type=meshPlot,
->>figure=1, axSpec=111, create=perElement, fieldOutput=voidRatio
->>figure=2, axSpec=111, c=red, ls=dashed, create=xyData, x=uTop, y=sumRFNodes,
+figure=1, axSpec=111, create=perElement, fieldOutput=voidRatio
+figure=2, axSpec=111, c=red, ls=dashed, create=xyData, x=uTop, y=sumRFNodes,
 
 

--- a/testfiles/marmot/Barodesy/test_.inp
+++ b/testfiles/marmot/Barodesy/test_.inp
@@ -33,7 +33,8 @@ all
 >>perElement, elSet=all, fieldOutput=dNorm
 >>configuration, overwrite=yes
 
-*step, maxInc=1e0, minInc=1e-5, maxNumInc=100000, maxIter=25, stepLength=1
+*step
+maxInc=1e0, minInc=1e-5, maxNumInc=100000, maxIter=25, stepLength=1
 >>options,         category=NISTSolver, extrapolation=on0
 >>dirichlet,       name=bottom, nSet=gen_bottom,      field=displacement, 2=0.0
 >>dirichlet,       name=leftbottom, nSet=gen_leftBottom,      field=displacement, 1=0.0
@@ -45,15 +46,18 @@ all
 
 
 
-*step, maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
+*step
+maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
 >>dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.003
 >>sdvini,    name=ini, elSet=all, sdv=0, val=0.40
 >>sdvini,    name=ini2, elSet=gen_shearBandCenter, sdv=0, val=0.43
 
-*step, maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
+*step
+maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
 >>dirichlet, name=top, nSet=gen_top,  field=displacement, 2=0.002
 
-*step, maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
+*step
+maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
 >>dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.003
 
 *output, type=meshPlot,

--- a/testfiles/marmot/Barodesy/test_.inp
+++ b/testfiles/marmot/Barodesy/test_.inp
@@ -15,49 +15,49 @@ all
 *job, name=cpe4job, domain=2d, solver=NISTParallel
 
 *fieldOutput, jobName=cpe4job
-create=perElement, name=q,            elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,1])', saveHistory=True
-create=perElement, name=eq,           elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,2])', saveHistory=True
-create=perElement, name=voidRatio,    elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,0]'
-create=perElement, name=dNorm,        elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,3]'
-create=perNode, name=Displacement, elSet=all, field=displacement, result=U,
-create=perElement, name=Stress,       elSet=all, result=stress, quadraturePoint=1
-create=perElement, name=Strain,       elSet=all, result=strain, quadraturePoint=1
-create=perNode, name=uTop,         nSet=gen_top,          field=displacement, result=U,    f(x)='mean(x[:, 1])', saveHistory=True
-create=perNode, name=sumRFNodes,   nSet=gen_top,          field=displacement, result=P,    f(x)='sum(x[:,  1])', saveHistory=True
+>>perElement, name=q,            elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,1])', saveHistory=True
+>>perElement, name=eq,           elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,2])', saveHistory=True
+>>perElement, name=voidRatio,    elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,0]'
+>>perElement, name=dNorm,        elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,3]'
+>>perNode, name=Displacement, elSet=all, field=displacement, result=U,
+>>perElement, name=Stress,       elSet=all, result=stress, quadraturePoint=1
+>>perElement, name=Strain,       elSet=all, result=strain, quadraturePoint=1
+>>perNode, name=uTop,         nSet=gen_top,          field=displacement, result=U,    f(x)='mean(x[:, 1])', saveHistory=True
+>>perNode, name=sumRFNodes,   nSet=gen_top,          field=displacement, result=P,    f(x)='sum(x[:,  1])', saveHistory=True
 
 *output, type=ensight, name=barodesy
-create=perNode,    elSet=all, fieldOutput=Displacement
-create=perElement, elSet=all, fieldOutput=Stress
-create=perElement, elSet=all, fieldOutput=Strain
-create=perElement, elSet=all, fieldOutput=voidRatio
-create=perElement, elSet=all, fieldOutput=dNorm
-configuration, overwrite=yes
+>>perNode, elSet=all, fieldOutput=Displacement
+>>perElement, elSet=all, fieldOutput=Stress
+>>perElement, elSet=all, fieldOutput=Strain
+>>perElement, elSet=all, fieldOutput=voidRatio
+>>perElement, elSet=all, fieldOutput=dNorm
+>>configuration, overwrite=yes
 
 *step, maxInc=1e0, minInc=1e-5, maxNumInc=100000, maxIter=25, stepLength=1
-options,         category=NISTSolver, extrapolation=on0
-dirichlet,       name=bottom, nSet=gen_bottom,      field=displacement, 2=0.0
-dirichlet,       name=leftbottom, nSet=gen_leftBottom,      field=displacement, 1=0.0
-geostatic,       name=geo, elSet=all, p1=-100, h1=0, p2=-100, h2=200, xLateral=1.0, zLateral=1.0
-distributedload, name=dll, surface=gen_left, magnitude=100, f(t)=1, type=pressure
-distributedload, name=dlr, surface=gen_right, magnitude=100, f(t)=1, type=pressure
-distributedload, name=dlTop, surface=gen_top, magnitude=100, f(t)=1, type=pressure
-options,         category=NISTArcLength, arcLengthController=off
+>>options,         category=NISTSolver, extrapolation=on0
+>>dirichlet,       name=bottom, nSet=gen_bottom,      field=displacement, 2=0.0
+>>dirichlet,       name=leftbottom, nSet=gen_leftBottom,      field=displacement, 1=0.0
+>>geostatic,       name=geo, elSet=all, p1=-100, h1=0, p2=-100, h2=200, xLateral=1.0, zLateral=1.0
+>>distributedload, name=dll, surface=gen_left, magnitude=100, f(t)=1, type=pressure
+>>distributedload, name=dlr, surface=gen_right, magnitude=100, f(t)=1, type=pressure
+>>distributedload, name=dlTop, surface=gen_top, magnitude=100, f(t)=1, type=pressure
+>>options,         category=NISTArcLength, arcLengthController=off
 
 
 
 *step, maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
-dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.003
-sdvini,    name=ini, elSet=all, sdv=0, val=0.40
-sdvini,    name=ini2, elSet=gen_shearBandCenter, sdv=0, val=0.43
+>>dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.003
+>>sdvini,    name=ini, elSet=all, sdv=0, val=0.40
+>>sdvini,    name=ini2, elSet=gen_shearBandCenter, sdv=0, val=0.43
 
 *step, maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
-dirichlet, name=top, nSet=gen_top,  field=displacement, 2=0.002
+>>dirichlet, name=top, nSet=gen_top,  field=displacement, 2=0.002
 
 *step, maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
-dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.003
+>>dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.003
 
 *output, type=meshPlot,
-figure=1, axSpec=111, create=perElement, fieldOutput=voidRatio
-figure=2, axSpec=111, c=red, ls=dashed, create=xyData, x=uTop, y=sumRFNodes,
+>>figure=1, axSpec=111, create=perElement, fieldOutput=voidRatio
+>>figure=2, axSpec=111, c=red, ls=dashed, create=xyData, x=uTop, y=sumRFNodes,
 
 

--- a/testfiles/marmot/BarodesyGradientVoid/test_.inp
+++ b/testfiles/marmot/BarodesyGradientVoid/test_.inp
@@ -13,6 +13,7 @@ h=0.1
 all
 
 *job, name=cpe4job, domain=2d, solver=NISTParallel
+*solver, solver=NISTParallel, name=theSolver
 
 *fieldOutput, jobName=cpe4job
 >>perElement, name=q,            elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,1])', saveHistory=True
@@ -33,7 +34,7 @@ all
 >>perElement, elSet=all, fieldOutput=dNorm
 >>configuration, overwrite=yes
 
-*step
+*step, solver=theSolver
 maxInc=1e0, minInc=1e-5, maxNumInc=100000, maxIter=25, stepLength=1
 >>options,         category=NISTSolver, extrapolation=on0
 >>dirichlet,       name=bottom, nSet=gen_bottom,      field=displacement, 2=0.0
@@ -46,7 +47,7 @@ maxInc=1e0, minInc=1e-5, maxNumInc=100000, maxIter=25, stepLength=1
 
 
 
-*step
+*step, solver=theSolver
 maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
 >>dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.01
 >>sdvini,    name=ini, elSet=all, sdv=0, val=0.40

--- a/testfiles/marmot/BarodesyGradientVoid/test_.inp
+++ b/testfiles/marmot/BarodesyGradientVoid/test_.inp
@@ -15,40 +15,40 @@ all
 *job, name=cpe4job, domain=2d, solver=NISTParallel
 
 *fieldOutput, jobName=cpe4job
-create=perElement, name=q,            elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,1])', saveHistory=True
-create=perElement, name=eq,           elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,2])', saveHistory=True
-create=perElement, name=voidRatio,    elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,0]'
-create=perElement, name=dNorm,        elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,3]'
-create=perNode, name=Displacement, elSet=all, field=displacement, result=U,
-create=perElement, name=Stress,       elSet=all, result=stress, quadraturePoint=1
-create=perElement, name=Strain,       elSet=all, result=strain, quadraturePoint=1
-create=perNode, name=uTop,         nSet=gen_top,          field=displacement, result=U,    f(x)='mean(x[:, 1])', saveHistory=True
-create=perNode, name=sumRFNodes,   nSet=gen_top,          field=displacement, result=P,    f(x)='sum(x[:,  1])', saveHistory=True
+>>perElement, name=q,            elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,1])', saveHistory=True
+>>perElement, name=eq,           elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,2])', saveHistory=True
+>>perElement, name=voidRatio,    elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,0]'
+>>perElement, name=dNorm,        elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,3]'
+>>perNode, name=Displacement, elSet=all, field=displacement, result=U,
+>>perElement, name=Stress,       elSet=all, result=stress, quadraturePoint=1
+>>perElement, name=Strain,       elSet=all, result=strain, quadraturePoint=1
+>>perNode, name=uTop,         nSet=gen_top,          field=displacement, result=U,    f(x)='mean(x[:, 1])', saveHistory=True
+>>perNode, name=sumRFNodes,   nSet=gen_top,          field=displacement, result=P,    f(x)='sum(x[:,  1])', saveHistory=True
 
 *output, type=ensight, name=barodesy
-create=perNode,    elSet=all, fieldOutput=Displacement
-create=perElement, elSet=all, fieldOutput=Stress
-create=perElement, elSet=all, fieldOutput=Strain
-create=perElement, elSet=all, fieldOutput=voidRatio
-create=perElement, elSet=all, fieldOutput=dNorm
-configuration, overwrite=yes
+>>perNode, elSet=all, fieldOutput=Displacement
+>>perElement, elSet=all, fieldOutput=Stress
+>>perElement, elSet=all, fieldOutput=Strain
+>>perElement, elSet=all, fieldOutput=voidRatio
+>>perElement, elSet=all, fieldOutput=dNorm
+>>configuration, overwrite=yes
 
 *step, maxInc=1e0, minInc=1e-5, maxNumInc=100000, maxIter=25, stepLength=1
-options,         category=NISTSolver, extrapolation=on0
-dirichlet,       name=bottom, nSet=gen_bottom,      field=displacement, 2=0.0
-dirichlet,       name=leftbottom, nSet=gen_leftBottom,      field=displacement, 1=0.0
-geostatic,       name=geo, elSet=all, p1=-100, h1=0, p2=-100, h2=200, xLateral=1.0, zLateral=1.0
-distributedload, name=dll, surface=gen_left, magnitude=100, f(t)=1, type=pressure
-distributedload, name=dlr, surface=gen_right, magnitude=100, f(t)=1, type=pressure
-distributedload, name=dlTop, surface=gen_top, magnitude=100, f(t)=1, type=pressure
-options,         category=NISTArcLength, arcLengthController=off
+>>options,         category=NISTSolver, extrapolation=on0
+>>dirichlet,       name=bottom, nSet=gen_bottom,      field=displacement, 2=0.0
+>>dirichlet,       name=leftbottom, nSet=gen_leftBottom,      field=displacement, 1=0.0
+>>geostatic,       name=geo, elSet=all, p1=-100, h1=0, p2=-100, h2=200, xLateral=1.0, zLateral=1.0
+>>distributedload, name=dll, surface=gen_left, magnitude=100, f(t)=1, type=pressure
+>>distributedload, name=dlr, surface=gen_right, magnitude=100, f(t)=1, type=pressure
+>>distributedload, name=dlTop, surface=gen_top, magnitude=100, f(t)=1, type=pressure
+>>options,         category=NISTArcLength, arcLengthController=off
 
 
 
 *step, maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
-dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.01
-sdvini,    name=ini, elSet=all, sdv=0, val=0.40
-sdvini,    name=ini2, elSet=gen_shearBandCenter, sdv=0, val=0.43
+>>dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.01
+>>sdvini,    name=ini, elSet=all, sdv=0, val=0.40
+>>sdvini,    name=ini2, elSet=gen_shearBandCenter, sdv=0, val=0.43
 
 ***step, maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
 **dirichlet, name=top, nSet=gen_top,  field=displacement, 2=0.002
@@ -57,7 +57,7 @@ sdvini,    name=ini2, elSet=gen_shearBandCenter, sdv=0, val=0.43
 **dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.003
 
 *output, type=meshPlot,
-figure=1, axSpec=111, create=perElement, fieldOutput=voidRatio
-figure=2, axSpec=111, c=red, ls=dashed, create=xyData, x=uTop, y=sumRFNodes,
+>>figure=1, axSpec=111, create=perElement, fieldOutput=voidRatio
+>>figure=2, axSpec=111, c=red, ls=dashed, create=xyData, x=uTop, y=sumRFNodes,
 
 

--- a/testfiles/marmot/BarodesyGradientVoid/test_.inp
+++ b/testfiles/marmot/BarodesyGradientVoid/test_.inp
@@ -9,29 +9,29 @@ h=0.1
 ** phiC N lambda* kappa* sigma* (1 when calculating in kpa) numericalCohesion
 24, 0.8, 0.059, 0.018, 1, 0.1, 0.005
 
-*section, name=section1, thickness=1.0, material=wealdClay, type=plane
+*section, name=section1, material=wealdClay, type=plane
 all
 
 *job, name=cpe4job, domain=2d, solver=NISTParallel
 *solver, solver=NISTParallel, name=theSolver
 
-*fieldOutput, jobName=cpe4job
+*fieldOutput,
 >>perElement, name=q,            elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,1])', saveHistory=True
 >>perElement, name=eq,           elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,2])', saveHistory=True
 >>perElement, name=voidRatio,    elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,0]'
 >>perElement, name=dNorm,        elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,3]'
->>perNode, name=Displacement, elSet=all, field=displacement, result=U,
+>>perNode, name=Displacement, elSet=all, field=displacement, result=U
 >>perElement, name=Stress,       elSet=all, result=stress, quadraturePoint=1
 >>perElement, name=Strain,       elSet=all, result=strain, quadraturePoint=1
 >>perNode, name=uTop,         nSet=gen_top,          field=displacement, result=U,    f(x)='mean(x[:, 1])', saveHistory=True
 >>perNode, name=sumRFNodes,   nSet=gen_top,          field=displacement, result=P,    f(x)='sum(x[:,  1])', saveHistory=True
 
 *output, type=ensight, name=barodesy
->>perNode, elSet=all, fieldOutput=Displacement
->>perElement, elSet=all, fieldOutput=Stress
->>perElement, elSet=all, fieldOutput=Strain
->>perElement, elSet=all, fieldOutput=voidRatio
->>perElement, elSet=all, fieldOutput=dNorm
+>>perNode, fieldOutput=Displacement
+>>perElement, fieldOutput=Stress
+>>perElement, fieldOutput=Strain
+>>perElement, fieldOutput=voidRatio
+>>perElement, fieldOutput=dNorm
 >>configuration, overwrite=yes
 
 *step, solver=theSolver
@@ -50,8 +50,8 @@ maxInc=1e0, minInc=1e-5, maxNumInc=100000, maxIter=25, stepLength=1
 *step, solver=theSolver
 maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
 >>dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.01
->>sdvini,    name=ini, elSet=all, sdv=0, val=0.40
->>sdvini,    name=ini2, elSet=gen_shearBandCenter, sdv=0, val=0.43
+>>setinitialconditions, elSet=all, property='sdvini', values='0, 0.40'
+>>setinitialconditions, elSet=gen_shearBandCenter, property='sdvini', values='0, 0.43'
 
 ***step, maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
 **dirichlet, name=top, nSet=gen_top,  field=displacement, 2=0.002
@@ -60,7 +60,7 @@ maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
 **dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.003
 
 *output, type=meshPlot,
->>figure=1, axSpec=111, create=perElement, fieldOutput=voidRatio
->>figure=2, axSpec=111, c=red, ls=dashed, create=xyData, x=uTop, y=sumRFNodes,
+figure=1, axSpec=111, create=perElement, fieldOutput=voidRatio
+figure=2, axSpec=111, c=red, ls=dashed, create=xyData, x=uTop, y=sumRFNodes,
 
 

--- a/testfiles/marmot/BarodesyGradientVoid/test_.inp
+++ b/testfiles/marmot/BarodesyGradientVoid/test_.inp
@@ -33,7 +33,8 @@ all
 >>perElement, elSet=all, fieldOutput=dNorm
 >>configuration, overwrite=yes
 
-*step, maxInc=1e0, minInc=1e-5, maxNumInc=100000, maxIter=25, stepLength=1
+*step
+maxInc=1e0, minInc=1e-5, maxNumInc=100000, maxIter=25, stepLength=1
 >>options,         category=NISTSolver, extrapolation=on0
 >>dirichlet,       name=bottom, nSet=gen_bottom,      field=displacement, 2=0.0
 >>dirichlet,       name=leftbottom, nSet=gen_leftBottom,      field=displacement, 1=0.0
@@ -45,7 +46,8 @@ all
 
 
 
-*step, maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
+*step
+maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
 >>dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.01
 >>sdvini,    name=ini, elSet=all, sdv=0, val=0.40
 >>sdvini,    name=ini2, elSet=gen_shearBandCenter, sdv=0, val=0.43

--- a/testfiles/marmot/DLoad3DUpdatedLagrange/_test.inp
+++ b/testfiles/marmot/DLoad3DUpdatedLagrange/_test.inp
@@ -3855,17 +3855,17 @@ all
 *solver, solver=NIST, name=theSolver
 
 *fieldOutput
-create=perNode, name=displacement, elSet=all, field=displacement, result=U, name=displacement
-create=perElement, name=stress, elSet=all, result=stress, quadraturePoint=1
-create=perElement, name=strain, elSet=all, result=strain, quadraturePoint=1
+>>perNode, name=displacement, elSet=all, field=displacement, result=U, name=displacement
+>>perElement, name=stress, elSet=all, result=stress, quadraturePoint=1
+>>perElement, name=strain, elSet=all, result=strain, quadraturePoint=1
 
 *output, type=ensight, name=ensightExport
-create=perNode,    fieldOutput=displacement
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>configuration, overwrite=yes
 
 *step, solver=theSolver, maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=clamp,  nSet=Set-1,   field=displacement, 1=0.0, 2=0.0, 3=0.
-distributedload, name=dload, surface=loadsurf, type=pressure, magnitude=10, f(t)=t
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=clamp,  nSet=Set-1,   field=displacement, 1=0.0, 2=0.0, 3=0.
+>>distributedload, name=dload, surface=loadsurf, type=pressure, magnitude=10, f(t)=t

--- a/testfiles/marmot/DLoad3DUpdatedLagrange/_test.inp
+++ b/testfiles/marmot/DLoad3DUpdatedLagrange/_test.inp
@@ -3848,14 +3848,14 @@ _loadsurf_S3, 3
 *material, name=stvenantkirchhoffisotropic, id=stvenantkirchhoffisotropic
 5000, 0.25
 
-*section, name=section1, thickness=1.0, material=stvenantkirchhoffisotropic, type=plane
+*section, name=section1, material=stvenantkirchhoffisotropic, type=plane
 all
 
 *job, name=c3d8job, domain=3d
 *solver, solver=NIST, name=theSolver
 
-*fieldOutput
->>perNode, name=displacement, elSet=all, field=displacement, result=U, name=displacement
+*fieldOutput,
+>>perNode, name=displacement, elSet=all, field=displacement, result=U
 >>perElement, name=stress, elSet=all, result=stress, quadraturePoint=1
 >>perElement, name=strain, elSet=all, result=strain, quadraturePoint=1
 

--- a/testfiles/marmot/DLoad3DUpdatedLagrange/_test.inp
+++ b/testfiles/marmot/DLoad3DUpdatedLagrange/_test.inp
@@ -3865,7 +3865,8 @@ all
 >>perElement, fieldOutput=strain
 >>configuration, overwrite=yes
 
-*step, solver=theSolver, maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
+*step, solver=theSolver
+maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=clamp,  nSet=Set-1,   field=displacement, 1=0.0, 2=0.0, 3=0.
 >>distributedload, name=dload, surface=loadsurf, type=pressure, magnitude=10, f(t)=t

--- a/testfiles/marmot/FieldOutput/fieldOutput.inp
+++ b/testfiles/marmot/FieldOutput/fieldOutput.inp
@@ -41,7 +41,8 @@ fieldOutput=RF_bottom, f(x)='sum ( x[:,1] )'
 *output, type=plotAlongPath, name=myNodeSetPlotter
 >>figure=2, nSet=gen_top, fieldOutput=RF_bottom, f(x)='x[:,1]', label=P along bottom, normalize=True
 
-*step, maxInc=1e-1, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=100
+*step
+maxInc=1e-1, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=100
 >>options, category=Ensight, intermediateSaveInterval=2,
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=1,          nSet=gen_leftBottom,    field=displacement, 2=0.0, 1=0.0

--- a/testfiles/marmot/FieldOutput/fieldOutput.inp
+++ b/testfiles/marmot/FieldOutput/fieldOutput.inp
@@ -1,7 +1,7 @@
 *material, name=modleon, id=modleon
 30000.0, 0.15 ,13 , 47.4 ,  55   , 4.74 , 0.85 , 0.12 , 0.003, 2.0, 0.000001, 15.0, 0.10, 1
 
-*section, name=section1, thickness=1.0, material=modleon, type=plane
+*section, name=section1, material=modleon, type=plane
 all
 
 *job, name=cps4job, domain=2d, solver=NIST
@@ -15,7 +15,7 @@ nX=20
 nY=20
 
 *fieldOutput,
->>perNode, name=displacement,              nSet=all,           field=displacement, result=U,
+>>perNode, name=displacement,              nSet=all,           field=displacement, result=U
 >>perNode, name=displacement_top,          nSet=gen_top,       field=displacement, result=U, saveHistory=True
 >>perNode, name=displacement_top_mean_1,   nSet=gen_top,       field=displacement, result=U, saveHistory=True, f(x)='mean( x[:,1])'
 >>perNode, name=RF_bottom,                 nSet=gen_bottom,    field=displacement, result=P, saveHistory=True
@@ -30,9 +30,9 @@ nY=20
 ** figure=1, axSpec=212, c=red, ls=dashed, create=xyData, x=time, y=RF_bottom, f(y)='sum ( y[:,:,1], axis=1)', label=Sum(RF)
 
 *output, type=ensight, name=myEnsightExport
->>perNode, fieldOutput=displacement,
->>perElement, fieldOutput=stress,
->>perElement, fieldOutput=alphaP,
+>>perNode, fieldOutput=displacement
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=alphaP
 >>configuration, overwrite=yes
 
 
@@ -40,7 +40,7 @@ nY=20
 fieldOutput=RF_bottom, f(x)='sum ( x[:,1] )'
 
 *output, type=plotAlongPath, name=myNodeSetPlotter
->>figure=2, nSet=gen_top, fieldOutput=RF_bottom, f(x)='x[:,1]', label=P along bottom, normalize=True
+figure=2, nSet=gen_top, fieldOutput=RF_bottom, f(x)='x[:,1]', label=P along bottom, normalize=True
 
 *step, solver=theSolver
 maxInc=1e-1, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=100

--- a/testfiles/marmot/FieldOutput/fieldOutput.inp
+++ b/testfiles/marmot/FieldOutput/fieldOutput.inp
@@ -5,6 +5,7 @@
 all
 
 *job, name=cps4job, domain=2d, solver=NIST
+*solver, solver=NIST, name=theSolver
 
 *modelGenerator, generator=planeRectQuad, name=gen
 x0=0, l=50
@@ -41,7 +42,7 @@ fieldOutput=RF_bottom, f(x)='sum ( x[:,1] )'
 *output, type=plotAlongPath, name=myNodeSetPlotter
 >>figure=2, nSet=gen_top, fieldOutput=RF_bottom, f(x)='x[:,1]', label=P along bottom, normalize=True
 
-*step
+*step, solver=theSolver
 maxInc=1e-1, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=100
 >>options, category=Ensight, intermediateSaveInterval=2,
 >>options, category=NISTSolver, extrapolation=linear

--- a/testfiles/marmot/FieldOutput/fieldOutput.inp
+++ b/testfiles/marmot/FieldOutput/fieldOutput.inp
@@ -14,14 +14,14 @@ nX=20
 nY=20
 
 *fieldOutput,
-create=perNode, name=displacement,              nSet=all,           field=displacement, result=U,
-create=perNode, name=displacement_top,          nSet=gen_top,       field=displacement, result=U, saveHistory=True
-create=perNode, name=displacement_top_mean_1,   nSet=gen_top,       field=displacement, result=U, saveHistory=True, f(x)='mean( x[:,1])'
-create=perNode, name=RF_bottom,                 nSet=gen_bottom,    field=displacement, result=P, saveHistory=True
-create=perNode, name=RF_bottom_sum_1,           nSet=gen_bottom,    field=displacement, result=P, saveHistory=True, f(x)='sum(x[:,1])'
-create=perElement, name=stress,                    elSet=all,          result=stress,      quadraturePoint=1
-create=perElement, name=stress_top,                elSet=gen_top,      result=stress,      quadraturePoint=1
-create=perElement, name=alphaP,                    elSet=all,          result=alphaP,      quadraturePoint=1
+>>perNode, name=displacement,              nSet=all,           field=displacement, result=U,
+>>perNode, name=displacement_top,          nSet=gen_top,       field=displacement, result=U, saveHistory=True
+>>perNode, name=displacement_top_mean_1,   nSet=gen_top,       field=displacement, result=U, saveHistory=True, f(x)='mean( x[:,1])'
+>>perNode, name=RF_bottom,                 nSet=gen_bottom,    field=displacement, result=P, saveHistory=True
+>>perNode, name=RF_bottom_sum_1,           nSet=gen_bottom,    field=displacement, result=P, saveHistory=True, f(x)='sum(x[:,1])'
+>>perElement, name=stress,                    elSet=all,          result=stress,      quadraturePoint=1
+>>perElement, name=stress_top,                elSet=gen_top,      result=stress,      quadraturePoint=1
+>>perElement, name=alphaP,                    elSet=all,          result=alphaP,      quadraturePoint=1
 
 ** *output, type=meshPlot,
 ** figure=1, axSpec=221, create=perNode,       fieldOutput=displacement,       f(x)='x[:,1]', label=U2
@@ -29,21 +29,21 @@ create=perElement, name=alphaP,                    elSet=all,          result=al
 ** figure=1, axSpec=212, c=red, ls=dashed, create=xyData, x=time, y=RF_bottom, f(y)='sum ( y[:,:,1], axis=1)', label=Sum(RF)
 
 *output, type=ensight, name=myEnsightExport
-create=perNode,    fieldOutput=displacement,
-create=perElement, fieldOutput=stress,
-create=perElement, fieldOutput=alphaP,
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement,
+>>perElement, fieldOutput=stress,
+>>perElement, fieldOutput=alphaP,
+>>configuration, overwrite=yes
 
 
 *output, type=monitor, name=myNodeMonitor
 fieldOutput=RF_bottom, f(x)='sum ( x[:,1] )'
 
 *output, type=plotAlongPath, name=myNodeSetPlotter
-figure=2, nSet=gen_top, fieldOutput=RF_bottom, f(x)='x[:,1]', label=P along bottom, normalize=True
+>>figure=2, nSet=gen_top, fieldOutput=RF_bottom, f(x)='x[:,1]', label=P along bottom, normalize=True
 
 *step, maxInc=1e-1, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=100
-options, category=Ensight, intermediateSaveInterval=2,
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=1,          nSet=gen_leftBottom,    field=displacement, 2=0.0, 1=0.0
-dirichlet, name=bottom,     nSet=gen_bottom,        field=displacement, 2=0,
-nodeforces, name=top,       nSet=gen_top,           field=displacement, 2=-80, f(t)=t**2
+>>options, category=Ensight, intermediateSaveInterval=2,
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=1,          nSet=gen_leftBottom,    field=displacement, 2=0.0, 1=0.0
+>>dirichlet, name=bottom,     nSet=gen_bottom,        field=displacement, 2=0,
+>>nodeforces, name=top,       nSet=gen_top,           field=displacement, 2=-80, f(t)=t**2

--- a/testfiles/marmot/GC3D20RMixed/test.inp
+++ b/testfiles/marmot/GC3D20RMixed/test.inp
@@ -4,7 +4,7 @@
 all
 
 *job, name=c3d8nljob, domain=3d
-*solver, solver=NISTParallelForMarmotElements, name=theSolver
+*solver, solver=NISTParallel, name=theSolver
 
 *include, input=mesh.inp
 

--- a/testfiles/marmot/GC3D8EAS9/testeas.inp
+++ b/testfiles/marmot/GC3D8EAS9/testeas.inp
@@ -53,7 +53,8 @@ weak
 *output, type=meshplot, name=RFPlot
 >>xyData, x=time, y=RFTop, legend=RF
 
-*step, solver=theSolver, maxInc=1e-1, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=100
+*step, solver=theSolver
+maxInc=1e-1, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=100
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=bcCorner,     nSet=origin,      field=displacement,     1=0, 2=0, 3=0
 >>dirichlet, name=bottom2, nSet=bottom,  field=displacement,               2=0,
@@ -61,6 +62,7 @@ weak
 >>dirichlet, name=back,   nSet=back, field=displacement,             3=0,
 >>dirichlet, name=front,   nSet=front, field=displacement,             3=0,
 
-*step, solver=theSolver, maxInc=1e-2, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=100
+*step, solver=theSolver
+maxInc=1e-2, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=100
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=top, nSet=top, field=displacement, 2=-2,

--- a/testfiles/marmot/GC3D8EAS9/testeas.inp
+++ b/testfiles/marmot/GC3D8EAS9/testeas.inp
@@ -13,54 +13,54 @@ weak
 *job, name=easjob, domain=3d
 *solver, solver=NISTParallel, name=theSolver
 *fieldOutput
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
-create=perNode, elSet=all, field=nonlocal damage, result=U, name=alpha_d_nonlocal
-create=perElement, elSet=all, result=stress, quadraturePoint=0:8, name=stress, f(x)='mean(x, axis=1)'
-create=perElement, elSet=all, result=strain, quadraturePoint=0:8, name=strain, f(x)='mean(x, axis=1)'
-create=perElement, elSet=all, result=alphaP, quadraturePoint=0:8, name=alphaP, f(x)='mean( x[:,:], axis=1) '
-create=perElement, elSet=all, result=alphaD, quadraturePoint=0:8, name=alphaD, f(x)='mean( x[:,:], axis=1) '
-create=perElement, elSet=all, result=omega, quadraturePoint=0:8, name=omega, f(x)='mean( x[:,:], axis=1) '
-create=perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas0, f(x)='mean( x[:,:,0], axis=1) '
-create=perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas1, f(x)='mean( x[:,:,1], axis=1) '
-create=perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas2, f(x)='mean( x[:,:,2], axis=1) '
-create=perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas3, f(x)='mean( x[:,:,3], axis=1) '
-create=perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas4, f(x)='mean( x[:,:,4], axis=1) '
-create=perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas5, f(x)='mean( x[:,:,5], axis=1) '
-create=perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas6, f(x)='mean( x[:,:,6], axis=1) '
-create=perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas7, f(x)='mean( x[:,:,7], axis=1) '
-create=perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas8, f(x)='mean( x[:,:,8], axis=1) '
-create=perNode, nSet=top, field=displacement, result=P, f(x)='( sum(x[:, 1]) ) ', name=RFTop, saveHistory=true
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, elSet=all, field=nonlocal damage, result=U, name=alpha_d_nonlocal
+>>perElement, elSet=all, result=stress, quadraturePoint=0:8, name=stress, f(x)='mean(x, axis=1)'
+>>perElement, elSet=all, result=strain, quadraturePoint=0:8, name=strain, f(x)='mean(x, axis=1)'
+>>perElement, elSet=all, result=alphaP, quadraturePoint=0:8, name=alphaP, f(x)='mean( x[:,:], axis=1) '
+>>perElement, elSet=all, result=alphaD, quadraturePoint=0:8, name=alphaD, f(x)='mean( x[:,:], axis=1) '
+>>perElement, elSet=all, result=omega, quadraturePoint=0:8, name=omega, f(x)='mean( x[:,:], axis=1) '
+>>perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas0, f(x)='mean( x[:,:,0], axis=1) '
+>>perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas1, f(x)='mean( x[:,:,1], axis=1) '
+>>perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas2, f(x)='mean( x[:,:,2], axis=1) '
+>>perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas3, f(x)='mean( x[:,:,3], axis=1) '
+>>perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas4, f(x)='mean( x[:,:,4], axis=1) '
+>>perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas5, f(x)='mean( x[:,:,5], axis=1) '
+>>perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas6, f(x)='mean( x[:,:,6], axis=1) '
+>>perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas7, f(x)='mean( x[:,:,7], axis=1) '
+>>perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas8, f(x)='mean( x[:,:,8], axis=1) '
+>>perNode, nSet=top, field=displacement, result=P, f(x)='( sum(x[:, 1]) ) ', name=RFTop, saveHistory=true
 
 *output, type=ensight, name=esExport
-create=perNode,    fieldOutput=displacement
-create=perNode,    fieldOutput=alpha_d_nonlocal
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
-create=perElement, fieldOutput=eas0
-create=perElement, fieldOutput=eas1
-create=perElement, fieldOutput=eas2
-create=perElement, fieldOutput=eas3
-create=perElement, fieldOutput=eas4
-create=perElement, fieldOutput=eas5
-create=perElement, fieldOutput=eas6
-create=perElement, fieldOutput=eas7
-create=perElement, fieldOutput=eas8
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perNode, fieldOutput=alpha_d_nonlocal
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
+>>perElement, fieldOutput=eas0
+>>perElement, fieldOutput=eas1
+>>perElement, fieldOutput=eas2
+>>perElement, fieldOutput=eas3
+>>perElement, fieldOutput=eas4
+>>perElement, fieldOutput=eas5
+>>perElement, fieldOutput=eas6
+>>perElement, fieldOutput=eas7
+>>perElement, fieldOutput=eas8
+>>configuration, overwrite=yes
 
 *output, type=meshplot, name=RFPlot
-create=xyData, x=time, y=RFTop, legend=RF
+>>xyData, x=time, y=RFTop, legend=RF
 
 *step, solver=theSolver, maxInc=1e-1, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=100
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=bcCorner,     nSet=origin,      field=displacement,     1=0, 2=0, 3=0
-dirichlet, name=bottom2, nSet=bottom,  field=displacement,               2=0,
-dirichlet, name=zrot,   nSet=zrotlock, field=displacement,             3=0,
-dirichlet, name=back,   nSet=back, field=displacement,             3=0,
-dirichlet, name=front,   nSet=front, field=displacement,             3=0,
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=bcCorner,     nSet=origin,      field=displacement,     1=0, 2=0, 3=0
+>>dirichlet, name=bottom2, nSet=bottom,  field=displacement,               2=0,
+>>dirichlet, name=zrot,   nSet=zrotlock, field=displacement,             3=0,
+>>dirichlet, name=back,   nSet=back, field=displacement,             3=0,
+>>dirichlet, name=front,   nSet=front, field=displacement,             3=0,
 
 *step, solver=theSolver, maxInc=1e-2, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=100
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=top, nSet=top, field=displacement, 2=-2,
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=top, nSet=top, field=displacement, 2=-2,

--- a/testfiles/marmot/GC3D8EAS9/testeas.inp
+++ b/testfiles/marmot/GC3D8EAS9/testeas.inp
@@ -12,7 +12,7 @@ weak
 
 *job, name=easjob, domain=3d
 *solver, solver=NISTParallel, name=theSolver
-*fieldOutput
+*fieldOutput,
 >>perNode, elSet=all, field=displacement, result=U, name=displacement
 >>perNode, elSet=all, field=nonlocal damage, result=U, name=alpha_d_nonlocal
 >>perElement, elSet=all, result=stress, quadraturePoint=0:8, name=stress, f(x)='mean(x, axis=1)'
@@ -51,7 +51,7 @@ weak
 >>configuration, overwrite=yes
 
 *output, type=meshplot, name=RFPlot
->>xyData, x=time, y=RFTop, legend=RF
+figure=1, axSpec=111, create=xyData, x=time, y=RFTop, legend=RF
 
 *step, solver=theSolver
 maxInc=1e-1, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=100

--- a/testfiles/marmot/GCPS8R/notchedbeam.inp
+++ b/testfiles/marmot/GCPS8R/notchedbeam.inp
@@ -7,31 +7,31 @@ all
 
 *job, name=cps8rnljob, domain=2d, solver=NISTParallel
 *fieldOutput
-create=perNode, name=load, nSet=topNodes,  field=displacement, result=P
-create=perNode, name=displacement, elSet=all, field=displacement, result=U, name=displacement
-create=perNode, name=nonlocalDamage, elSet=all, field=nonlocal damage, result=U,
-create=perElement, name=stress, elSet=all, result=stress, quadraturePoint=0:4, f(x)='mean(x, axis=1)'
-create=perElement, name=strain, elSet=all, result=strain, quadraturePoint=0:4, f(x)='mean(x, axis=1)'
-create=perElement, name=alphaP, elSet=all, result=alphaP, quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
-create=perElement, name=alphaD, elSet=all, result=alphaD,quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
-create=perElement, name=omega, elSet=all, result=omega, quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
+>>perNode, name=load, nSet=topNodes,  field=displacement, result=P
+>>perNode, name=displacement, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, name=nonlocalDamage, elSet=all, field=nonlocal damage, result=U,
+>>perElement, name=stress, elSet=all, result=stress, quadraturePoint=0:4, f(x)='mean(x, axis=1)'
+>>perElement, name=strain, elSet=all, result=strain, quadraturePoint=0:4, f(x)='mean(x, axis=1)'
+>>perElement, name=alphaP, elSet=all, result=alphaP, quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
+>>perElement, name=alphaD, elSet=all, result=alphaD,quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
+>>perElement, name=omega, elSet=all, result=omega, quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
 
 
 *output, type=monitor, jobName=cps8rnljob
 fieldOutput=load, f(x)='sum(x[:,1])'
 
 *output, type=ensight, name=ensightExport
-create=perNode,    fieldOutput=displacement
-create=perNode,    fieldOutput=nonlocalDamage
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perNode, fieldOutput=nonlocalDamage
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
+>>configuration, overwrite=yes
 
 *step, maxInc=1e-1, minInc=1e-6, maxNumInc=1000, maxIter=25,
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=left,  nSet=left,   field=displacement, 1=0.0, 2=0.0
-dirichlet, name=right, nSet=right,  field=displacement, 2=0
-dirichlet, name=top, nSet=topNodes, field=displacement, 2=-.5
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=left,  nSet=left,   field=displacement, 1=0.0, 2=0.0
+>>dirichlet, name=right, nSet=right,  field=displacement, 2=0
+>>dirichlet, name=top, nSet=topNodes, field=displacement, 2=-.5

--- a/testfiles/marmot/GCPS8R/notchedbeam.inp
+++ b/testfiles/marmot/GCPS8R/notchedbeam.inp
@@ -30,7 +30,8 @@ fieldOutput=load, f(x)='sum(x[:,1])'
 >>perElement, fieldOutput=omega
 >>configuration, overwrite=yes
 
-*step, maxInc=1e-1, minInc=1e-6, maxNumInc=1000, maxIter=25,
+*step
+maxInc=1e-1, minInc=1e-6, maxNumInc=1000, maxIter=25
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=left,  nSet=left,   field=displacement, 1=0.0, 2=0.0
 >>dirichlet, name=right, nSet=right,  field=displacement, 2=0

--- a/testfiles/marmot/GCPS8R/notchedbeam.inp
+++ b/testfiles/marmot/GCPS8R/notchedbeam.inp
@@ -6,6 +6,7 @@
 all
 
 *job, name=cps8rnljob, domain=2d, solver=NISTParallel
+*solver, solver=NISTParallel, name=theSolver
 *fieldOutput
 >>perNode, name=load, nSet=topNodes,  field=displacement, result=P
 >>perNode, name=displacement, elSet=all, field=displacement, result=U, name=displacement
@@ -30,7 +31,7 @@ fieldOutput=load, f(x)='sum(x[:,1])'
 >>perElement, fieldOutput=omega
 >>configuration, overwrite=yes
 
-*step
+*step, solver=theSolver
 maxInc=1e-1, minInc=1e-6, maxNumInc=1000, maxIter=25
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=left,  nSet=left,   field=displacement, 1=0.0, 2=0.0

--- a/testfiles/marmot/GCPS8R/notchedbeam.inp
+++ b/testfiles/marmot/GCPS8R/notchedbeam.inp
@@ -2,15 +2,15 @@
 *material, name=modleonNonLocal, id=modleon
 30000.0, 0.15 ,13 , 47.4 ,  55   , 4.74 , 0.85 , 0.12 , 0.003, 2.0, 0.000001, 15.0, 5, 1.05, 0.0017, 1
 
-*section, name=section1, thickness=1.0, material=modleon, type=plane
+*section, name=section1, material=modleon, type=plane
 all
 
 *job, name=cps8rnljob, domain=2d, solver=NISTParallel
 *solver, solver=NISTParallel, name=theSolver
-*fieldOutput
+*fieldOutput,
 >>perNode, name=load, nSet=topNodes,  field=displacement, result=P
->>perNode, name=displacement, elSet=all, field=displacement, result=U, name=displacement
->>perNode, name=nonlocalDamage, elSet=all, field=nonlocal damage, result=U,
+>>perNode, name=displacement, elSet=all, field=displacement, result=U
+>>perNode, name=nonlocalDamage, elSet=all, field=nonlocal damage, result=U
 >>perElement, name=stress, elSet=all, result=stress, quadraturePoint=0:4, f(x)='mean(x, axis=1)'
 >>perElement, name=strain, elSet=all, result=strain, quadraturePoint=0:4, f(x)='mean(x, axis=1)'
 >>perElement, name=alphaP, elSet=all, result=alphaP, quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
@@ -18,7 +18,7 @@ all
 >>perElement, name=omega, elSet=all, result=omega, quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
 
 
-*output, type=monitor, jobName=cps8rnljob
+*output, type=monitor
 fieldOutput=load, f(x)='sum(x[:,1])'
 
 *output, type=ensight, name=ensightExport

--- a/testfiles/marmot/GCPS8RMixed/notchedbeam.inp
+++ b/testfiles/marmot/GCPS8RMixed/notchedbeam.inp
@@ -2,14 +2,14 @@
 *material, name=modleonNonLocal, id=modleon
 30000.0, 0.15 ,13 , 47.4 ,  55   , 4.74 , 0.85 , 0.12 , 0.003, 2.0, 0.000001, 15.0, 5, 1.05, 0.0017, 1
 
-*section, name=section1, thickness=1.0, material=modleon, type=plane
+*section, name=section1, material=modleon, type=plane
 all
 
 *job, name=myjob, domain=2d, solver=NISTParallel
 *solver, solver=NISTParallel, name=theSolver
-*fieldOutput
+*fieldOutput,
 >>perNode, name=load, nSet=topNodes,  field=displacement, result=P
->>perNode, name=displacement, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, name=displacement, elSet=all, field=displacement, result=U
 **name=nonlocalDamage, elSet=all, field=nonlocal damage, result=U, <-- this option is currently not supported by fieldoutput in Edelweiss
 **name=stress, elSet=all, result=stress, quadraturePoint=0:4, f(x)='mean(x, axis=1)'
 **name=strain, elSet=all, result=strain, quadraturePoint=0:4, f(x)='mean(x, axis=1)'
@@ -20,7 +20,7 @@ all
 >>perElement, elSet=all, result=strain, quadraturePoint=0:4, name=strain, f(x)='mean(x, axis=1)'
 
 
-*output, type=monitor, jobName=myjob
+*output, type=monitor
 fieldOutput=load, f(x)='sum(x[:,1])'
 
 *output, type=ensight, name=notchedBeam

--- a/testfiles/marmot/GCPS8RMixed/notchedbeam.inp
+++ b/testfiles/marmot/GCPS8RMixed/notchedbeam.inp
@@ -7,33 +7,33 @@ all
 
 *job, name=myjob, domain=2d, solver=NISTParallel
 *fieldOutput
-create=perNode, name=load, nSet=topNodes,  field=displacement, result=P
-create=perNode, name=displacement, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, name=load, nSet=topNodes,  field=displacement, result=P
+>>perNode, name=displacement, elSet=all, field=displacement, result=U, name=displacement
 **name=nonlocalDamage, elSet=all, field=nonlocal damage, result=U, <-- this option is currently not supported by fieldoutput in Edelweiss
 **name=stress, elSet=all, result=stress, quadraturePoint=0:4, f(x)='mean(x, axis=1)'
 **name=strain, elSet=all, result=strain, quadraturePoint=0:4, f(x)='mean(x, axis=1)'
 **name=alphaP, elSet=all, result=alphaP, quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
 **name=alphaD, elSet=all, result=alphaD,quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
-create=perElement, name=omega, elSet=all, result=omega, quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
-create=perElement, elSet=all, result=stress, quadraturePoint=0:4, name=stress, f(x)='mean(x, axis=1)'
-create=perElement, elSet=all, result=strain, quadraturePoint=0:4, name=strain, f(x)='mean(x, axis=1)'
+>>perElement, name=omega, elSet=all, result=omega, quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
+>>perElement, elSet=all, result=stress, quadraturePoint=0:4, name=stress, f(x)='mean(x, axis=1)'
+>>perElement, elSet=all, result=strain, quadraturePoint=0:4, name=strain, f(x)='mean(x, axis=1)'
 
 
 *output, type=monitor, jobName=myjob
 fieldOutput=load, f(x)='sum(x[:,1])'
 
 *output, type=ensight, name=notchedBeam
-configuration, overwrite=yes
-create=perNode,    fieldOutput=displacement
+>>configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
 **create=perNode,    fieldOutput=nonlocalDamage
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
 **create=perElement, fieldOutput=alphaP
 **create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
+>>perElement, fieldOutput=omega
 
 *step, maxInc=1e-1, minInc=1e-6, maxNumInc=1000, maxIter=25,
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=left,  nSet=left,   field=displacement, 1=0.0, 2=0.0
-dirichlet, name=right, nSet=right,  field=displacement, 2=0
-dirichlet, name=top, nSet=topNodes, field=displacement, 2=-.5
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=left,  nSet=left,   field=displacement, 1=0.0, 2=0.0
+>>dirichlet, name=right, nSet=right,  field=displacement, 2=0
+>>dirichlet, name=top, nSet=topNodes, field=displacement, 2=-.5

--- a/testfiles/marmot/GCPS8RMixed/notchedbeam.inp
+++ b/testfiles/marmot/GCPS8RMixed/notchedbeam.inp
@@ -32,7 +32,8 @@ fieldOutput=load, f(x)='sum(x[:,1])'
 **create=perElement, fieldOutput=alphaD
 >>perElement, fieldOutput=omega
 
-*step, maxInc=1e-1, minInc=1e-6, maxNumInc=1000, maxIter=25,
+*step
+maxInc=1e-1, minInc=1e-6, maxNumInc=1000, maxIter=25
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=left,  nSet=left,   field=displacement, 1=0.0, 2=0.0
 >>dirichlet, name=right, nSet=right,  field=displacement, 2=0

--- a/testfiles/marmot/GCPS8RMixed/notchedbeam.inp
+++ b/testfiles/marmot/GCPS8RMixed/notchedbeam.inp
@@ -6,6 +6,7 @@
 all
 
 *job, name=myjob, domain=2d, solver=NISTParallel
+*solver, solver=NISTParallel, name=theSolver
 *fieldOutput
 >>perNode, name=load, nSet=topNodes,  field=displacement, result=P
 >>perNode, name=displacement, elSet=all, field=displacement, result=U, name=displacement
@@ -32,7 +33,7 @@ fieldOutput=load, f(x)='sum(x[:,1])'
 **create=perElement, fieldOutput=alphaD
 >>perElement, fieldOutput=omega
 
-*step
+*step, solver=theSolver
 maxInc=1e-1, minInc=1e-6, maxNumInc=1000, maxIter=25
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=left,  nSet=left,   field=displacement, 1=0.0, 2=0.0

--- a/testfiles/marmot/GMCDPFiniteStrainPlaneStrain/test_large.inp
+++ b/testfiles/marmot/GMCDPFiniteStrainPlaneStrain/test_large.inp
@@ -14,6 +14,7 @@ all
 gen_shearBandCenter
 
 *job, name=cpe4job, domain=2d, solver=NISTParallel
+*solver, solver=NISTParallel, name=theSolver
 *fieldOutput
 >>perNode, elSet=all, field=displacement, result=U, name=displacement
 >>perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
@@ -52,7 +53,7 @@ fieldOutput=RF
 ***exportPlots,
 **figure=2, fileName=mesh
 
-*step
+*step, solver=theSolver
 maxInc=5e-2, minInc=1e-5, maxNumInc=10000, maxIter=25, stepLength=100
 >>options, category=NISTSolver, extrapolation=linear
 initializematerial, name=init, elSet=all

--- a/testfiles/marmot/GMCDPFiniteStrainPlaneStrain/test_large.inp
+++ b/testfiles/marmot/GMCDPFiniteStrainPlaneStrain/test_large.inp
@@ -52,7 +52,8 @@ fieldOutput=RF
 ***exportPlots,
 **figure=2, fileName=mesh
 
-*step, maxInc=5e-2, minInc=1e-5, maxNumInc=10000, maxIter=25, stepLength=100
+*step
+maxInc=5e-2, minInc=1e-5, maxNumInc=10000, maxIter=25, stepLength=100
 >>options, category=NISTSolver, extrapolation=linear
 initializematerial, name=init, elSet=all
 >>dirichlet, name=bottom, nSet=gen_bottom,  field=displacement, 2=0,

--- a/testfiles/marmot/GMCDPFiniteStrainPlaneStrain/test_large.inp
+++ b/testfiles/marmot/GMCDPFiniteStrainPlaneStrain/test_large.inp
@@ -15,14 +15,14 @@ gen_shearBandCenter
 
 *job, name=cpe4job, domain=2d, solver=NISTParallel
 *fieldOutput
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
-create=perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
-create=perNode, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
-create=perElement, elSet=all, result=alphaP, quadraturePoint=0:4, name=alphaP, f(x)='max( x[:,:], axis=1) '
-create=perElement, elSet=all, result=alphaD, quadraturePoint=0:4, name=alphaD, f(x)='max( x[:,:], axis=1) '
-create=perElement, elSet=all, result=omega, quadraturePoint=0:4, name=omega, f(x)='max( x[:,:], axis=1) '
-create=perNode, name=RF, nSet=top, field=displacement, result=P, f(x)='sum(x[:,1])', saveHistory=True, export=RF
-create=perNode, name=U, nSet=top, field=displacement, result=U, f(x)='mean(x[:,1])', saveHistory=True, export=U
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
+>>perNode, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
+>>perElement, elSet=all, result=alphaP, quadraturePoint=0:4, name=alphaP, f(x)='max( x[:,:], axis=1) '
+>>perElement, elSet=all, result=alphaD, quadraturePoint=0:4, name=alphaD, f(x)='max( x[:,:], axis=1) '
+>>perElement, elSet=all, result=omega, quadraturePoint=0:4, name=omega, f(x)='max( x[:,:], axis=1) '
+>>perNode, name=RF, nSet=top, field=displacement, result=P, f(x)='sum(x[:,1])', saveHistory=True, export=RF
+>>perNode, name=U, nSet=top, field=displacement, result=U, f(x)='mean(x[:,1])', saveHistory=True, export=U
 
 *modelGenerator, generator=planeRectQuad, name=gen
 x0=0, h=200
@@ -38,13 +38,13 @@ fieldOutput=alphaD, f(x)='max(x)'
 fieldOutput=RF
 
 *output, type=ensight, name=esExport
-configuration,     overwrite=True
-create=perNode,    fieldOutput=displacement
-create=perNode,    fieldOutput=micro rotation
-create=perNode,    fieldOutput=nonlocal damage
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
+>>configuration,     overwrite=True
+>>perNode, fieldOutput=displacement
+>>perNode, fieldOutput=micro rotation
+>>perNode, fieldOutput=nonlocal damage
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
 
 ***output, type=meshplot, name=RFPlot
 **figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
@@ -53,8 +53,8 @@ create=perElement, fieldOutput=omega
 **figure=2, fileName=mesh
 
 *step, maxInc=5e-2, minInc=1e-5, maxNumInc=10000, maxIter=25, stepLength=100
-options, category=NISTSolver, extrapolation=linear
+>>options, category=NISTSolver, extrapolation=linear
 initializematerial, name=init, elSet=all
-dirichlet, name=bottom, nSet=gen_bottom,  field=displacement, 2=0,
-dirichlet, name=bc, nSet=gen_leftBottom,  field=displacement, 2=0, 1=0
-dirichlet, name=top, nSet=gen_top, field=displacement, 2=-20
+>>dirichlet, name=bottom, nSet=gen_bottom,  field=displacement, 2=0,
+>>dirichlet, name=bc, nSet=gen_leftBottom,  field=displacement, 2=0, 1=0
+>>dirichlet, name=top, nSet=gen_top, field=displacement, 2=-20

--- a/testfiles/marmot/GMCDPFiniteStrainPlaneStrain/test_large.inp
+++ b/testfiles/marmot/GMCDPFiniteStrainPlaneStrain/test_large.inp
@@ -15,7 +15,7 @@ gen_shearBandCenter
 
 *job, name=cpe4job, domain=2d, solver=NISTParallel
 *solver, solver=NISTParallel, name=theSolver
-*fieldOutput
+*fieldOutput,
 >>perNode, elSet=all, field=displacement, result=U, name=displacement
 >>perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
 >>perNode, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage

--- a/testfiles/marmot/GMCDPPlaneStrain/test_.inp
+++ b/testfiles/marmot/GMCDPPlaneStrain/test_.inp
@@ -17,6 +17,7 @@ all
 gen_shearBand
 
 *job, name=cpe4job, domain=2d, solver=NISTParallel
+*solver, solver=NISTParallel, name=theSolver
 *fieldOutput
 elSet=all, field=displacement, result=U, name=displacement
 elSet=all, field=micro rotation, result=U, name=micro rotation
@@ -57,7 +58,7 @@ fieldOutput=RF
 *output, type=meshplot, name=RFPlot
 >>figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
 
-*step
+*step, solver=theSolver
 maxInc=1e-2, minInc=1e-7, maxNumInc=10000, maxIter=25, stepLength=100
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=bottom, nSet=gen_bottom,  field=displacement, 2=0,

--- a/testfiles/marmot/GMCDPPlaneStrain/test_.inp
+++ b/testfiles/marmot/GMCDPPlaneStrain/test_.inp
@@ -46,19 +46,19 @@ fieldOutput=RF
 ** direction=1
 
 *output, type=ensight, name=esExport
-create=perNode,    fieldOutput=displacement
-create=perNode,    fieldOutput=micro rotation
-create=perNode,    fieldOutput=nonlocal damage
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perNode, fieldOutput=micro rotation
+>>perNode, fieldOutput=nonlocal damage
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
+>>configuration, overwrite=yes
 
 *output, type=meshplot, name=RFPlot
-figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
+>>figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
 
 *step, maxInc=1e-2, minInc=1e-7, maxNumInc=10000, maxIter=25, stepLength=100
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=bottom, nSet=gen_bottom,  field=displacement, 2=0,
-dirichlet, name=bc, nSet=gen_leftBottom,  field=displacement, 2=0, 1=0
-dirichlet, name=top, nSet=gen_top, field=displacement, 2=-5
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=bottom, nSet=gen_bottom,  field=displacement, 2=0,
+>>dirichlet, name=bc, nSet=gen_leftBottom,  field=displacement, 2=0, 1=0
+>>dirichlet, name=top, nSet=gen_top, field=displacement, 2=-5

--- a/testfiles/marmot/GMCDPPlaneStrain/test_.inp
+++ b/testfiles/marmot/GMCDPPlaneStrain/test_.inp
@@ -11,22 +11,22 @@
 **0.75,        -0.25,   0.75,     -.25,           0.333333332,  0
 
 
-*section, name=section1, thickness=1.0, material=GMCDP, type=plane
+*section, name=section1, material=GMCDP, type=plane
 all
-*section, name=section2, thickness=.98, material=GMCDP, type=plane
+*section, name=section2, material=GMCDP, type=plane
 gen_shearBand
 
 *job, name=cpe4job, domain=2d, solver=NISTParallel
 *solver, solver=NISTParallel, name=theSolver
-*fieldOutput
-elSet=all, field=displacement, result=U, name=displacement
-elSet=all, field=micro rotation, result=U, name=micro rotation
-elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
-elSet=all, result=alphaP, quadraturePoint=0:4, name=alphaP, f(x)='max( x[:,:], axis=1) '
-elSet=all, result=alphaD, quadraturePoint=0:4, name=alphaD, f(x)='max( x[:,:], axis=1) '
-elSet=all, result=omega, quadraturePoint=0:4, name=omega, f(x)='max( x[:,:], axis=1) '
-name=RF, nSet=gen_top, field=displacement, result=P, f(x)='sum(x[:,1])', saveHistory=True
-name=U, nSet=gen_top, field=displacement, result=U, f(x)='mean(x[:,1])', saveHistory=True
+*fieldOutput,
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
+>>perNode, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
+>>perElement, elSet=all, result=alphaP, quadraturePoint=0:4, name=alphaP, f(x)='max( x[:,:], axis=1) '
+>>perElement, elSet=all, result=alphaD, quadraturePoint=0:4, name=alphaD, f(x)='max( x[:,:], axis=1) '
+>>perElement, elSet=all, result=omega, quadraturePoint=0:4, name=omega, f(x)='max( x[:,:], axis=1) '
+>>perNode, name=RF, nSet=gen_top, field=displacement, result=P, f(x)='sum(x[:,1])', saveHistory=True
+>>perNode, name=U, nSet=gen_top, field=displacement, result=U, f(x)='mean(x[:,1])', saveHistory=True
 
 *modelGenerator, generator=planeRectQuad, name=gen
 x0=0, h=200
@@ -56,7 +56,7 @@ fieldOutput=RF
 >>configuration, overwrite=yes
 
 *output, type=meshplot, name=RFPlot
->>figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
+figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
 
 *step, solver=theSolver
 maxInc=1e-2, minInc=1e-7, maxNumInc=10000, maxIter=25, stepLength=100

--- a/testfiles/marmot/GMCDPPlaneStrain/test_.inp
+++ b/testfiles/marmot/GMCDPPlaneStrain/test_.inp
@@ -57,7 +57,8 @@ fieldOutput=RF
 *output, type=meshplot, name=RFPlot
 >>figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
 
-*step, maxInc=1e-2, minInc=1e-7, maxNumInc=10000, maxIter=25, stepLength=100
+*step
+maxInc=1e-2, minInc=1e-7, maxNumInc=10000, maxIter=25, stepLength=100
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=bottom, nSet=gen_bottom,  field=displacement, 2=0,
 >>dirichlet, name=bc, nSet=gen_leftBottom,  field=displacement, 2=0, 1=0

--- a/testfiles/marmot/GMCDPPlaneStrain/test_coarse.inp
+++ b/testfiles/marmot/GMCDPPlaneStrain/test_coarse.inp
@@ -11,14 +11,14 @@
 **0.75,        -0.25,   0.75,     -.25,           0.333333332,  0
 
 
-*section, name=section1, thickness=1.0, material=GMCDP, type=plane
+*section, name=section1, material=GMCDP, type=plane
 all
-*section, name=section2, thickness=.99, material=GMCDP, type=plane
+*section, name=section2, material=GMCDP, type=plane
 gen_shearBandCenter
 
 *job, name=cpe4job, domain=2d, solver=NISTParallel
 *solver, solver=NISTParallel, name=theSolver
-*fieldOutput
+*fieldOutput,
 >>perNode, elSet=all, field=displacement, result=U, name=displacement
 >>perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
 >>perNode, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
@@ -55,8 +55,8 @@ fieldOutput=RF
 >>perElement, fieldOutput=omega
 
 *output, type=meshplot, name=RFPlot
->>figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
->>figure=2, axpSec=111, create=meshOnly, configuration=deformed
+figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
+figure=2, axpSec=111, create=meshOnly, configuration=deformed
 *exportPlots,
 figure=2, fileName=mesh
 

--- a/testfiles/marmot/GMCDPPlaneStrain/test_coarse.inp
+++ b/testfiles/marmot/GMCDPPlaneStrain/test_coarse.inp
@@ -59,7 +59,8 @@ fieldOutput=RF
 *exportPlots,
 figure=2, fileName=mesh
 
-*step, maxInc=1e-2, minInc=1e-7, maxNumInc=10000, maxIter=25, stepLength=100
+*step
+maxInc=1e-2, minInc=1e-7, maxNumInc=10000, maxIter=25, stepLength=100
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=bottom, nSet=gen_bottom,  field=displacement, 2=0,
 >>dirichlet, name=bc, nSet=gen_leftBottom,  field=displacement, 2=0, 1=0

--- a/testfiles/marmot/GMCDPPlaneStrain/test_coarse.inp
+++ b/testfiles/marmot/GMCDPPlaneStrain/test_coarse.inp
@@ -17,6 +17,7 @@ all
 gen_shearBandCenter
 
 *job, name=cpe4job, domain=2d, solver=NISTParallel
+*solver, solver=NISTParallel, name=theSolver
 *fieldOutput
 >>perNode, elSet=all, field=displacement, result=U, name=displacement
 >>perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
@@ -59,7 +60,7 @@ fieldOutput=RF
 *exportPlots,
 figure=2, fileName=mesh
 
-*step
+*step, solver=theSolver
 maxInc=1e-2, minInc=1e-7, maxNumInc=10000, maxIter=25, stepLength=100
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=bottom, nSet=gen_bottom,  field=displacement, 2=0,

--- a/testfiles/marmot/GMCDPPlaneStrain/test_coarse.inp
+++ b/testfiles/marmot/GMCDPPlaneStrain/test_coarse.inp
@@ -18,14 +18,14 @@ gen_shearBandCenter
 
 *job, name=cpe4job, domain=2d, solver=NISTParallel
 *fieldOutput
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
-create=perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
-create=perNode, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
-create=perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaP, f(x)='max( x[:,:,0], axis=1) '
-create=perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaD, f(x)='max( x[:,:,1], axis=1) '
-create=perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=omega, f(x)='max( x[:,:,2], axis=1) '
-create=perNode, name=RF, nSet=gen_top, field=displacement, result=P, f(x)='sum(x[:,1])', saveHistory=True, export=RF
-create=perNode, name=U, nSet=gen_top, field=displacement, result=U, f(x)='mean(x[:,1])', saveHistory=True, export=U
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
+>>perNode, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
+>>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaP, f(x)='max( x[:,:,0], axis=1) '
+>>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaD, f(x)='max( x[:,:,1], axis=1) '
+>>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=omega, f(x)='max( x[:,:,2], axis=1) '
+>>perNode, name=RF, nSet=gen_top, field=displacement, result=P, f(x)='sum(x[:,1])', saveHistory=True, export=RF
+>>perNode, name=U, nSet=gen_top, field=displacement, result=U, f(x)='mean(x[:,1])', saveHistory=True, export=U
 
 *modelGenerator, generator=planeRectQuad, name=gen
 x0=0, h=200
@@ -46,21 +46,21 @@ fieldOutput=RF
 ** direction=1
 
 *output, type=ensight, name=esExport
-create=perNode,    fieldOutput=displacement
-create=perNode,    fieldOutput=micro rotation
-create=perNode,    fieldOutput=nonlocal damage
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
+>>perNode, fieldOutput=displacement
+>>perNode, fieldOutput=micro rotation
+>>perNode, fieldOutput=nonlocal damage
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
 
 *output, type=meshplot, name=RFPlot
-figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
-figure=2, axpSec=111, create=meshOnly, configuration=deformed
+>>figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
+>>figure=2, axpSec=111, create=meshOnly, configuration=deformed
 *exportPlots,
 figure=2, fileName=mesh
 
 *step, maxInc=1e-2, minInc=1e-7, maxNumInc=10000, maxIter=25, stepLength=100
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=bottom, nSet=gen_bottom,  field=displacement, 2=0,
-dirichlet, name=bc, nSet=gen_leftBottom,  field=displacement, 2=0, 1=0
-dirichlet, name=top, nSet=gen_top, field=displacement, 2=-5
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=bottom, nSet=gen_bottom,  field=displacement, 2=0,
+>>dirichlet, name=bc, nSet=gen_leftBottom,  field=displacement, 2=0, 1=0
+>>dirichlet, name=top, nSet=gen_top, field=displacement, 2=-5

--- a/testfiles/marmot/GMCDPPlaneStrain3D/test_.inp
+++ b/testfiles/marmot/GMCDPPlaneStrain3D/test_.inp
@@ -66,7 +66,8 @@ fieldOutput=RF
 *output, type=meshplot, name=RFPlot
 >>figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
 
-*step, maxInc=1e-2, minInc=5e-4, maxNumInc=10000, maxIter=25, stepLength=100
+*step
+maxInc=1e-2, minInc=5e-4, maxNumInc=10000, maxIter=25, stepLength=100
 >>options, category=NISTSolver, extrapolation=linear
 >>options, category=Ensight, intermediateSaveInterval=1
 >>dirichlet, name=bottom, nSet=bottom,  field=displacement, 2=0,

--- a/testfiles/marmot/GMCDPPlaneStrain3D/test_.inp
+++ b/testfiles/marmot/GMCDPPlaneStrain3D/test_.inp
@@ -39,10 +39,10 @@ bottom
 ** *job, name=cpe4job, domain=3d, solver=NISTParallel, linsolver=amgcl
 *job, name=cpe4job, domain=3d, solver=NISTParallel,
 *solver, solver=NISTParallel, name=theSolver
-*fieldOutput
+*fieldOutput,
 >>perNode, elSet=all, field=displacement, result=U, name=displacement
 **elSet=all, field=micro rotation, result=U, name=micro rotation
->>perElement, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
+>>perNode, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
 >>perElement, elSet=all, result=alphaP, quadraturePoint=0:4, name=alphaP, f(x)='max( x[:,:], axis=1) '
 >>perElement, elSet=all, result=alphaD, quadraturePoint=0:4, name=alphaD, f(x)='max( x[:,:], axis=1) '
 >>perElement, elSet=all, result=omega, quadraturePoint=0:4, name=omega, f(x)='max( x[:,:], axis=1) '
@@ -65,7 +65,7 @@ fieldOutput=RF
 >>perElement, fieldOutput=omega
 
 *output, type=meshplot, name=RFPlot
->>figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
+figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
 
 *step, solver=theSolver
 maxInc=1e-2, minInc=5e-4, maxNumInc=10000, maxIter=25, stepLength=100

--- a/testfiles/marmot/GMCDPPlaneStrain3D/test_.inp
+++ b/testfiles/marmot/GMCDPPlaneStrain3D/test_.inp
@@ -38,6 +38,7 @@ bottom
 
 ** *job, name=cpe4job, domain=3d, solver=NISTParallel, linsolver=amgcl
 *job, name=cpe4job, domain=3d, solver=NISTParallel,
+*solver, solver=NISTParallel, name=theSolver
 *fieldOutput
 >>perNode, elSet=all, field=displacement, result=U, name=displacement
 **elSet=all, field=micro rotation, result=U, name=micro rotation
@@ -66,7 +67,7 @@ fieldOutput=RF
 *output, type=meshplot, name=RFPlot
 >>figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
 
-*step
+*step, solver=theSolver
 maxInc=1e-2, minInc=5e-4, maxNumInc=10000, maxIter=25, stepLength=100
 >>options, category=NISTSolver, extrapolation=linear
 >>options, category=Ensight, intermediateSaveInterval=1

--- a/testfiles/marmot/GMCDPPlaneStrain3D/test_.inp
+++ b/testfiles/marmot/GMCDPPlaneStrain3D/test_.inp
@@ -39,14 +39,14 @@ bottom
 ** *job, name=cpe4job, domain=3d, solver=NISTParallel, linsolver=amgcl
 *job, name=cpe4job, domain=3d, solver=NISTParallel,
 *fieldOutput
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
 **elSet=all, field=micro rotation, result=U, name=micro rotation
-create=perElement, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
-create=perElement, elSet=all, result=alphaP, quadraturePoint=0:4, name=alphaP, f(x)='max( x[:,:], axis=1) '
-create=perElement, elSet=all, result=alphaD, quadraturePoint=0:4, name=alphaD, f(x)='max( x[:,:], axis=1) '
-create=perElement, elSet=all, result=omega, quadraturePoint=0:4, name=omega, f(x)='max( x[:,:], axis=1) '
-create=perNode, name=RF, nSet=top, field=displacement, result=P, f(x)='sum(x[:,1])/2.5', saveHistory=True
-create=perNode, name=U, nSet=top, field=displacement, result=U, f(x)='mean(x[:,1])', saveHistory=True
+>>perElement, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
+>>perElement, elSet=all, result=alphaP, quadraturePoint=0:4, name=alphaP, f(x)='max( x[:,:], axis=1) '
+>>perElement, elSet=all, result=alphaD, quadraturePoint=0:4, name=alphaD, f(x)='max( x[:,:], axis=1) '
+>>perElement, elSet=all, result=omega, quadraturePoint=0:4, name=omega, f(x)='max( x[:,:], axis=1) '
+>>perNode, name=RF, nSet=top, field=displacement, result=P, f(x)='sum(x[:,1])/2.5', saveHistory=True
+>>perNode, name=U, nSet=top, field=displacement, result=U, f(x)='mean(x[:,1])', saveHistory=True
 
 *output, type=monitor, name=omegaMon
 fieldOutput=omega, f(x)='max(x)'
@@ -55,24 +55,24 @@ fieldOutput=alphaD, f(x)='max(x)'
 fieldOutput=RF
 
 *output, type=ensight, name=esExport
-create=perNode,    fieldOutput=displacement
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>configuration, overwrite=yes
 **create=perNode,    fieldOutput=micro rotation
-create=perNode,    fieldOutput=nonlocal damage
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
+>>perNode, fieldOutput=nonlocal damage
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
 
 *output, type=meshplot, name=RFPlot
-figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
+>>figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
 
 *step, maxInc=1e-2, minInc=5e-4, maxNumInc=10000, maxIter=25, stepLength=100
-options, category=NISTSolver, extrapolation=linear
-options, category=Ensight, intermediateSaveInterval=1
-dirichlet, name=bottom, nSet=bottom,  field=displacement, 2=0,
+>>options, category=NISTSolver, extrapolation=linear
+>>options, category=Ensight, intermediateSaveInterval=1
+>>dirichlet, name=bottom, nSet=bottom,  field=displacement, 2=0,
 **dirichlet, name=bottomR, nSet=bottom,  field=micro rotation, 1=0,2=0,3=0
 **dirichlet, name=topR, nSet=top,  field=micro rotation, 1=0,2=0,3=0
-dirichlet, name=origin, nSet=origin,  field=displacement, 2=0, 1=0, 3=0
-dirichlet, name=top, nSet=top, field=displacement, 2=-5
-dirichlet, name=frontAndBackD, nSet=frontAndBack, field=displacement, 3=0
-dirichlet, name=frontAndBackR, nSet=frontAndBack, field=micro rotation, 1=0, 2=0
+>>dirichlet, name=origin, nSet=origin,  field=displacement, 2=0, 1=0, 3=0
+>>dirichlet, name=top, nSet=top, field=displacement, 2=-5
+>>dirichlet, name=frontAndBackD, nSet=frontAndBack, field=displacement, 3=0
+>>dirichlet, name=frontAndBackR, nSet=frontAndBack, field=micro rotation, 1=0, 2=0

--- a/testfiles/marmot/GMCDPTriaxialTest/test_.inp
+++ b/testfiles/marmot/GMCDPTriaxialTest/test_.inp
@@ -41,26 +41,26 @@ bottom
 ***job, name=cpe4job, domain=3d, solver=NISTPArcLength
 
 *fieldOutput,
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
-create=perNode, nSet=top, field=displacement, result=P, name=displacement, name=RF, f(x)=' sum(x[:,2]) ', saveHistory=True, export=RF
-create=perNode, nSet=top, field=displacement, result=U, name=UTop,  f(x)=' (x[0,2]) ', saveHistory=True, export=UTop
-create=perNode, elSet=all, field=nonlocal damage , result=U, name=nonlocal damage
-create=perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
-create=perElement, elSet=all, result=alphaP, quadraturePoint=0:4, name=alphaP, f(x)='mean( x[:,:], axis=1) '
-create=perElement, elSet=all, result=alphaD, quadraturePoint=0:4, name=alphaD, f(x)='mean( x[:,:], axis=1) '
-create=perElement, elSet=all, result=omega, quadraturePoint=0:4, name=omega, f(x)='mean( x[:,:], axis=1) '
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, nSet=top, field=displacement, result=P, name=displacement, name=RF, f(x)=' sum(x[:,2]) ', saveHistory=True, export=RF
+>>perNode, nSet=top, field=displacement, result=U, name=UTop,  f(x)=' (x[0,2]) ', saveHistory=True, export=UTop
+>>perNode, elSet=all, field=nonlocal damage , result=U, name=nonlocal damage
+>>perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
+>>perElement, elSet=all, result=alphaP, quadraturePoint=0:4, name=alphaP, f(x)='mean( x[:,:], axis=1) '
+>>perElement, elSet=all, result=alphaD, quadraturePoint=0:4, name=alphaD, f(x)='mean( x[:,:], axis=1) '
+>>perElement, elSet=all, result=omega, quadraturePoint=0:4, name=omega, f(x)='mean( x[:,:], axis=1) '
 
 *output, type=meshplot, name=RFPlot
-create=xyData, x=time, y=RF, legend=RF
+>>xyData, x=time, y=RF, legend=RF
 *output, type=ensight, name=ensightExport
-create=perNode,    fieldOutput=displacement
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>configuration, overwrite=yes
 
 **create=perNode,    fieldOutput=micro rotation
-create=perNode,    fieldOutput=nonlocal damage
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
+>>perNode, fieldOutput=nonlocal damage
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
 *output, type=monitor, name=omegaMon
 fieldOutput=omega, f(x)='max(x)'
 fieldOutput=nonlocal damage, f(x)='max(x)'
@@ -69,20 +69,20 @@ fieldOutput=alphaD, f(x)='max(x)'
 fieldOutput=RF
 
 *step, solver=theSolver, maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=bottom,  nSet=bottom,   field=displacement, 3=0.0
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=bottom,  nSet=bottom,   field=displacement, 3=0.0
 ** dirichlet, name=topD,  nSet=top,   field=nonlocal damage, 1=0.0
-dirichlet, name=origin,  nSet=origin,   field=displacement, 1=0.0,
-dirichlet, name=symD,  nSet=sym,   field=displacement, 2=0.0
-dirichlet, name=symR,  nSet=sym,   field=micro rotation, 1=0.0, 3=0
-distributedload, name=dload, surface=sleeveTop, type=pressure, magnitude=10, f(t)=t
-options, category=NISTArcLength, arcLengthController=off
+>>dirichlet, name=origin,  nSet=origin,   field=displacement, 1=0.0,
+>>dirichlet, name=symD,  nSet=sym,   field=displacement, 2=0.0
+>>dirichlet, name=symR,  nSet=sym,   field=micro rotation, 1=0.0, 3=0
+>>distributedload, name=dload, surface=sleeveTop, type=pressure, magnitude=10, f(t)=t
+>>options, category=NISTArcLength, arcLengthController=off
 
 **---- STEP WITHOUT SNAPBACK
 *step, solver=theSolver, maxInc=4e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=linear,
-options, category=Ensight, intermediateSaveInterval=1
-dirichlet, name=top,  nSet=top,   field=displacement, 3=-10
+>>options, category=NISTSolver, extrapolation=linear,
+>>options, category=Ensight, intermediateSaveInterval=1
+>>dirichlet, name=top,  nSet=top,   field=displacement, 3=-10
 
 **---- STEP WITH SNAPBACK
 ***step, solver=theSolver, maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=10, stepLength=1

--- a/testfiles/marmot/GMCDPTriaxialTest/test_.inp
+++ b/testfiles/marmot/GMCDPTriaxialTest/test_.inp
@@ -42,7 +42,7 @@ bottom
 
 *fieldOutput,
 >>perNode, elSet=all, field=displacement, result=U, name=displacement
->>perNode, nSet=top, field=displacement, result=P, name=displacement, name=RF, f(x)=' sum(x[:,2]) ', saveHistory=True, export=RF
+>>perNode, nSet=top, field=displacement, result=P, name=displacement, f(x)=' sum(x[:,2]) ', saveHistory=True, export=RF
 >>perNode, nSet=top, field=displacement, result=U, name=UTop,  f(x)=' (x[0,2]) ', saveHistory=True, export=UTop
 >>perNode, elSet=all, field=nonlocal damage , result=U, name=nonlocal damage
 >>perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
@@ -51,7 +51,7 @@ bottom
 >>perElement, elSet=all, result=omega, quadraturePoint=0:4, name=omega, f(x)='mean( x[:,:], axis=1) '
 
 *output, type=meshplot, name=RFPlot
->>xyData, x=time, y=RF, legend=RF
+figure=1, axSpec=111, create=xyData, x=time, y=RF, legend=RF
 *output, type=ensight, name=ensightExport
 >>perNode, fieldOutput=displacement
 >>configuration, overwrite=yes

--- a/testfiles/marmot/GMCDPTriaxialTest/test_.inp
+++ b/testfiles/marmot/GMCDPTriaxialTest/test_.inp
@@ -68,7 +68,8 @@ fieldOutput=alphaP, f(x)='max(x)'
 fieldOutput=alphaD, f(x)='max(x)'
 fieldOutput=RF
 
-*step, solver=theSolver, maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
+*step, solver=theSolver
+maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=bottom,  nSet=bottom,   field=displacement, 3=0.0
 ** dirichlet, name=topD,  nSet=top,   field=nonlocal damage, 1=0.0
@@ -79,7 +80,8 @@ fieldOutput=RF
 >>options, category=NISTArcLength, arcLengthController=off
 
 **---- STEP WITHOUT SNAPBACK
-*step, solver=theSolver, maxInc=4e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
+*step, solver=theSolver
+maxInc=4e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
 >>options, category=NISTSolver, extrapolation=linear,
 >>options, category=Ensight, intermediateSaveInterval=1
 >>dirichlet, name=top,  nSet=top,   field=displacement, 3=-10

--- a/testfiles/marmot/KLU/klu_test.inp
+++ b/testfiles/marmot/KLU/klu_test.inp
@@ -17,8 +17,8 @@ elType=CPE4
 
 
 *step, maxInc=1e0, minInc=1e-2, maxNumInc=100, maxIter=25, stepLength=1, solver=theSolver
-dirichlet, name=left, nSet=gen_left, field=displacement, 1=0, 2=0
-dirichlet, name=bottom, nSet=gen_leftBottom, field=displacement, 2=0
+>>dirichlet, name=left, nSet=gen_left, field=displacement, 1=0, 2=0
+>>dirichlet, name=bottom, nSet=gen_leftBottom, field=displacement, 2=0
 
 *step, maxInc=5e-3, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=1, solver=theSolver
-dirichlet, name=right, nSet=gen_right, field=displacement, 2=0.2
+>>dirichlet, name=right, nSet=gen_right, field=displacement, 2=0.2

--- a/testfiles/marmot/KLU/klu_test.inp
+++ b/testfiles/marmot/KLU/klu_test.inp
@@ -16,9 +16,11 @@ nY=2
 elType=CPE4
 
 
-*step, maxInc=1e0, minInc=1e-2, maxNumInc=100, maxIter=25, stepLength=1, solver=theSolver
+*step, solver=theSolver
+maxInc=1e0, minInc=1e-2, maxNumInc=100, maxIter=25, stepLength=1
 >>dirichlet, name=left, nSet=gen_left, field=displacement, 1=0, 2=0
 >>dirichlet, name=bottom, nSet=gen_leftBottom, field=displacement, 2=0
 
-*step, maxInc=5e-3, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=1, solver=theSolver
+*step, solver=theSolver
+maxInc=5e-3, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=1
 >>dirichlet, name=right, nSet=gen_right, field=displacement, 2=0.2

--- a/testfiles/marmot/MUMPS/mumps_test.inp
+++ b/testfiles/marmot/MUMPS/mumps_test.inp
@@ -17,8 +17,8 @@ elType=CPE4
 
 
 *step, maxInc=1e0, minInc=1e-2, maxNumInc=100, maxIter=25, stepLength=1, solver=theSolver
-dirichlet, name=left, nSet=gen_left, field=displacement, 1=0, 2=0
-dirichlet, name=bottom, nSet=gen_leftBottom, field=displacement, 2=0
+>>dirichlet, name=left, nSet=gen_left, field=displacement, 1=0, 2=0
+>>dirichlet, name=bottom, nSet=gen_leftBottom, field=displacement, 2=0
 
 *step, maxInc=5e-3, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=1, solver=theSolver
-dirichlet, name=right, nSet=gen_right, field=displacement, 2=0.2
+>>dirichlet, name=right, nSet=gen_right, field=displacement, 2=0.2

--- a/testfiles/marmot/MUMPS/mumps_test.inp
+++ b/testfiles/marmot/MUMPS/mumps_test.inp
@@ -16,9 +16,11 @@ nY=2
 elType=CPE4
 
 
-*step, maxInc=1e0, minInc=1e-2, maxNumInc=100, maxIter=25, stepLength=1, solver=theSolver
+*step, solver=theSolver
+maxInc=1e0, minInc=1e-2, maxNumInc=100, maxIter=25, stepLength=1
 >>dirichlet, name=left, nSet=gen_left, field=displacement, 1=0, 2=0
 >>dirichlet, name=bottom, nSet=gen_leftBottom, field=displacement, 2=0
 
-*step, maxInc=5e-3, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=1, solver=theSolver
+*step, solver=theSolver
+maxInc=5e-3, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=1
 >>dirichlet, name=right, nSet=gen_right, field=displacement, 2=0.2

--- a/testfiles/marmot/PETSCLU/petsclu.inp
+++ b/testfiles/marmot/PETSCLU/petsclu.inp
@@ -17,8 +17,8 @@ elType=CPE4
 
 
 *step, maxInc=1e0, minInc=1e-2, maxNumInc=100, maxIter=25, stepLength=1, solver=theSolver
-dirichlet, name=left, nSet=gen_left, field=displacement, 1=0, 2=0
-dirichlet, name=bottom, nSet=gen_leftBottom, field=displacement, 2=0
+>>dirichlet, name=left, nSet=gen_left, field=displacement, 1=0, 2=0
+>>dirichlet, name=bottom, nSet=gen_leftBottom, field=displacement, 2=0
 
 *step, maxInc=5e-3, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=1, solver=theSolver
-dirichlet, name=right, nSet=gen_right, field=displacement, 2=0.2
+>>dirichlet, name=right, nSet=gen_right, field=displacement, 2=0.2

--- a/testfiles/marmot/PETSCLU/petsclu.inp
+++ b/testfiles/marmot/PETSCLU/petsclu.inp
@@ -16,9 +16,11 @@ nY=2
 elType=CPE4
 
 
-*step, maxInc=1e0, minInc=1e-2, maxNumInc=100, maxIter=25, stepLength=1, solver=theSolver
+*step, solver=theSolver
+maxInc=1e0, minInc=1e-2, maxNumInc=100, maxIter=25, stepLength=1
 >>dirichlet, name=left, nSet=gen_left, field=displacement, 1=0, 2=0
 >>dirichlet, name=bottom, nSet=gen_leftBottom, field=displacement, 2=0
 
-*step, maxInc=5e-3, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=1, solver=theSolver
+*step, solver=theSolver
+maxInc=5e-3, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=1
 >>dirichlet, name=right, nSet=gen_right, field=displacement, 2=0.2

--- a/testfiles/marmot/PlaneWithHole/testLong.inp
+++ b/testfiles/marmot/PlaneWithHole/testLong.inp
@@ -886,7 +886,8 @@ all
 **create=perElement, fieldOutput=stress7
 **create=perElement, fieldOutput=stress8
 
-*step, solver=theSolver, maxInc=0.1, minInc=1e-6, maxNumInc=1000, maxIter=100
+*step, solver=theSolver
+maxInc=0.1, minInc=1e-6, maxNumInc=1000, maxIter=100
 >>options, category=NISTSolver, extrapolation=off
 >>dirichlet, name=side, nSet=Set-2,  field=displacement, 1=0
 >>dirichlet, name=bottom, nSet=Set-1, field=displacement, 2=0

--- a/testfiles/marmot/PlaneWithHole/testLong.inp
+++ b/testfiles/marmot/PlaneWithHole/testLong.inp
@@ -858,13 +858,13 @@ all
    3, 4
 
 *fieldOutput
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
-create=perElement, elSet=all, result=strain, name=strain, quadraturePoint=0:4, f(x)='np.mean(x,axis=1)'
-create=perElement, elSet=all, result=stress, name=stress, quadraturePoint=0:4, f(x)='np.mean(x,axis=1)'
-create=perElement, elSet=all, result=stress, name=stress0, quadraturePoint=0
-create=perElement, elSet=all, result=stress, name=stress1, quadraturePoint=1
-create=perElement, elSet=all, result=stress, name=stress2, quadraturePoint=2
-create=perElement, elSet=all, result=stress, name=stress3, quadraturePoint=3
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perElement, elSet=all, result=strain, name=strain, quadraturePoint=0:4, f(x)='np.mean(x,axis=1)'
+>>perElement, elSet=all, result=stress, name=stress, quadraturePoint=0:4, f(x)='np.mean(x,axis=1)'
+>>perElement, elSet=all, result=stress, name=stress0, quadraturePoint=0
+>>perElement, elSet=all, result=stress, name=stress1, quadraturePoint=1
+>>perElement, elSet=all, result=stress, name=stress2, quadraturePoint=2
+>>perElement, elSet=all, result=stress, name=stress3, quadraturePoint=3
 **create=perElement, elSet=all, result=stress, name=stress4, quadraturePoint=4
 **create=perElement, elSet=all, result=stress, name=stress5, quadraturePoint=5
 **create=perElement, elSet=all, result=stress, name=stress6, quadraturePoint=6
@@ -872,14 +872,14 @@ create=perElement, elSet=all, result=stress, name=stress3, quadraturePoint=3
 **create=perElement, elSet=all, result=stress, name=stress8, quadraturePoint=8
 
 *output, type=ensight, name=esExport
-create=perNode, fieldOutput=displacement
-configuration, overwrite=yes
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-create=perElement, fieldOutput=stress0
-create=perElement, fieldOutput=stress1
-create=perElement, fieldOutput=stress2
-create=perElement, fieldOutput=stress3
+>>perNode, fieldOutput=displacement
+>>configuration, overwrite=yes
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>perElement, fieldOutput=stress0
+>>perElement, fieldOutput=stress1
+>>perElement, fieldOutput=stress2
+>>perElement, fieldOutput=stress3
 **create=perElement, fieldOutput=stress4
 **create=perElement, fieldOutput=stress5
 **create=perElement, fieldOutput=stress6
@@ -887,8 +887,8 @@ create=perElement, fieldOutput=stress3
 **create=perElement, fieldOutput=stress8
 
 *step, solver=theSolver, maxInc=0.1, minInc=1e-6, maxNumInc=1000, maxIter=100
-options, category=NISTSolver, extrapolation=off
-dirichlet, name=side, nSet=Set-2,  field=displacement, 1=0
-dirichlet, name=bottom, nSet=Set-1, field=displacement, 2=0
-nodeforces, name=load, nSet=load, components='28.125,0.', field=displacement
-nodeforces, name=loadhalf, nSet=loadhalf, components='14.0625,0.', field=displacement
+>>options, category=NISTSolver, extrapolation=off
+>>dirichlet, name=side, nSet=Set-2,  field=displacement, 1=0
+>>dirichlet, name=bottom, nSet=Set-1, field=displacement, 2=0
+>>nodeforces, name=load, nSet=load, components='28.125,0.', field=displacement
+>>nodeforces, name=loadhalf, nSet=loadhalf, components='14.0625,0.', field=displacement

--- a/testfiles/marmot/QPMarmotMaterialGradientEnhancedHypoElastic/_test.inp
+++ b/testfiles/marmot/QPMarmotMaterialGradientEnhancedHypoElastic/_test.inp
@@ -22,12 +22,14 @@ all
 *job, name=mySingleElementJob, domain=3d
 *solver, solver=NIST, name=theSolver
 
-*step, solver=theSolver, maxInc=1e0, minInc=1e0, maxNumInc=100, maxIter=25, stepLength=1
+*step, solver=theSolver
+maxInc=1e0, minInc=1e0, maxNumInc=100, maxIter=25, stepLength=1
 >>setinitialconditions, property=characteristic element length, values='100,'
 >>dirichlet,  name=prescribed_strain, nSet=all, field=strain symmetric, components='[ 0, x, x, 0, 0, 0 ]',
 >>nodeforces, name=prescribed_stress, nSet=all, field=strain symmetric, components='[ x, 0, 0, x, x, x ]'
 
-*step, solver=theSolver, startInc=1e-2, maxInc=1e-1, minInc=1e-5, maxNumInc=100, maxIter=25, stepLength=1
+*step, solver=theSolver
+startInc=1e-2, maxInc=1e-1, minInc=1e-5, maxNumInc=100, maxIter=25, stepLength=1
 >>dirichlet, name=prescribed_strain,                                    components='[ -0.1,  x,    x, 0,   0, 0 ]'
 >>nodeforces, name=prescribed_stress,                                   components='[ x,    -0.0,   -0.0, x,   x, x ]'
 

--- a/testfiles/marmot/RotationalSpringTotalLagrange/test_.inp
+++ b/testfiles/marmot/RotationalSpringTotalLagrange/test_.inp
@@ -9,22 +9,22 @@ all
 *job, name=c3d8tljob, domain=3d
 *solver, solver=NISTParallel, name=theSolver
 *fieldOutput,
-create=perElement, name=displacement, elSet=all, field=displacement, result=U, name=displacement
-create=perNode, name=stress, elSet=all, result=stress, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
-create=perNode, name=strain, elSet=all, result=strain, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
+>>perElement, name=displacement, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, name=stress, elSet=all, result=stress, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
+>>perNode, name=strain, elSet=all, result=strain, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
 
 *constraint, type=rigidbody, name=rb1
 referencePoint=RP
 nset=p_Set-2
 
 *output, type=ensight, name=ensightExport
-create=perNode, fieldOutput=displacement
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>configuration, overwrite=yes
 
 *step, solver=theSolver, maxInc=1e-2, minInc=1e-4, maxNumInc=1000, maxIter=10
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=enc, nSet=Set-1, field=displacement, 1=0, 2=0, 3=0
-dirichlet, name=enc2, nSet=Set-5, field=displacement, 1=0, 2=0, 3=0
-dirichlet, name=rpMov, nSet=RP, field=rotation, 1=-3.141, 2=0, 3=0
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=enc, nSet=Set-1, field=displacement, 1=0, 2=0, 3=0
+>>dirichlet, name=enc2, nSet=Set-5, field=displacement, 1=0, 2=0, 3=0
+>>dirichlet, name=rpMov, nSet=RP, field=rotation, 1=-3.141, 2=0, 3=0

--- a/testfiles/marmot/RotationalSpringTotalLagrange/test_.inp
+++ b/testfiles/marmot/RotationalSpringTotalLagrange/test_.inp
@@ -3,15 +3,15 @@
 *material, name=stvenantkirchhoffisotropic, id=le
 30000.0, 0.15
 
-*section, name=section1, thickness=1.0, material=le, type=plane
+*section, name=section1, material=le, type=plane
 all
 
 *job, name=c3d8tljob, domain=3d
 *solver, solver=NISTParallel, name=theSolver
 *fieldOutput,
->>perElement, name=displacement, elSet=all, field=displacement, result=U, name=displacement
->>perNode, name=stress, elSet=all, result=stress, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
->>perNode, name=strain, elSet=all, result=strain, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
+>>perNode, name=displacement, elSet=all, field=displacement, result=U
+>>perElement, name=stress, elSet=all, result=stress, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
+>>perElement, name=strain, elSet=all, result=strain, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
 
 *constraint, type=rigidbody, name=rb1
 referencePoint=RP

--- a/testfiles/marmot/RotationalSpringTotalLagrange/test_.inp
+++ b/testfiles/marmot/RotationalSpringTotalLagrange/test_.inp
@@ -23,7 +23,8 @@ nset=p_Set-2
 >>perElement, fieldOutput=strain
 >>configuration, overwrite=yes
 
-*step, solver=theSolver, maxInc=1e-2, minInc=1e-4, maxNumInc=1000, maxIter=10
+*step, solver=theSolver
+maxInc=1e-2, minInc=1e-4, maxNumInc=1000, maxIter=10
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=enc, nSet=Set-1, field=displacement, 1=0, 2=0, 3=0
 >>dirichlet, name=enc2, nSet=Set-5, field=displacement, 1=0, 2=0, 3=0

--- a/testfiles/marmot/RotationalSpringUpdatedLagrange/test_.inp
+++ b/testfiles/marmot/RotationalSpringUpdatedLagrange/test_.inp
@@ -9,9 +9,9 @@ all
 *job, name=c3d8tljob, domain=3d
 *solver, solver=NISTParallel, name=theSolver
 *fieldOutput,
-name=displacement, elSet=all, field=displacement, result=U, name=displacement
-name=stress, elSet=all, result=stress, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
-name=strain, elSet=all, result=strain, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
+>>perNode, name=displacement, elSet=all, field=displacement, result=U
+>>perElement, name=stress, elSet=all, result=stress, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
+>>perElement, name=strain, elSet=all, result=strain, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
 
 *constraint, type=rigidbody, name=rb1
 referencePoint=RP

--- a/testfiles/marmot/RotationalSpringUpdatedLagrange/test_.inp
+++ b/testfiles/marmot/RotationalSpringUpdatedLagrange/test_.inp
@@ -18,13 +18,13 @@ referencePoint=RP
 nset=p_Set-2
 
 *output, type=ensight, name=ensightExport
-create=perNode, fieldOutput=displacement
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>configuration, overwrite=yes
 
 *step, solver=theSolver, maxInc=1e-2, minInc=1e-4, maxNumInc=1000, maxIter=10
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=enc, nSet=Set-1, field=displacement, 1=0, 2=0, 3=0
-dirichlet, name=enc2, nSet=Set-5, field=displacement, 1=0, 2=0, 3=0
-dirichlet, name=rpMov, nSet=RP, field=rotation, 1=-3.141, 2=0, 3=0
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=enc, nSet=Set-1, field=displacement, 1=0, 2=0, 3=0
+>>dirichlet, name=enc2, nSet=Set-5, field=displacement, 1=0, 2=0, 3=0
+>>dirichlet, name=rpMov, nSet=RP, field=rotation, 1=-3.141, 2=0, 3=0

--- a/testfiles/marmot/RotationalSpringUpdatedLagrange/test_.inp
+++ b/testfiles/marmot/RotationalSpringUpdatedLagrange/test_.inp
@@ -23,7 +23,8 @@ nset=p_Set-2
 >>perElement, fieldOutput=strain
 >>configuration, overwrite=yes
 
-*step, solver=theSolver, maxInc=1e-2, minInc=1e-4, maxNumInc=1000, maxIter=10
+*step, solver=theSolver
+maxInc=1e-2, minInc=1e-4, maxNumInc=1000, maxIter=10
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=enc, nSet=Set-1, field=displacement, 1=0, 2=0, 3=0
 >>dirichlet, name=enc2, nSet=Set-5, field=displacement, 1=0, 2=0, 3=0

--- a/testfiles/marmot/RotationalSpringUpdatedLagrangeJaumann/test_.inp
+++ b/testfiles/marmot/RotationalSpringUpdatedLagrangeJaumann/test_.inp
@@ -18,13 +18,13 @@ referencePoint=RP
 nset=p_Set-2
 
 *output, type=ensight, name=ensightExport
-create=perNode, fieldOutput=displacement
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>configuration, overwrite=yes
 
 *step, solver=theSolver, maxInc=1e-2, minInc=1e-4, maxNumInc=1000, maxIter=10
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=enc, nSet=Set-1, field=displacement, 1=0, 2=0, 3=0
-dirichlet, name=enc2, nSet=Set-5, field=displacement, 1=0, 2=0, 3=0
-dirichlet, name=rpMov, nSet=RP, field=rotation, 1=-3.141, 2=0, 3=0
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=enc, nSet=Set-1, field=displacement, 1=0, 2=0, 3=0
+>>dirichlet, name=enc2, nSet=Set-5, field=displacement, 1=0, 2=0, 3=0
+>>dirichlet, name=rpMov, nSet=RP, field=rotation, 1=-3.141, 2=0, 3=0

--- a/testfiles/marmot/RotationalSpringUpdatedLagrangeJaumann/test_.inp
+++ b/testfiles/marmot/RotationalSpringUpdatedLagrangeJaumann/test_.inp
@@ -23,7 +23,8 @@ nset=p_Set-2
 >>perElement, fieldOutput=strain
 >>configuration, overwrite=yes
 
-*step, solver=theSolver, maxInc=1e-2, minInc=1e-4, maxNumInc=1000, maxIter=10
+*step, solver=theSolver
+maxInc=1e-2, minInc=1e-4, maxNumInc=1000, maxIter=10
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=enc, nSet=Set-1, field=displacement, 1=0, 2=0, 3=0
 >>dirichlet, name=enc2, nSet=Set-5, field=displacement, 1=0, 2=0, 3=0

--- a/testfiles/marmot/RotationalSpringUpdatedLagrangeJaumann/test_.inp
+++ b/testfiles/marmot/RotationalSpringUpdatedLagrangeJaumann/test_.inp
@@ -9,9 +9,9 @@ all
 *job, name=c3d8tljob, domain=3d
 *solver, solver=NISTParallel, name=theSolver
 *fieldOutput,
-name=displacement, elSet=all, field=displacement, result=U, name=displacement
-name=stress, elSet=all, result=stress, f(x)=' mean(x, axis=1) ', quadraturePoint=0:3
-name=strain, elSet=all, result=strain, f(x)=' mean(x, axis=1) ', quadraturePoint=0:3
+>>perNode, name=displacement, elSet=all, field=displacement, result=U
+>>perElement, name=stress, elSet=all, result=stress, f(x)=' mean(x, axis=1) ', quadraturePoint=0:3
+>>perElement, name=strain, elSet=all, result=strain, f(x)=' mean(x, axis=1) ', quadraturePoint=0:3
 
 *constraint, type=rigidbody, name=rb1
 referencePoint=RP

--- a/testfiles/marmot/TriaxialTestRDPNonLocalP125/test_.inp
+++ b/testfiles/marmot/TriaxialTestRDPNonLocalP125/test_.inp
@@ -44,37 +44,37 @@ weak
 ***job, name=cpe4job, domain=3d, solver=NISTParallel
 
 *fieldOutput,
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
-create=perNode, nSet=top, field=displacement, result=P, name=displacement, name=RF, f(x)=' sum(x[:,2]) ', saveHistory=True, export=RF
-create=perNode, nSet=top, field=displacement, result=U, name=UTop,  f(x)=' (x[0,2]) ', saveHistory=True, export=UTop
-create=perNode, elSet=all, field=nonlocal damage , result=U, name=alpha_d_nl
-create=perElement, elSet=all, result=stress, quadraturePoint=0:4, name=stress, f(x)='mean(x, axis=1)'
-create=perElement, elSet=all, result=strain, quadraturePoint=0:4, name=strain, f(x)='mean(x, axis=1)'
-create=perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaP, f(x)='mean( x[:,:,0], axis=1) '
-create=perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaD, f(x)='mean( x[:,:,2], axis=1) '
-create=perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=omega, f(x)='mean( x[:,:,4], axis=1) '
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, nSet=top, field=displacement, result=P, name=displacement, name=RF, f(x)=' sum(x[:,2]) ', saveHistory=True, export=RF
+>>perNode, nSet=top, field=displacement, result=U, name=UTop,  f(x)=' (x[0,2]) ', saveHistory=True, export=UTop
+>>perNode, elSet=all, field=nonlocal damage , result=U, name=alpha_d_nl
+>>perElement, elSet=all, result=stress, quadraturePoint=0:4, name=stress, f(x)='mean(x, axis=1)'
+>>perElement, elSet=all, result=strain, quadraturePoint=0:4, name=strain, f(x)='mean(x, axis=1)'
+>>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaP, f(x)='mean( x[:,:,0], axis=1) '
+>>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaD, f(x)='mean( x[:,:,2], axis=1) '
+>>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=omega, f(x)='mean( x[:,:,4], axis=1) '
 
 *output, type=meshplot, name=RFPlot
-create=xyData, x=time, y=RF, legend=RF
+>>xyData, x=time, y=RF, legend=RF
 *output, type=ensight, name=ensightExport
-create=perNode,    fieldOutput=displacement
-create=perNode,    fieldOutput=alpha_d_nl
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perNode, fieldOutput=alpha_d_nl
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
+>>configuration, overwrite=yes
 
 *step, maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=bottom,  nSet=bottom,   field=displacement, 3=0.0
-dirichlet, name=origin,  nSet=origin,   field=displacement, 1=0.0,
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=bottom,  nSet=bottom,   field=displacement, 3=0.0
+>>dirichlet, name=origin,  nSet=origin,   field=displacement, 1=0.0,
 **dirichlet, name=adb,  nSet=bottom,   field=nonlocal damage , 1=0.0
 **dirichlet, name=adt,  nSet=top,   field=nonlocal damage , 1=0.0,
-dirichlet, name=sym,  nSet=sym,   field=displacement, 2=0.0
-distributedload, name=dload, surface=sleeveTop, type=pressure, magnitude=12.5, f(t)=t
-options, category=NISTArcLength, arcLengthController=off
+>>dirichlet, name=sym,  nSet=sym,   field=displacement, 2=0.0
+>>distributedload, name=dload, surface=sleeveTop, type=pressure, magnitude=12.5, f(t)=t
+>>options, category=NISTArcLength, arcLengthController=off
 
 ** ---- STEP WITHOUT SNAPBACK
 ***step, maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
@@ -84,9 +84,9 @@ options, category=NISTArcLength, arcLengthController=off
 
 ** ---- STEP WITH SNAPBACK
 *step, maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=linear,
-options, category=Ensight, intermediateSaveInterval=1
-dirichlet, name=top,  nSet=top,   field=displacement, 3=-0.525
-options, category=NISTArcLength, arcLengthController=indirectcontrol, stopCondition='fieldOutputs["UTop"] < -1.0'
-indirectcontrol, dof1=' nodeSets["all"][490].fields["displacement"][2] ' , dof2=' nodeSets["all"][608].fields["displacement"][2] ' , L=-.525
+>>options, category=NISTSolver, extrapolation=linear,
+>>options, category=Ensight, intermediateSaveInterval=1
+>>dirichlet, name=top,  nSet=top,   field=displacement, 3=-0.525
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, stopCondition='fieldOutputs["UTop"] < -1.0'
+>>indirectcontrol, dof1=' nodeSets["all"][490].fields["displacement"][2] ' , dof2=' nodeSets["all"][608].fields["displacement"][2] ' , L=-.525
 

--- a/testfiles/marmot/TriaxialTestRDPNonLocalP125/test_.inp
+++ b/testfiles/marmot/TriaxialTestRDPNonLocalP125/test_.inp
@@ -46,7 +46,7 @@ weak
 
 *fieldOutput,
 >>perNode, elSet=all, field=displacement, result=U, name=displacement
->>perNode, nSet=top, field=displacement, result=P, name=displacement, name=RF, f(x)=' sum(x[:,2]) ', saveHistory=True, export=RF
+>>perNode, nSet=top, field=displacement, result=P, name=displacement, f(x)=' sum(x[:,2]) ', saveHistory=True, export=RF
 >>perNode, nSet=top, field=displacement, result=U, name=UTop,  f(x)=' (x[0,2]) ', saveHistory=True, export=UTop
 >>perNode, elSet=all, field=nonlocal damage , result=U, name=alpha_d_nl
 >>perElement, elSet=all, result=stress, quadraturePoint=0:4, name=stress, f(x)='mean(x, axis=1)'
@@ -56,7 +56,7 @@ weak
 >>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=omega, f(x)='mean( x[:,:,4], axis=1) '
 
 *output, type=meshplot, name=RFPlot
->>xyData, x=time, y=RF, legend=RF
+figure=1, axSpec=111, create=xyData, x=time, y=RF, legend=RF
 *output, type=ensight, name=ensightExport
 >>perNode, fieldOutput=displacement
 >>perNode, fieldOutput=alpha_d_nl
@@ -91,5 +91,5 @@ maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
 >>options, category=Ensight, intermediateSaveInterval=1
 >>dirichlet, name=top,  nSet=top,   field=displacement, 3=-0.525
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, stopCondition='fieldOutputs["UTop"] < -1.0'
->>indirectcontrol, dof1=' nodeSets["all"][490].fields["displacement"][2] ' , dof2=' nodeSets["all"][608].fields["displacement"][2] ' , L=-.525
+>>indirectcontrol, dof1=' nodeSets["all"][490].fields["displacement"][2] ' , dof2=' nodeSets["all"][608].fields["displacement"][2] ' , L=-.525, cVector1='[-1]', cVector2='[1]'
 

--- a/testfiles/marmot/TriaxialTestRDPNonLocalP125/test_.inp
+++ b/testfiles/marmot/TriaxialTestRDPNonLocalP125/test_.inp
@@ -41,6 +41,7 @@ weak
 ** Name: BC-Bottom Type: Displacement/Rotation
 
 *job, name=cpe4job, domain=3d, solver=NISTPArcLength
+*solver, solver=NISTPArcLength, name=theSolver
 ***job, name=cpe4job, domain=3d, solver=NISTParallel
 
 *fieldOutput,
@@ -66,7 +67,7 @@ weak
 >>perElement, fieldOutput=omega
 >>configuration, overwrite=yes
 
-*step
+*step, solver=theSolver
 maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=bottom,  nSet=bottom,   field=displacement, 3=0.0
@@ -84,7 +85,7 @@ maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
 **dirichlet, name=top,  nSet=top,   field=displacement, 3=-.525
 
 ** ---- STEP WITH SNAPBACK
-*step
+*step, solver=theSolver
 maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
 >>options, category=NISTSolver, extrapolation=linear,
 >>options, category=Ensight, intermediateSaveInterval=1

--- a/testfiles/marmot/TriaxialTestRDPNonLocalP125/test_.inp
+++ b/testfiles/marmot/TriaxialTestRDPNonLocalP125/test_.inp
@@ -66,7 +66,8 @@ weak
 >>perElement, fieldOutput=omega
 >>configuration, overwrite=yes
 
-*step, maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
+*step
+maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=bottom,  nSet=bottom,   field=displacement, 3=0.0
 >>dirichlet, name=origin,  nSet=origin,   field=displacement, 1=0.0,
@@ -83,7 +84,8 @@ weak
 **dirichlet, name=top,  nSet=top,   field=displacement, 3=-.525
 
 ** ---- STEP WITH SNAPBACK
-*step, maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
+*step
+maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
 >>options, category=NISTSolver, extrapolation=linear,
 >>options, category=Ensight, intermediateSaveInterval=1
 >>dirichlet, name=top,  nSet=top,   field=displacement, 3=-0.525

--- a/testfiles/marmot/TriaxialTestRDPNonLocalP375/test_.inp
+++ b/testfiles/marmot/TriaxialTestRDPNonLocalP375/test_.inp
@@ -42,6 +42,7 @@ weak
 
 ***job, name=cpe4job, domain=3d, solver=NISTPArcLength
 *job, name=cpe4job, domain=3d, solver=NISTParallel
+*solver, solver=NISTParallel, name=theSolver
 
 *fieldOutput,
 >>perNode, elSet=all, field=displacement, result=U, name=displacement
@@ -66,7 +67,7 @@ weak
 >>perElement, fieldOutput=omega
 >>configuration, overwrite=yes
 
-*step
+*step, solver=theSolver
 maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=bottom,  nSet=bottom,   field=displacement, 3=0.0
@@ -78,7 +79,7 @@ maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
 >>options, category=NISTArcLength, arcLengthController=off
 
 **---- STEP WITHOUT SNAPBACK
-*step
+*step, solver=theSolver
 maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
 >>options, category=NISTSolver, extrapolation=linear,
 >>options, category=Ensight, intermediateSaveInterval=1

--- a/testfiles/marmot/TriaxialTestRDPNonLocalP375/test_.inp
+++ b/testfiles/marmot/TriaxialTestRDPNonLocalP375/test_.inp
@@ -44,43 +44,43 @@ weak
 *job, name=cpe4job, domain=3d, solver=NISTParallel
 
 *fieldOutput,
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
-create=perNode, nSet=top, field=displacement, result=P, name=displacement, name=RF, f(x)=' sum(x[:,2]) ', saveHistory=True, export=RF
-create=perNode, nSet=top, field=displacement, result=U, name=UTop,  f(x)=' (x[0,2]) ', saveHistory=True, export=UTop
-create=perNode, elSet=all, field=nonlocal damage , result=U, name=alpha_d_nl
-create=perElement, elSet=all, result=stress, quadraturePoint=0:4, name=stress, f(x)='mean(x, axis=1)'
-create=perElement, elSet=all, result=strain, quadraturePoint=0:4, name=strain, f(x)='mean(x, axis=1)'
-create=perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaP, f(x)='mean( x[:,:,0], axis=1) '
-create=perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaD, f(x)='mean( x[:,:,2], axis=1) '
-create=perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=omega, f(x)='mean( x[:,:,4], axis=1) '
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, nSet=top, field=displacement, result=P, name=displacement, name=RF, f(x)=' sum(x[:,2]) ', saveHistory=True, export=RF
+>>perNode, nSet=top, field=displacement, result=U, name=UTop,  f(x)=' (x[0,2]) ', saveHistory=True, export=UTop
+>>perNode, elSet=all, field=nonlocal damage , result=U, name=alpha_d_nl
+>>perElement, elSet=all, result=stress, quadraturePoint=0:4, name=stress, f(x)='mean(x, axis=1)'
+>>perElement, elSet=all, result=strain, quadraturePoint=0:4, name=strain, f(x)='mean(x, axis=1)'
+>>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaP, f(x)='mean( x[:,:,0], axis=1) '
+>>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaD, f(x)='mean( x[:,:,2], axis=1) '
+>>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=omega, f(x)='mean( x[:,:,4], axis=1) '
 
 *output, type=meshplot, name=RFPlot
-create=xyData, x=time, y=RF, legend=RF
+>>xyData, x=time, y=RF, legend=RF
 *output, type=ensight, name=ensightExport
-create=perNode,    fieldOutput=displacement
-create=perNode,    fieldOutput=alpha_d_nl
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perNode, fieldOutput=alpha_d_nl
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
+>>configuration, overwrite=yes
 
 *step, maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=bottom,  nSet=bottom,   field=displacement, 3=0.0
-dirichlet, name=origin,  nSet=origin,   field=displacement, 1=0.0,
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=bottom,  nSet=bottom,   field=displacement, 3=0.0
+>>dirichlet, name=origin,  nSet=origin,   field=displacement, 1=0.0,
 **dirichlet, name=adb,  nSet=bottom,   field=nonlocal damage , 1=0.0
 **dirichlet, name=adt,  nSet=top,   field=nonlocal damage , 1=0.0,
-dirichlet, name=sym,  nSet=sym,   field=displacement, 2=0.0
-distributedload, name=dload, surface=sleeveTop, type=pressure, magnitude=37.5, f(t)=t
-options, category=NISTArcLength, arcLengthController=off
+>>dirichlet, name=sym,  nSet=sym,   field=displacement, 2=0.0
+>>distributedload, name=dload, surface=sleeveTop, type=pressure, magnitude=37.5, f(t)=t
+>>options, category=NISTArcLength, arcLengthController=off
 
 **---- STEP WITHOUT SNAPBACK
 *step, maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=linear,
-options, category=Ensight, intermediateSaveInterval=1
-dirichlet, name=top,  nSet=top,   field=displacement, 3=-.525
+>>options, category=NISTSolver, extrapolation=linear,
+>>options, category=Ensight, intermediateSaveInterval=1
+>>dirichlet, name=top,  nSet=top,   field=displacement, 3=-.525
 
 ** ---- STEP WITH SNAPBACK
 ***step, maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1

--- a/testfiles/marmot/TriaxialTestRDPNonLocalP375/test_.inp
+++ b/testfiles/marmot/TriaxialTestRDPNonLocalP375/test_.inp
@@ -66,7 +66,8 @@ weak
 >>perElement, fieldOutput=omega
 >>configuration, overwrite=yes
 
-*step, maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
+*step
+maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=bottom,  nSet=bottom,   field=displacement, 3=0.0
 >>dirichlet, name=origin,  nSet=origin,   field=displacement, 1=0.0,
@@ -77,7 +78,8 @@ weak
 >>options, category=NISTArcLength, arcLengthController=off
 
 **---- STEP WITHOUT SNAPBACK
-*step, maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
+*step
+maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
 >>options, category=NISTSolver, extrapolation=linear,
 >>options, category=Ensight, intermediateSaveInterval=1
 >>dirichlet, name=top,  nSet=top,   field=displacement, 3=-.525

--- a/testfiles/marmot/TriaxialTestRDPNonLocalP375/test_.inp
+++ b/testfiles/marmot/TriaxialTestRDPNonLocalP375/test_.inp
@@ -46,7 +46,7 @@ weak
 
 *fieldOutput,
 >>perNode, elSet=all, field=displacement, result=U, name=displacement
->>perNode, nSet=top, field=displacement, result=P, name=displacement, name=RF, f(x)=' sum(x[:,2]) ', saveHistory=True, export=RF
+>>perNode, nSet=top, field=displacement, result=P, name=displacement, f(x)=' sum(x[:,2]) ', saveHistory=True, export=RF
 >>perNode, nSet=top, field=displacement, result=U, name=UTop,  f(x)=' (x[0,2]) ', saveHistory=True, export=UTop
 >>perNode, elSet=all, field=nonlocal damage , result=U, name=alpha_d_nl
 >>perElement, elSet=all, result=stress, quadraturePoint=0:4, name=stress, f(x)='mean(x, axis=1)'
@@ -56,7 +56,7 @@ weak
 >>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=omega, f(x)='mean( x[:,:,4], axis=1) '
 
 *output, type=meshplot, name=RFPlot
->>xyData, x=time, y=RF, legend=RF
+figure=1, axSpec=111, create=xyData, x=time, y=RF, legend=RF
 *output, type=ensight, name=ensightExport
 >>perNode, fieldOutput=displacement
 >>perNode, fieldOutput=alpha_d_nl

--- a/testfiles/marmot/TwistingTrussJaumannRate/_test.inp
+++ b/testfiles/marmot/TwistingTrussJaumannRate/_test.inp
@@ -1025,13 +1025,13 @@
 *material, name=linearelastic, id=le,
 30000.0, 0.15
 
-*section, name=section1, thickness=1.0, material=le, type=solid
+*section, name=section1, material=le, type=solid
 all
 
 *job, name=c3d8job, domain=3d,
 *solver, solver=NISTParallel, name=theSolver
-*fieldOutput
->>perNode, name=displacement, elSet=all, field=displacement, result=U, name=displacement
+*fieldOutput,
+>>perNode, name=displacement, elSet=all, field=displacement, result=U
 >>perElement, name=stress, elSet=all, result=stress, f(x)='mean(x, axis=1) ', quadraturePoint=0:3
 
 *constraint, type=rigidbody, name=rb1

--- a/testfiles/marmot/TwistingTrussJaumannRate/_test.inp
+++ b/testfiles/marmot/TwistingTrussJaumannRate/_test.inp
@@ -1043,7 +1043,8 @@ referencePoint=rBottom
 >>perElement, fieldOutput=stress
 >>configuration, overwrite=yes
 
-*step, solver=theSolver, maxInc=5e-2, minInc=1e-4, maxNumInc=1000, maxIter=20
+*step, solver=theSolver
+maxInc=5e-2, minInc=1e-4, maxNumInc=1000, maxIter=20
 >>options, category=NISTSolver, extrapolation=linear
 >>dirichlet, name=left,  nSet=left,         field=displacement, 1=0.0, 2=0, 3=0
 >>dirichlet, name=rotRP,  nSet=rBottom,   field=rotation, 1=1.5707,

--- a/testfiles/marmot/TwistingTrussJaumannRate/_test.inp
+++ b/testfiles/marmot/TwistingTrussJaumannRate/_test.inp
@@ -1031,19 +1031,19 @@ all
 *job, name=c3d8job, domain=3d,
 *solver, solver=NISTParallel, name=theSolver
 *fieldOutput
-create=perNode, name=displacement, elSet=all, field=displacement, result=U, name=displacement
-create=perElement, name=stress, elSet=all, result=stress, f(x)='mean(x, axis=1) ', quadraturePoint=0:3
+>>perNode, name=displacement, elSet=all, field=displacement, result=U, name=displacement
+>>perElement, name=stress, elSet=all, result=stress, f(x)='mean(x, axis=1) ', quadraturePoint=0:3
 
 *constraint, type=rigidbody, name=rb1
 nSet=right
 referencePoint=rBottom
 
 *output, type=ensight, name=ensightExport
-create=perNode, fieldOutput=displacement
-create=perElement, fieldOutput=stress
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perElement, fieldOutput=stress
+>>configuration, overwrite=yes
 
 *step, solver=theSolver, maxInc=5e-2, minInc=1e-4, maxNumInc=1000, maxIter=20
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=left,  nSet=left,         field=displacement, 1=0.0, 2=0, 3=0
-dirichlet, name=rotRP,  nSet=rBottom,   field=rotation, 1=1.5707,
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=left,  nSet=left,         field=displacement, 1=0.0, 2=0, 3=0
+>>dirichlet, name=rotRP,  nSet=rBottom,   field=rotation, 1=1.5707,

--- a/testfiles/marmot/WedgeSplittingTest/test_.inp
+++ b/testfiles/marmot/WedgeSplittingTest/test_.inp
@@ -14129,24 +14129,24 @@ _Surf-PressureR_S4, 4
 ****** omegaMax, nonlocalRadius nonlocalweight              epsilonF
 **     0.999999,   2.0,        1.05,     4e-04
      0.99,   4.0,        1.05,     8e-04
-*section, name=sectionAll, thickness=100.00, material=urmnl, type=plane
+*section, name=sectionAll, material=urmnl, type=plane
 Set-Complete
 
 *job, name=cpe4job, domain=2d, solver=NISTPArcLength
 *solver, solver=NISTPArcLength, name=theSolver
 
 *fieldOutput,
-elSet=Set-Complete, field=displacement, result=U, name=disp
-elSet=Set-Complete, field=nonlocal damage, result=U, name=adnl
-name=Stress, elSet=Set-Complete, result=stress, quadraturePoint=1
-name=Strain, elSet=Set-Complete, result=strain, quadraturePoint=1
-name=AlphaP, elSet=Set-Complete, result=sdv, quadraturePoint=1, f(x)='x[:,0]'
-name=AlphaD, elSet=Set-Complete, result=sdv, quadraturePoint=1, f(x)='x[:,2]'
-name=Omega,  elSet=Set-Complete, result=sdv, quadraturePoint=1, f(x)='x[:,4]'
-name=Displacement_Notch, nSet=Set-PointNotch, field=displacement, result=U, saveHistory=True
-name=Displacement_NotchNew, nSet=Set-PointLoad, field=displacement, result=U, saveHistory=True
-name=Force_SP, nSet=Set-PressureLeft,  field=displacement, result=P, saveHistory=True
-name=Force_SPnew, nSet=Set-PointLoadL,  field=displacement, result=P, saveHistory=True
+>>perNode, elSet=Set-Complete, field=displacement, result=U, name=disp
+>>perNode, elSet=Set-Complete, field=nonlocal damage, result=U, name=adnl
+>>perElement, name=Stress, elSet=Set-Complete, result=stress, quadraturePoint=1
+>>perElement, name=Strain, elSet=Set-Complete, result=strain, quadraturePoint=1
+>>perElement, name=AlphaP, elSet=Set-Complete, result=sdv, quadraturePoint=1, f(x)='x[:,0]'
+>>perElement, name=AlphaD, elSet=Set-Complete, result=sdv, quadraturePoint=1, f(x)='x[:,2]'
+>>perElement, name=Omega,  elSet=Set-Complete, result=sdv, quadraturePoint=1, f(x)='x[:,4]'
+>>perNode, name=Displacement_Notch, nSet=Set-PointNotch, field=displacement, result=U, saveHistory=True
+>>perNode, name=Displacement_NotchNew, nSet=Set-PointLoad, field=displacement, result=U, saveHistory=True
+>>perNode, name=Force_SP, nSet=Set-PressureLeft,  field=displacement, result=P, saveHistory=True
+>>perNode, name=Force_SPnew, nSet=Set-PointLoadL,  field=displacement, result=P, saveHistory=True
 
 
 ***constraint, type=linearizedRigidBody, name=rb1
@@ -14156,17 +14156,17 @@ name=Force_SPnew, nSet=Set-PointLoadL,  field=displacement, result=P, saveHistor
 **nSet=_PickedSet20,
 **referencePoint=_PickedSet19
 *output, type=meshPlot,
->>figure=1, create=xyData,  export=True, label=FSP_CMOD_medium_E22000_epsF8e-4_fcu20MPa_nu0_15_mg1_5_m0_6_5_l4mm_BC10mm_thick100mm_allCycles_looseTol_pointLoad, x=Displacement_NotchNew, y=Force_SPnew, f(x)='sum(abs(x[:,:,0]), axis=1)', f(y)='sum(y[:,:,0], axis=1)'
+figure=1, create=xyData,  export=True, label=FSP_CMOD_medium_E22000_epsF8e-4_fcu20MPa_nu0_15_mg1_5_m0_6_5_l4mm_BC10mm_thick100mm_allCycles_looseTol_pointLoad, x=Displacement_NotchNew, y=Force_SPnew, f(x)='sum(abs(x[:,:,0]), axis=1)', f(y)='sum(y[:,:,0], axis=1)'
 
 
 *output, type=ensight, name=WST_medium_pointload
->>perNode, elSet=Set-Complete, fieldOutput=disp
->>perNode, elSet=Set-Complete, fieldOutput=adnl
->>perElement, elSet=Set-Complete, fieldOutput=Stress
->>perElement, elSet=Set-Complete, fieldOutput=Strain
->>perElement, elSet=Set-Complete, fieldOutput=AlphaP
->>perElement, elSet=Set-Complete, fieldOutput=AlphaD
->>perElement, elSet=Set-Complete, fieldOutput=Omega
+>>perNode, fieldOutput=disp
+>>perNode, fieldOutput=adnl
+>>perElement, fieldOutput=Stress
+>>perElement, fieldOutput=Strain
+>>perElement, fieldOutput=AlphaP
+>>perElement, fieldOutput=AlphaD
+>>perElement, fieldOutput=Omega
 >>configuration, overwrite=yes
 
 *step, solver=theSolver
@@ -14178,7 +14178,7 @@ maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 >>dirichlet, name=bottom_v, nSet=Set-BCBottom, field=displacement, 2=0.0
 >>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
->>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.111,
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.111, cVector1='[-1]', cVector2='[1]',
 **indirectcontrol, dof1=' nodes[260].fields["displacement"][0] ', dof2=' nodes[521].fields["displacement"][0] ', L=+0.175,
 
 *step, solver=theSolver
@@ -14188,7 +14188,7 @@ maxInc=5e-3, minInc=1e-7
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
 >>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
->>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01, cVector1='[-1]', cVector2='[1]'
 
 *step, solver=theSolver
 maxInc=1e-1, minInc=1e-7, maxNumInc=10000
@@ -14197,7 +14197,7 @@ maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
 >>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
->>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.128,
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.128, cVector1='[-1]', cVector2='[1]',
 
 *step, solver=theSolver
 maxInc=5e-3, minInc=1e-7
@@ -14206,7 +14206,7 @@ maxInc=5e-3, minInc=1e-7
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
 >>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
->>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01, cVector1='[-1]', cVector2='[1]'
 
 *step, solver=theSolver
 maxInc=1e-1, minInc=1e-7, maxNumInc=10000
@@ -14215,7 +14215,7 @@ maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
 >>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
->>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.151,
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.151, cVector1='[-1]', cVector2='[1]',
 
 *step, solver=theSolver
 maxInc=5e-3, minInc=1e-7
@@ -14224,7 +14224,7 @@ maxInc=5e-3, minInc=1e-7
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
 >>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
->>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01, cVector1='[-1]', cVector2='[1]'
 
 *step, solver=theSolver
 maxInc=1e-1, minInc=1e-7, maxNumInc=10000
@@ -14233,7 +14233,7 @@ maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
 >>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
->>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.175,
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.175, cVector1='[-1]', cVector2='[1]',
 
 *step, solver=theSolver
 maxInc=5e-3, minInc=1e-7
@@ -14242,7 +14242,7 @@ maxInc=5e-3, minInc=1e-7
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
 >>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
->>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01, cVector1='[-1]', cVector2='[1]'
 
 *step, solver=theSolver
 maxInc=1e-1, minInc=1e-7, maxNumInc=10000
@@ -14251,7 +14251,7 @@ maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
 >>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
->>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.204,
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.204, cVector1='[-1]', cVector2='[1]',
 
 *step, solver=theSolver
 maxInc=5e-3, minInc=1e-7
@@ -14260,7 +14260,7 @@ maxInc=5e-3, minInc=1e-7
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
 >>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
->>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01, cVector1='[-1]', cVector2='[1]'
 
 *step, solver=theSolver
 maxInc=1e-1, minInc=1e-7, maxNumInc=10000
@@ -14269,5 +14269,5 @@ maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
 >>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
->>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.300,
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.300, cVector1='[-1]', cVector2='[1]',
 

--- a/testfiles/marmot/WedgeSplittingTest/test_.inp
+++ b/testfiles/marmot/WedgeSplittingTest/test_.inp
@@ -14168,7 +14168,8 @@ name=Force_SPnew, nSet=Set-PointLoadL,  field=displacement, result=P, saveHistor
 >>perElement, elSet=Set-Complete, fieldOutput=Omega
 >>configuration, overwrite=yes
 
-*step, maxInc=1e-1, minInc=1e-7, maxNumInc=10000
+*step
+maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 >>options, category=NISTSolver5, extrapolation=linear
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
@@ -14179,7 +14180,8 @@ name=Force_SPnew, nSet=Set-PointLoadL,  field=displacement, result=P, saveHistor
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.111,
 **indirectcontrol, dof1=' nodes[260].fields["displacement"][0] ', dof2=' nodes[521].fields["displacement"][0] ', L=+0.175,
 
-*step, maxInc=5e-3, minInc=1e-7
+*step
+maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
 >>options, category=NISTSolver5, extrapolation=linear
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
@@ -14187,7 +14189,8 @@ name=Force_SPnew, nSet=Set-PointLoadL,  field=displacement, result=P, saveHistor
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
 
-*step, maxInc=1e-1, minInc=1e-7, maxNumInc=10000
+*step
+maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 >>options, category=NISTSolver5, extrapolation=linear
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
@@ -14195,7 +14198,8 @@ name=Force_SPnew, nSet=Set-PointLoadL,  field=displacement, result=P, saveHistor
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.128,
 
-*step, maxInc=5e-3, minInc=1e-7
+*step
+maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
 >>options, category=NISTSolver5, extrapolation=linear
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
@@ -14203,7 +14207,8 @@ name=Force_SPnew, nSet=Set-PointLoadL,  field=displacement, result=P, saveHistor
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
 
-*step, maxInc=1e-1, minInc=1e-7, maxNumInc=10000
+*step
+maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 >>options, category=NISTSolver5, extrapolation=linear
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
@@ -14211,7 +14216,8 @@ name=Force_SPnew, nSet=Set-PointLoadL,  field=displacement, result=P, saveHistor
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.151,
 
-*step, maxInc=5e-3, minInc=1e-7
+*step
+maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
 >>options, category=NISTSolver5, extrapolation=linear
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
@@ -14219,7 +14225,8 @@ name=Force_SPnew, nSet=Set-PointLoadL,  field=displacement, result=P, saveHistor
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
 
-*step, maxInc=1e-1, minInc=1e-7, maxNumInc=10000
+*step
+maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 >>options, category=NISTSolver5, extrapolation=linear
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
@@ -14227,7 +14234,8 @@ name=Force_SPnew, nSet=Set-PointLoadL,  field=displacement, result=P, saveHistor
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.175,
 
-*step, maxInc=5e-3, minInc=1e-7
+*step
+maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
 >>options, category=NISTSolver5, extrapolation=linear
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
@@ -14235,7 +14243,8 @@ name=Force_SPnew, nSet=Set-PointLoadL,  field=displacement, result=P, saveHistor
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
 
-*step, maxInc=1e-1, minInc=1e-7, maxNumInc=10000
+*step
+maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 >>options, category=NISTSolver5, extrapolation=linear
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
@@ -14243,7 +14252,8 @@ name=Force_SPnew, nSet=Set-PointLoadL,  field=displacement, result=P, saveHistor
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.204,
 
-*step, maxInc=5e-3, minInc=1e-7
+*step
+maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
 >>options, category=NISTSolver5, extrapolation=linear
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
@@ -14251,7 +14261,8 @@ name=Force_SPnew, nSet=Set-PointLoadL,  field=displacement, result=P, saveHistor
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
 
-*step, maxInc=1e-1, minInc=1e-7, maxNumInc=10000
+*step
+maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 >>options, category=NISTSolver5, extrapolation=linear
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'

--- a/testfiles/marmot/WedgeSplittingTest/test_.inp
+++ b/testfiles/marmot/WedgeSplittingTest/test_.inp
@@ -14155,107 +14155,107 @@ name=Force_SPnew, nSet=Set-PointLoadL,  field=displacement, result=P, saveHistor
 **nSet=_PickedSet20,
 **referencePoint=_PickedSet19
 *output, type=meshPlot,
-figure=1, create=xyData,  export=True, label=FSP_CMOD_medium_E22000_epsF8e-4_fcu20MPa_nu0_15_mg1_5_m0_6_5_l4mm_BC10mm_thick100mm_allCycles_looseTol_pointLoad, x=Displacement_NotchNew, y=Force_SPnew, f(x)='sum(abs(x[:,:,0]), axis=1)', f(y)='sum(y[:,:,0], axis=1)'
+>>figure=1, create=xyData,  export=True, label=FSP_CMOD_medium_E22000_epsF8e-4_fcu20MPa_nu0_15_mg1_5_m0_6_5_l4mm_BC10mm_thick100mm_allCycles_looseTol_pointLoad, x=Displacement_NotchNew, y=Force_SPnew, f(x)='sum(abs(x[:,:,0]), axis=1)', f(y)='sum(y[:,:,0], axis=1)'
 
 
 *output, type=ensight, name=WST_medium_pointload
-create=perNode,    elSet=Set-Complete, fieldOutput=disp
-create=perNode,    elSet=Set-Complete, fieldOutput=adnl
-create=perElement, elSet=Set-Complete, fieldOutput=Stress
-create=perElement, elSet=Set-Complete, fieldOutput=Strain
-create=perElement, elSet=Set-Complete, fieldOutput=AlphaP
-create=perElement, elSet=Set-Complete, fieldOutput=AlphaD
-create=perElement, elSet=Set-Complete, fieldOutput=Omega
-configuration, overwrite=yes
+>>perNode, elSet=Set-Complete, fieldOutput=disp
+>>perNode, elSet=Set-Complete, fieldOutput=adnl
+>>perElement, elSet=Set-Complete, fieldOutput=Stress
+>>perElement, elSet=Set-Complete, fieldOutput=Strain
+>>perElement, elSet=Set-Complete, fieldOutput=AlphaP
+>>perElement, elSet=Set-Complete, fieldOutput=AlphaD
+>>perElement, elSet=Set-Complete, fieldOutput=Omega
+>>configuration, overwrite=yes
 
 *step, maxInc=1e-1, minInc=1e-7, maxNumInc=10000
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
-dirichlet, name=bottom_h, nSet=Set-BCBottom, field=displacement, 1=0.0
-dirichlet, name=bottom_v, nSet=Set-BCBottom, field=displacement, 2=0.0
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.111,
+>>dirichlet, name=bottom_h, nSet=Set-BCBottom, field=displacement, 1=0.0
+>>dirichlet, name=bottom_v, nSet=Set-BCBottom, field=displacement, 2=0.0
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.111,
 **indirectcontrol, dof1=' nodes[260].fields["displacement"][0] ', dof2=' nodes[521].fields["displacement"][0] ', L=+0.175,
 
 *step, maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
 
 *step, maxInc=1e-1, minInc=1e-7, maxNumInc=10000
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.128,
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.128,
 
 *step, maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
 
 *step, maxInc=1e-1, minInc=1e-7, maxNumInc=10000
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.151,
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.151,
 
 *step, maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
 
 *step, maxInc=1e-1, minInc=1e-7, maxNumInc=10000
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.175,
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.175,
 
 *step, maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
 
 *step, maxInc=1e-1, minInc=1e-7, maxNumInc=10000
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.204,
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.204,
 
 *step, maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
 
 *step, maxInc=1e-1, minInc=1e-7, maxNumInc=10000
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.300,
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.300,
 

--- a/testfiles/marmot/WedgeSplittingTest/test_.inp
+++ b/testfiles/marmot/WedgeSplittingTest/test_.inp
@@ -14133,6 +14133,7 @@ _Surf-PressureR_S4, 4
 Set-Complete
 
 *job, name=cpe4job, domain=2d, solver=NISTPArcLength
+*solver, solver=NISTPArcLength, name=theSolver
 
 *fieldOutput,
 elSet=Set-Complete, field=displacement, result=U, name=disp
@@ -14168,7 +14169,7 @@ name=Force_SPnew, nSet=Set-PointLoadL,  field=displacement, result=P, saveHistor
 >>perElement, elSet=Set-Complete, fieldOutput=Omega
 >>configuration, overwrite=yes
 
-*step
+*step, solver=theSolver
 maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 >>options, category=NISTSolver5, extrapolation=linear
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear
@@ -14180,7 +14181,7 @@ maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.111,
 **indirectcontrol, dof1=' nodes[260].fields["displacement"][0] ', dof2=' nodes[521].fields["displacement"][0] ', L=+0.175,
 
-*step
+*step, solver=theSolver
 maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
 >>options, category=NISTSolver5, extrapolation=linear
@@ -14189,7 +14190,7 @@ maxInc=5e-3, minInc=1e-7
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
 
-*step
+*step, solver=theSolver
 maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 >>options, category=NISTSolver5, extrapolation=linear
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
@@ -14198,7 +14199,7 @@ maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.128,
 
-*step
+*step, solver=theSolver
 maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
 >>options, category=NISTSolver5, extrapolation=linear
@@ -14207,7 +14208,7 @@ maxInc=5e-3, minInc=1e-7
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
 
-*step
+*step, solver=theSolver
 maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 >>options, category=NISTSolver5, extrapolation=linear
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
@@ -14216,7 +14217,7 @@ maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.151,
 
-*step
+*step, solver=theSolver
 maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
 >>options, category=NISTSolver5, extrapolation=linear
@@ -14225,7 +14226,7 @@ maxInc=5e-3, minInc=1e-7
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
 
-*step
+*step, solver=theSolver
 maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 >>options, category=NISTSolver5, extrapolation=linear
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
@@ -14234,7 +14235,7 @@ maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.175,
 
-*step
+*step, solver=theSolver
 maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
 >>options, category=NISTSolver5, extrapolation=linear
@@ -14243,7 +14244,7 @@ maxInc=5e-3, minInc=1e-7
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
 
-*step
+*step, solver=theSolver
 maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 >>options, category=NISTSolver5, extrapolation=linear
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
@@ -14252,7 +14253,7 @@ maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.204,
 
-*step
+*step, solver=theSolver
 maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
 >>options, category=NISTSolver5, extrapolation=linear
@@ -14261,7 +14262,7 @@ maxInc=5e-3, minInc=1e-7
 >>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
 >>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
 
-*step
+*step, solver=theSolver
 maxInc=1e-1, minInc=1e-7, maxNumInc=10000
 >>options, category=NISTSolver5, extrapolation=linear
 >>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False


### PR DESCRIPTION
…keyword syntax

Example input files that are not named test.inp (and therefore not automatically tested in CI) were still using the old pre-May 2026 EdelweissFE input syntax where module-level keywords within *step, *fieldOutput and *output blocks appeared as plain data lines without the >> prefix.

Current syntax requires all module-level keyword lines to be prefixed with >>.

Affected conversions:
- *fieldOutput: 'create=perNode/perElement/xyData, ...' → '>>perNode/perElement/xyData, ...'
- *output:      'create=perNode/perElement, ...' → '>>perNode/perElement, ...'
              'configuration, ...' → '>>configuration, ...'
              'figure=..., ...' → '>>figure=..., ...'
- *step:        'dirichlet, ...' → '>>dirichlet, ...'
              'options, ...' → '>>options, ...'
              'nodeforces, ...' → '>>nodeforces, ...'
              'distributedload, ...' → '>>distributedload, ...'
              'bodyforce, ...' → '>>bodyforce, ...'
              'geostatic, ...' → '>>geostatic, ...'
              'sdvini, ...' → '>>sdvini, ...'
              'indirectcontrol, ...' → '>>indirectcontrol, ...'

27 files updated across edelweiss-only/ and marmot/ test directories.