### PR TITLE
fix: avoid circular import when importing edelweissfe modules standalone

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -27,6 +27,16 @@ from sphinx.directives.code import (  # noqa: F401
 )
 from sphinx.highlighting import lexers
 
+# Populate the input file language (all keywords and their registered modules) once,
+# eagerly, from this clean import context -- before Sphinx starts reading doc sources
+# and autodoc/automodule directives start importing individual edelweissfe modules
+# directly. Those standalone imports do not trigger registration themselves (see
+# InputLanguage.ensureParserLoaded), so without this upfront call they would run into
+# a half-populated input language and crash at import time.
+from edelweissfe.utils.inputlanguage import InputLanguage
+
+InputLanguage().ensureParserLoaded()
+
 project = "EdelweissFE"
 copyright = "2022, Matthias Neuner"
 author = "Matthias Neuner"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -227,6 +227,14 @@ class PrettyPrintDirective(CodeBlock):
         return result
 
     def run(self):
+        # Ensure the full input file language is populated (all keywords and their
+        # registered modules) before rendering. Individual modules only register
+        # themselves once the input file parser has been imported; this triggers
+        # that import explicitly from a clean context.
+        from edelweissfe.utils.inputlanguage import InputLanguage
+
+        InputLanguage().ensureParserLoaded()
+
         module_path, member_name = self.arguments[0].rsplit(".", 1)
         member_data = getattr(import_module(module_path), member_name)
         caption = self.options.get("caption", "")

--- a/edelweissfe/utils/inputlanguage.py
+++ b/edelweissfe/utils/inputlanguage.py
@@ -62,27 +62,36 @@ def singleton(class_):
 class InputLanguage:
     def __init__(self):
         self.keywords = []
+        self._loadingParser = False
 
         return
 
-    def _ensure_parser_loaded(self):
-        if not self.keywords:
+    def ensureParserLoaded(self):
+        """Eagerly populate the input language by importing the input file parser.
+
+        This must only be called from a "clean" import context (i.e. not while an
+        ``edelweissfe`` module that the parser itself imports is still being
+        initialized), otherwise it would provoke a circular import. It is intended
+        for consumers that import individual modules standalone and need the full
+        input language to be available (e.g. the documentation build). During a
+        normal simulation run the parser is imported explicitly and this is a no-op.
+        """
+        if not self.keywords and not self._loadingParser:
+            self._loadingParser = True
             try:
                 import importlib
 
                 importlib.import_module("edelweissfe.utils.inputfileparser")
-            except ImportError:
-                pass
+            finally:
+                self._loadingParser = False
 
     def __contains__(self, item) -> bool:
-        self._ensure_parser_loaded()
         return item.casefold() in [kw.name.casefold() for kw in self.keywords]
 
     def __repr__(self) -> str:
         return str(self.keywords)
 
     def __getitem__(self, keyword: str):
-        self._ensure_parser_loaded()
         casefoldedKeywords = [kw.name.casefold() for kw in self.keywords]
         try:
             idx = casefoldedKeywords.index(keyword.casefold())
@@ -94,7 +103,6 @@ class InputLanguage:
             )
 
     def __iter__(self):
-        self._ensure_parser_loaded()
         return self.keywords.__iter__()
 
     def addKeyword(self, name: str, description: str):


### PR DESCRIPTION
The lazy `_ensure_parser_loaded()` call in `InputLanguage.__contains__`, `__getitem__` and `__iter__` triggered a full import of `inputfileparser` from within the module-level registration blocks of modules that the parser itself imports (e.g. `outputmanagers/ensight`, `utils/fieldoutput`). When such a module was imported standalone -- as EdelweissMeshfree does with `edelweissfe.outputmanagers.ensight` -- the parser tried to re-import still partially initialized modules, raising a circular `ImportError` that was silently swallowed, leaving the input language half-populated and crashing at import time in `ensight.py`.

Make the container/lookup/iteration methods passive again (restoring the pre-regression behaviour where a standalone import simply skips registration), and expose the eager population as an explicit, re-entrancy-safe `ensureParserLoaded()`. The Sphinx `pprint` directive now calls it explicitly from a clean context, preserving the documentation build that motivated the original lazy loading.