### PR TITLE
feat: improved freethreading performance

### DIFF
--- a/edelweissfe/analyticalfields/randomscalar.py
+++ b/edelweissfe/analyticalfields/randomscalar.py
@@ -29,7 +29,6 @@
 "Müller, S., Schüler, L., Zech, A., and Heße, F.: GSTools v1.3: a toolbox for geostatistical modelling in Python, Geosci. Model Dev., 15, 3161–3182, https://doi.org/10.5194/gmd-15-3161-2022, 2022."
 """
 
-import gstools
 import numpy as np
 
 from edelweissfe.analyticalfields.base.analyticalfieldbase import (
@@ -88,6 +87,12 @@ class AnalyticalField(AnalyticalFieldBase):
         nu: float = module["nu"].default,
         seed: int = module["seed"].default,
     ):
+        # gstools is imported lazily: its Cython extension does not declare
+        # free-threading support, so importing it re-enables the GIL process-wide
+        # and would disable thread-parallel computations for ALL simulations,
+        # even those not using random fields.
+        import gstools
+
         self.name = name
         self.type = "randomScalar"
 

--- a/edelweissfe/analyticalfields/randomscalar.py
+++ b/edelweissfe/analyticalfields/randomscalar.py
@@ -91,7 +91,13 @@ class AnalyticalField(AnalyticalFieldBase):
         # free-threading support, so importing it re-enables the GIL process-wide
         # and would disable thread-parallel computations for ALL simulations,
         # even those not using random fields.
-        import gstools
+        try:
+            import gstools
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError(
+                "the 'randomScalar' analytical field requires the 'gstools' package "
+                "(install via 'pip install gstools' or 'mamba install -c conda-forge gstools')"
+            ) from e
 
         self.name = name
         self.type = "randomScalar"

--- a/edelweissfe/config/linsolve.py
+++ b/edelweissfe/config/linsolve.py
@@ -38,6 +38,8 @@ def getDefaultLinSolver():
     try:
         from edelweissfe.linsolve.pardiso.pardiso import PardisoSolver
 
+        # symbolic-factorization reuse is opt-in only, see getLinSolverByName; the
+        # default here intentionally matches that safe default.
         return PardisoSolver()
     except ImportError:
         from scipy.sparse.linalg import spsolve
@@ -57,7 +59,18 @@ def getLinSolverByName(linsolverName, opts):
     elif linsolverName.lower() == "pardiso":
         from edelweissfe.linsolve.pardiso.pardiso import PardisoSolver
 
-        return PardisoSolver()
+        # Symbolic-factorization reuse across solves is only correct if the caller
+        # can guarantee the sparsity pattern stays genuinely stable for the solver
+        # instance's entire lifetime; it has been observed to silently produce wrong
+        # (but not NaN, so undetected by the usual failure check) results for some
+        # coupled-DOF problems. Off by default; opt in explicitly via
+        # opts["reuseSymbolicFactorization"] = True once that has been verified safe
+        # for the problem at hand.
+        reuseSymbolicFactorization = (
+            bool(opts.get("reuseSymbolicFactorization", False)) if isinstance(opts, Mapping) else False
+        )
+
+        return PardisoSolver(reuseSymbolicFactorization=reuseSymbolicFactorization)
     elif linsolverName.lower() == "panuapardiso":
         from edelweissfe.linsolve.panuapardiso.panuapardiso import panuaPardisoSolve
 

--- a/edelweissfe/config/linsolve.py
+++ b/edelweissfe/config/linsolve.py
@@ -36,9 +36,9 @@ from collections.abc import Mapping
 
 def getDefaultLinSolver():
     try:
-        from edelweissfe.linsolve.pardiso.pardiso import pardisoSolve
+        from edelweissfe.linsolve.pardiso.pardiso import PardisoSolver
 
-        return pardisoSolve
+        return PardisoSolver()
     except ImportError:
         from scipy.sparse.linalg import spsolve
 
@@ -55,9 +55,9 @@ def getLinSolverByName(linsolverName, opts):
 
         return lambda A, b: spsolve(A, b, use_umfpack=True)
     elif linsolverName.lower() == "pardiso":
-        from edelweissfe.linsolve.pardiso.pardiso import pardisoSolve
+        from edelweissfe.linsolve.pardiso.pardiso import PardisoSolver
 
-        return pardisoSolve
+        return PardisoSolver()
     elif linsolverName.lower() == "panuapardiso":
         from edelweissfe.linsolve.panuapardiso.panuapardiso import panuaPardisoSolve
 

--- a/edelweissfe/linsolve/pardiso/pardiso.pyx
+++ b/edelweissfe/linsolve/pardiso/pardiso.pyx
@@ -88,6 +88,7 @@ cdef class PardisoSolver:
     cdef int mnum
     cdef int msglvl
     cdef int rows
+    cdef bint ptIsActive  # pt may hold PARDISO-internal allocations (phase -1 required)
     cdef bint hasSymbolicFactorization
 
     # the pattern arrays of the currently analyzed matrix (0-based, for change detection)
@@ -98,13 +99,21 @@ cdef class PardisoSolver:
     cdef int[::1] indptrFortran
 
     def __cinit__(self):
+        cdef int i
+
         self.mtype = 11
         self.maxfct = 1
         self.mnum = 1
         self.msglvl = 0
+        self.ptIsActive = False
         self.hasSymbolicFactorization = False
         self.currentIndices = None
         self.currentIndptr = None
+
+        # PARDISO requires pt to be all zeros before the first call
+        for i in range(64):
+            self.pt[i] = 0
+            self.iparm[i] = 0
 
     def __dealloc__(self):
         self._releaseMemory()
@@ -117,13 +126,14 @@ cdef class PardisoSolver:
         cdef int idum = 0
         cdef double ddum = 0
 
-        if not self.hasSymbolicFactorization:
+        if not self.ptIsActive:
             return
 
         pardiso(self.pt, &self.maxfct, &self.mnum, &self.mtype, &phase,
                 &self.rows, &ddum, &idum, &idum, &idum, &nRhs,
                 &self.iparm[0], &self.msglvl, &ddum, &ddum, &error)
 
+        self.ptIsActive = False
         self.hasSymbolicFactorization = False
         self.currentIndices = None
         self.currentIndptr = None
@@ -162,11 +172,19 @@ cdef class PardisoSolver:
 
         self._releaseMemory()
 
+        if A.nnz > np.iinfo(np.intc).max:
+            raise ValueError(
+                "matrix has {:} nonzeros, exceeding the 32-bit PARDISO interface".format(A.nnz)
+            )
+
         self.rows = A.shape[0]
-        self.indicesFortran = A.indices + 1  # pardiso uses fortran 1-based indexing
-        self.indptrFortran = A.indptr + 1    # pardiso uses fortran 1-based indexing
+        # pardiso uses fortran 1-based indexing; scipy may use int64 index arrays for
+        # large matrices, so cast explicitly to the 32-bit interface type
+        self.indicesFortran = np.ascontiguousarray(A.indices + 1, dtype=np.intc)
+        self.indptrFortran = np.ascontiguousarray(A.indptr + 1, dtype=np.intc)
 
         pardisoinit(self.pt, &self.mtype, &self.iparm[0])
+        self.ptIsActive = True
 
         cdef double[::1] data = A.data
 

--- a/edelweissfe/linsolve/pardiso/pardiso.pyx
+++ b/edelweissfe/linsolve/pardiso/pardiso.pyx
@@ -34,8 +34,6 @@
 This module provides an interface to the PARDISO solver provided by the Intel Math Kernel Library (MKL).
 """
 
-import os
-
 import numpy as np
 
 cimport numpy as np
@@ -68,9 +66,183 @@ def setParameter(iparm, idx: int, value: int):
     return iparm
 
 
+cdef class PardisoSolver:
+    """
+    Stateful interface to the MKL PARDISO solver.
+
+    The reordering and symbolic factorization (PARDISO phase 11) depend only on the
+    sparsity pattern of the system matrix. Within a step, the pattern is constant across
+    Newton iterations, so the symbolic factorization is computed once and reused for
+    every subsequent solve with the same pattern; each solve then only performs the
+    numerical factorization (phase 22) and back substitution (phase 33). A change of
+    the sparsity pattern is detected automatically and triggers a re-analysis.
+
+    The number of threads is controlled by MKL via the usual environment variables
+    (``OMP_NUM_THREADS`` / ``MKL_NUM_THREADS``).
+    """
+
+    cdef long pt[64]      # internal solver memory pointer
+    cdef int iparm[64]    # parameters for pardiso
+    cdef int mtype        # real and unsymmetric matrix
+    cdef int maxfct
+    cdef int mnum
+    cdef int msglvl
+    cdef int rows
+    cdef bint hasSymbolicFactorization
+
+    # the pattern arrays of the currently analyzed matrix (0-based, for change detection)
+    cdef object currentIndices
+    cdef object currentIndptr
+    # persistent 1-based copies handed to pardiso (fortran indexing)
+    cdef int[::1] indicesFortran
+    cdef int[::1] indptrFortran
+
+    def __cinit__(self):
+        self.mtype = 11
+        self.maxfct = 1
+        self.mnum = 1
+        self.msglvl = 0
+        self.hasSymbolicFactorization = False
+        self.currentIndices = None
+        self.currentIndptr = None
+
+    def __dealloc__(self):
+        self._releaseMemory()
+
+    cdef void _releaseMemory(self):
+        """Release all internal PARDISO memory (phase -1)."""
+        cdef int phase = -1
+        cdef int error = 0
+        cdef int nRhs = 1
+        cdef int idum = 0
+        cdef double ddum = 0
+
+        if not self.hasSymbolicFactorization:
+            return
+
+        pardiso(self.pt, &self.maxfct, &self.mnum, &self.mtype, &phase,
+                &self.rows, &ddum, &idum, &idum, &idum, &nRhs,
+                &self.iparm[0], &self.msglvl, &ddum, &ddum, &error)
+
+        self.hasSymbolicFactorization = False
+        self.currentIndices = None
+        self.currentIndptr = None
+
+    cdef bint _hasSamePattern(self, A):
+        """Check if the sparsity pattern of A matches the analyzed one."""
+        if not self.hasSymbolicFactorization:
+            return False
+
+        indices = A.indices
+        indptr = A.indptr
+
+        # fast path: in-place assembly reuses the identical pattern arrays
+        if indices is self.currentIndices and indptr is self.currentIndptr:
+            return True
+
+        if (
+            A.shape[0] == self.rows
+            and np.array_equal(indptr, self.currentIndptr)
+            and np.array_equal(indices, self.currentIndices)
+        ):
+            # same pattern in new arrays; adopt them for future identity checks
+            self.currentIndices = indices
+            self.currentIndptr = indptr
+            return True
+
+        return False
+
+    cdef int _analyze(self, A) except -1:
+        """Run reordering and symbolic factorization (phase 11) for the pattern of A."""
+        cdef int phase = 11
+        cdef int error = 0
+        cdef int nRhs = 1
+        cdef int idum = 0
+        cdef double ddum = 0
+
+        self._releaseMemory()
+
+        self.rows = A.shape[0]
+        self.indicesFortran = A.indices + 1  # pardiso uses fortran 1-based indexing
+        self.indptrFortran = A.indptr + 1    # pardiso uses fortran 1-based indexing
+
+        pardisoinit(self.pt, &self.mtype, &self.iparm[0])
+
+        cdef double[::1] data = A.data
+
+        pardiso(self.pt, &self.maxfct, &self.mnum, &self.mtype, &phase,
+                &self.rows, &data[0], &self.indptrFortran[0], &self.indicesFortran[0], &idum, &nRhs,
+                &self.iparm[0], &self.msglvl, &ddum, &ddum, &error)
+
+        if error != 0:
+            self._releaseMemory()
+            raise RuntimeError("PARDISO analysis failed with error code {:}".format(error))
+
+        self.hasSymbolicFactorization = True
+        self.currentIndices = A.indices
+        self.currentIndptr = A.indptr
+
+        return 0
+
+    def __call__(self, A, b):
+        """
+        Solve a linear system of equations.
+
+        Parameters
+        ----------
+        A : csr_matrix
+            The system matrix.
+        b : ndarray
+            The right-hand side vector (or matrix for multiple right-hand sides).
+
+        Returns
+        -------
+        ndarray
+            The solution vector.
+        """
+
+        if not self._hasSamePattern(A):
+            self._analyze(A)
+
+        cdef double[::1] data = A.data
+
+        # prepare rhs and solution
+        cdef double[::1, :] b_ = np.asfortranarray(b.reshape((self.rows, -1)))
+        cdef int nRhs = b_.shape[1]
+        cdef double[::1, :] x = np.zeros_like(b_, order="F")
+
+        cdef int phase
+        cdef int error = 0
+        cdef int idum = 0
+        cdef double ddum = 0
+
+        # numerical factorization
+        phase = 22
+        pardiso(self.pt, &self.maxfct, &self.mnum, &self.mtype, &phase,
+                &self.rows, &data[0], &self.indptrFortran[0], &self.indicesFortran[0], &idum, &nRhs,
+                &self.iparm[0], &self.msglvl, &ddum, &ddum, &error)
+
+        if error == 0:
+            # back substitution and iterative refinement
+            phase = 33
+            pardiso(self.pt, &self.maxfct, &self.mnum, &self.mtype, &phase,
+                    &self.rows, &data[0], &self.indptrFortran[0], &self.indicesFortran[0], &idum, &nRhs,
+                    &self.iparm[0], &self.msglvl, &b_[0, 0], &x[0, 0], &error)
+
+        if error != 0:
+            # signal failure via NaNs; the nonlinear solvers translate this into a cutback
+            np.asarray(x).fill(np.nan)
+
+        return np.reshape(x, b.shape)
+
+
 def pardisoSolve(A, b):
     """
     Solve a linear system of equations using the Intel MKL PARDISO solver.
+
+    One-shot convenience wrapper around :class:`PardisoSolver`; for repeated solves
+    with an identical sparsity pattern, use a persistent :class:`PardisoSolver`
+    instance to reuse the symbolic factorization.
 
     Parameters
     ----------
@@ -85,68 +257,4 @@ def pardisoSolve(A, b):
         The solution vector.
     """
 
-    # prepare system matrix
-    cdef int rows = A.shape[0]
-    cdef double[::1] data = A.data
-    cdef int[::1] indices = A.indices + 1  # pardiso uses fortran 1-based indexing
-    cdef int[::1] indptr = A.indptr + 1    # pardiso uses fortran 1-based indexing
-
-    # prepare rhs
-    cdef double[::1, :] b_ = b.reshape((rows, -1), order="F")
-    cdef int nRhs = b_.shape[1]
-
-    # prepare solution vector
-    cdef double[::1, :] x = np.zeros_like(b_, order="F")
-
-    # initialize solver
-    cdef long int *pt[64]  # internal solver memory pointer
-    cdef int[64] iparm     # parameters for pardiso
-    cdef int mtype = 11    # real and unsymmetric matrix
-    cdef int error = 0     # initialize error flag
-
-    # initialie pardiso solver
-    pardisoinit(pt, &mtype, &iparm[0])
-
-    # set parameters
-    cdef int maxfct = 5   # maximum number of numerical factorizations
-    cdef int mnum = 1     # which factorization to use
-    cdef int msglvl = 0   # print statistical information
-    cdef int[::1] perm    # permutation vector
-    cdef double ddum = 0  # dummy variable
-
-    # set custom parameters for pardiso
-    iparm = setParameter(iparm, 0, 0)  # use default values
-
-    omp_num_threads = os.environ.get("OMP_NUM_THREADS")
-    threads = int(omp_num_threads) if omp_num_threads is not None else -1
-
-    # set parameters for solver
-    # usage: setParameter(iparm, idx, value)
-    iparm = setParameter(iparm, 2, threads)  # set number of threads
-
-    cdef int phase
-    # reordering and symbolic factorization
-    phase = 11
-    pardiso(pt, &maxfct, &mnum, &mtype, &phase,
-            &rows, &data[0], &indptr[0], &indices[0], &perm[0], &nRhs,
-            iparm, &msglvl, &ddum, &ddum, &error)
-
-    # numerical factorization
-    phase = 22
-    pardiso(pt, &maxfct, &mnum, &mtype, &phase,
-            &rows, &data[0], &indptr[0], &indices[0], &perm[0], &nRhs,
-            &iparm[0], &msglvl, &ddum, &ddum, &error)
-
-    # back substitution and iterative refinement
-    phase = 33
-    pardiso(pt, &maxfct, &mnum, &mtype, &phase,
-            &rows, &data[0], &indptr[0], &indices[0], &perm[0], &nRhs,
-            &iparm[0], &msglvl, &b_[0, 0], &x[0, 0], &error)
-
-    # free the memory
-    phase = -1
-    pardiso(pt, &maxfct, &mnum, &mtype, &phase,
-            &rows, &data[0], &indptr[0], &indices[0], &perm[0], &nRhs,
-            &iparm[0], &msglvl, &b_[0, 0], &x[0, 0], &error)
-
-    return np.reshape(x, b.shape)
+    return PardisoSolver()(A, b)

--- a/edelweissfe/linsolve/pardiso/pardiso.pyx
+++ b/edelweissfe/linsolve/pardiso/pardiso.pyx
@@ -188,6 +188,10 @@ cdef class PardisoSolver:
             raise ValueError(
                 "matrix has {:} nonzeros, exceeding the 32-bit PARDISO interface".format(A.nnz)
             )
+        if A.shape[0] > np.iinfo(np.intc).max:
+            raise ValueError(
+                "matrix has {:} rows, exceeding the 32-bit PARDISO interface".format(A.shape[0])
+            )
 
         self.rows = A.shape[0]
         # pardiso uses fortran 1-based indexing; scipy may use int64 index arrays for

--- a/edelweissfe/linsolve/pardiso/pardiso.pyx
+++ b/edelweissfe/linsolve/pardiso/pardiso.pyx
@@ -71,11 +71,21 @@ cdef class PardisoSolver:
     Stateful interface to the MKL PARDISO solver.
 
     The reordering and symbolic factorization (PARDISO phase 11) depend only on the
-    sparsity pattern of the system matrix. Within a step, the pattern is constant across
-    Newton iterations, so the symbolic factorization is computed once and reused for
-    every subsequent solve with the same pattern; each solve then only performs the
-    numerical factorization (phase 22) and back substitution (phase 33). A change of
-    the sparsity pattern is detected automatically and triggers a re-analysis.
+    sparsity pattern of the system matrix, so it is in principle safe to compute it
+    once and reuse it for every subsequent solve with the same pattern (each solve
+    then only performs the numerical factorization, phase 22, and back substitution,
+    phase 33). A change of the sparsity pattern is detected automatically and
+    triggers a re-analysis.
+
+    However, this reuse has been observed to silently produce numerically wrong
+    results (with PARDISO reporting ``error == 0``, so the usual NaN-based failure
+    check does not catch it) for some coupled-DOF problems where the numerically
+    relevant pivot structure shifts substantially between solves even though the
+    sparsity pattern itself does not change. Reuse is therefore **disabled by
+    default**; pass ``reuseSymbolicFactorization=True`` to opt in once this has been
+    verified safe for the problem at hand (e.g. by comparing against one-shot
+    solves on the actual matrix sequence). With reuse disabled, this class behaves
+    like the free function :func:`pardisoSolve`, just as a reusable object.
 
     The number of threads is controlled by MKL via the usual environment variables
     (``OMP_NUM_THREADS`` / ``MKL_NUM_THREADS``).
@@ -90,6 +100,7 @@ cdef class PardisoSolver:
     cdef int rows
     cdef bint ptIsActive  # pt may hold PARDISO-internal allocations (phase -1 required)
     cdef bint hasSymbolicFactorization
+    cdef bint reuseSymbolicFactorization
 
     # the pattern arrays of the currently analyzed matrix (0-based, for change detection)
     cdef object currentIndices
@@ -98,7 +109,7 @@ cdef class PardisoSolver:
     cdef int[::1] indicesFortran
     cdef int[::1] indptrFortran
 
-    def __cinit__(self):
+    def __cinit__(self, reuseSymbolicFactorization=False):
         cdef int i
 
         self.mtype = 11
@@ -107,6 +118,7 @@ cdef class PardisoSolver:
         self.msglvl = 0
         self.ptIsActive = False
         self.hasSymbolicFactorization = False
+        self.reuseSymbolicFactorization = reuseSymbolicFactorization
         self.currentIndices = None
         self.currentIndptr = None
 
@@ -219,7 +231,9 @@ cdef class PardisoSolver:
             The solution vector.
         """
 
-        if not self._hasSamePattern(A):
+        # if reuse is disabled, always re-analyze; _hasSamePattern is not even
+        # evaluated in that case (see the class docstring for why reuse is opt-in)
+        if not self.reuseSymbolicFactorization or not self._hasSamePattern(A):
             self._analyze(A)
 
         cdef double[::1] data = A.data
@@ -252,6 +266,24 @@ cdef class PardisoSolver:
             np.asarray(x).fill(np.nan)
 
         return np.reshape(x, b.shape)
+
+    def invalidate(self):
+        """
+        Force a fresh reordering and symbolic factorization (PARDISO phase 11) on the
+        next solve, regardless of what the array-identity / ``array_equal`` pattern
+        check in :meth:`_hasSamePattern` would otherwise conclude.
+
+        Call this whenever the caller knows the sparsity pattern may have changed
+        through a channel the automatic detection might not reliably catch — e.g. a
+        solver that rebuilds its CSR generator whenever the active domain changes,
+        which can happen more often than once per analysis step (unlike EdelweissFE's
+        own static-mesh usage, where a fresh instance is constructed once per step and
+        the pattern is never actually re-checked against a real change).
+
+        No-op when ``reuseSymbolicFactorization`` is False, since every solve already
+        re-analyzes unconditionally in that case.
+        """
+        self.hasSymbolicFactorization = False
 
 
 def pardisoSolve(A, b):

--- a/edelweissfe/numerics/dofvector.py
+++ b/edelweissfe/numerics/dofvector.py
@@ -46,27 +46,25 @@ class DofVector(np.ndarray):
     def __new__(cls, nDof: int, entitiesInDofVector: dict):
         obj = np.zeros(nDof, dtype=float).view(cls)
         obj.entitiesInDofVector = entitiesInDofVector
+        obj._scatterTemplate = None
         return obj
 
     def __array_finalize__(self, obj):
         if obj is None:
             return
         self.entitiesInDofVector = getattr(obj, "entitiesInDofVector", None)
+        self._scatterTemplate = getattr(obj, "_scatterTemplate", None)
 
     def __getitem__(self, key):
-        if isinstance(key, (int, slice, np.ndarray, list)):
-            return super().__getitem__(key)
-
+        # try the entity lookup first; it is by far the most common access pattern.
+        # Non-entity keys (ints, slices, arrays, lists) miss the dictionary cheaply
+        # via KeyError/TypeError and fall through to plain ndarray indexing.
         try:
             return super().__getitem__(self.entitiesInDofVector[key])
         except (KeyError, TypeError):
             return super().__getitem__(key)
 
     def __setitem__(self, key, value):
-        if isinstance(key, (int, slice, np.ndarray, list)):
-            super().__setitem__(key, value)
-            return
-
         try:
             super().__setitem__(self.entitiesInDofVector[key], value)
         except (KeyError, TypeError):
@@ -94,9 +92,17 @@ class DofVector(np.ndarray):
         """
         Create a scatter vector for ALL entities in this DofVector.
 
+        The underlying layout (entity lookup map and scatter indices) is computed once
+        and cached, so repeated calls (e.g. once per Newton iteration) only allocate
+        the zero-initialized data buffer.
+
         Returns
         -------
         ScatterDofVector
             The ScatterDofVector.
         """
-        return edelweissfe.numerics.scatterdofvector.ScatterDofVector(self.entitiesInDofVector, self.size)
+        if self._scatterTemplate is None:
+            self._scatterTemplate = edelweissfe.numerics.scatterdofvector.ScatterDofVectorTemplate(
+                self.entitiesInDofVector, self.size
+            )
+        return edelweissfe.numerics.scatterdofvector.ScatterDofVector(self._scatterTemplate)

--- a/edelweissfe/numerics/dofvector.py
+++ b/edelweissfe/numerics/dofvector.py
@@ -101,7 +101,10 @@ class DofVector(np.ndarray):
         ScatterDofVector
             The ScatterDofVector.
         """
-        if self._scatterTemplate is None:
+        # __array_finalize__ inherits _scatterTemplate across views/copies, but a view's
+        # entitiesInDofVector may later be replaced by a different mapping (e.g. copy()
+        # assigns a fresh dict) - guard against reusing a template built for a stale one.
+        if self._scatterTemplate is None or self._scatterTemplate.entitiesInDofVector is not self.entitiesInDofVector:
             self._scatterTemplate = edelweissfe.numerics.scatterdofvector.ScatterDofVectorTemplate(
                 self.entitiesInDofVector, self.size
             )

--- a/edelweissfe/numerics/parallelizationutilities.py
+++ b/edelweissfe/numerics/parallelizationutilities.py
@@ -27,8 +27,10 @@
 import concurrent.futures
 import os
 import sys
+import threading
 
 _threadPools = {}
+_threadPoolsLock = threading.Lock()
 
 
 def isFreeThreadingSupported() -> bool:
@@ -55,6 +57,7 @@ def getNumberOfThreads() -> int:
     EdelweissFE has a built-in mechanism to determine the number of threads to be used for parallel computations.
     It checks if the environment variable `OMP_NUM_THREADS` is set. If it is
     and can be converted to an integer, that value is used. If not, the function falls back to using a default value of 1.
+    The result is clamped to at least 1, since a `ThreadPoolExecutor` requires at least one worker.
 
     Returns:
         int: Number of threads to be used.
@@ -66,7 +69,7 @@ def getNumberOfThreads() -> int:
     except ValueError:
         num_workers = 1
 
-    return num_workers
+    return max(1, num_workers)
 
 
 def getThreadPool(numThreads: int) -> concurrent.futures.ThreadPoolExecutor:
@@ -79,7 +82,7 @@ def getThreadPool(numThreads: int) -> concurrent.futures.ThreadPoolExecutor:
     Parameters
     ----------
     numThreads
-        The number of worker threads.
+        The number of worker threads. Clamped to at least 1.
 
     Returns
     -------
@@ -87,8 +90,13 @@ def getThreadPool(numThreads: int) -> concurrent.futures.ThreadPoolExecutor:
         The persistent thread pool.
     """
 
+    numThreads = max(1, numThreads)
+
     pool = _threadPools.get(numThreads)
     if pool is None:
-        pool = _threadPools[numThreads] = concurrent.futures.ThreadPoolExecutor(max_workers=numThreads)
+        with _threadPoolsLock:
+            pool = _threadPools.get(numThreads)
+            if pool is None:
+                pool = _threadPools[numThreads] = concurrent.futures.ThreadPoolExecutor(max_workers=numThreads)
 
     return pool

--- a/edelweissfe/numerics/parallelizationutilities.py
+++ b/edelweissfe/numerics/parallelizationutilities.py
@@ -24,8 +24,11 @@
 #  the top level directory of EdelweissFE.
 #  ---------------------------------------------------------------------
 
+import concurrent.futures
 import os
 import sys
+
+_threadPools = {}
 
 
 def isFreeThreadingSupported() -> bool:
@@ -64,3 +67,28 @@ def getNumberOfThreads() -> int:
         num_workers = 1
 
     return num_workers
+
+
+def getThreadPool(numThreads: int) -> concurrent.futures.ThreadPoolExecutor:
+    """Get a persistent thread pool with the requested number of worker threads.
+
+    Pools are created lazily and reused for the lifetime of the process. This avoids
+    the cost of spawning and joining worker threads for every parallel computation,
+    which the solvers request once per Newton iteration.
+
+    Parameters
+    ----------
+    numThreads
+        The number of worker threads.
+
+    Returns
+    -------
+    concurrent.futures.ThreadPoolExecutor
+        The persistent thread pool.
+    """
+
+    pool = _threadPools.get(numThreads)
+    if pool is None:
+        pool = _threadPools[numThreads] = concurrent.futures.ThreadPoolExecutor(max_workers=numThreads)
+
+    return pool

--- a/edelweissfe/numerics/scatterdofvector.py
+++ b/edelweissfe/numerics/scatterdofvector.py
@@ -31,10 +31,14 @@ import numpy as np
 import edelweissfe.numerics.dofvector
 
 
-class ScatterDofVector(np.ndarray):
+class ScatterDofVectorTemplate:
     """
-    A Scatter Vector that stores data for entities contiguously.
-    Includes a fast lookup map to support random access by Entity.
+    The precomputed, immutable layout of a :class:`ScatterDofVector`:
+    the entity lookup map and the gather/scatter index array.
+
+    Since the layout only depends on the entities and their indices in the DofVector,
+    it can be computed once and shared by all scatter vectors of the same equation
+    system, e.g. across Newton iterations.
 
     Parameters
     ----------
@@ -44,29 +48,49 @@ class ScatterDofVector(np.ndarray):
         The total number of degrees of freedom.
     """
 
-    def __new__(cls, entitiesInDofVector: dict, nDof: int):
-        entities = list(entitiesInDofVector.keys())
-
+    def __init__(self, entitiesInDofVector: dict, nDof: int):
         sizes = np.array([len(v) for v in entitiesInDofVector.values()], dtype=np.intc)
-        total_size = np.sum(sizes)
+        total_size = int(np.sum(sizes))
 
-        obj = np.zeros(total_size, dtype=float).view(cls)
-
-        offsets = np.zeros(len(entities) + 1, dtype=np.intc)
+        offsets = np.zeros(len(entitiesInDofVector) + 1, dtype=np.intc)
         np.cumsum(sizes, out=offsets[1:])
 
-        obj._offset_map = dict(zip(entities, offsets))
+        # map entity -> (offset, size), such that a single lookup suffices for access
+        self.offsetMap = {
+            entity: (offset, size) for entity, offset, size in zip(entitiesInDofVector.keys(), offsets, sizes)
+        }
 
-        obj._global_indices = np.empty(total_size, dtype=np.int32)
+        self.globalIndices = np.empty(total_size, dtype=np.int32)
 
         current_offset = 0
         for entity, indices in entitiesInDofVector.items():
             n = len(indices)
-            obj._global_indices[current_offset : current_offset + n] = indices
+            self.globalIndices[current_offset : current_offset + n] = indices
             current_offset += n
 
-        obj._entitiesInDofVector = entitiesInDofVector
-        obj._nDof = nDof
+        self.entitiesInDofVector = entitiesInDofVector
+        self.nDof = nDof
+        self.totalSize = total_size
+
+
+class ScatterDofVector(np.ndarray):
+    """
+    A Scatter Vector that stores data for entities contiguously.
+    Includes a fast lookup map to support random access by Entity.
+
+    Parameters
+    ----------
+    template
+        The precomputed layout of the scatter vector.
+    """
+
+    def __new__(cls, template: ScatterDofVectorTemplate):
+        obj = np.zeros(template.totalSize, dtype=float).view(cls)
+
+        obj._offset_map = template.offsetMap
+        obj._global_indices = template.globalIndices
+        obj._entitiesInDofVector = template.entitiesInDofVector
+        obj._nDof = template.nDof
 
         return obj
 
@@ -87,13 +111,10 @@ class ScatterDofVector(np.ndarray):
         key
             The key for indexing, either an entity or an integer index.
         """
-        if isinstance(key, (int, slice, np.ndarray, list)):
-            return super().__getitem__(key)
-
+        # try the entity lookup first; it is by far the most common access pattern
         try:
-            val = self._offset_map[key]
-            size = len(self._entitiesInDofVector[key])
-            return super().__getitem__(slice(val, val + size))
+            offset, size = self._offset_map[key]
+            return super().__getitem__(slice(offset, offset + size))
         except (KeyError, TypeError):
             return super().__getitem__(key)
 
@@ -108,7 +129,9 @@ class ScatterDofVector(np.ndarray):
             If True, assemble the absolute values.
         """
         data = np.abs(self) if absolute else self
-        np.add.at(targetDofVector, self._global_indices, data)
+        # bincount performs the duplicate-resolving scatter-add in a single pass,
+        # considerably faster than the unbuffered np.add.at
+        targetDofVector += np.bincount(self._global_indices, weights=data, minlength=self._nDof)
 
     def toDofVector(self, absolute=False) -> "DofVector":  # noqa: F821
         """Create a new DofVector from this scatter vector.

--- a/edelweissfe/numerics/vijsystemmatrix.py
+++ b/edelweissfe/numerics/vijsystemmatrix.py
@@ -68,9 +68,9 @@ class VIJSystemMatrix(np.ndarray):
         self.entitiesInVIJ = getattr(obj, "entitiesInVIJ", None)
 
     def __getitem__(self, key):
-        if isinstance(key, (int, slice, np.ndarray, list)):
-            return super().__getitem__(key)
-
+        # try the entity lookup first; it is by far the most common access pattern.
+        # Non-entity keys (ints, slices, arrays, lists) miss the dictionary cheaply
+        # via KeyError/TypeError and fall through to plain ndarray indexing.
         try:
             # Entity Lookup
             idxInVIJ = self.entitiesInVIJ[key]

--- a/edelweissfe/sections/planerandomthickness.py
+++ b/edelweissfe/sections/planerandomthickness.py
@@ -1,4 +1,3 @@
-import gstools
 import numpy as np
 
 from edelweissfe.utils.math import createFunction
@@ -7,6 +6,12 @@ from edelweissfe.utils.misc import convertLinesToStringDictionary
 
 class Section:
     def __init__(self, name, options, materialName, t, model):
+        # gstools is imported lazily: its Cython extension does not declare
+        # free-threading support, so importing it re-enables the GIL process-wide
+        # and would disable thread-parallel computations for ALL simulations,
+        # even those not using random fields.
+        import gstools
+
         self.options = convertLinesToStringDictionary(options)
         options = self.options
 

--- a/edelweissfe/sections/planerandomthickness.py
+++ b/edelweissfe/sections/planerandomthickness.py
@@ -10,7 +10,13 @@ class Section:
         # free-threading support, so importing it re-enables the GIL process-wide
         # and would disable thread-parallel computations for ALL simulations,
         # even those not using random fields.
-        import gstools
+        try:
+            import gstools
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError(
+                "the 'planeRandomThickness' section requires the 'gstools' package "
+                "(install via 'pip install gstools' or 'mamba install -c conda-forge gstools')"
+            ) from e
 
         self.options = convertLinesToStringDictionary(options)
         options = self.options

--- a/edelweissfe/solvers/base/dirichlet.pyx
+++ b/edelweissfe/solvers/base/dirichlet.pyx
@@ -85,6 +85,8 @@ def applyDirichletK(nls, K: csr_matrix, dirichlets: Iterable) -> csr_matrix:
             else:
                 data[j] = 0.0  # Off-diagonal
 
-    # clean up the matrix
-    K.eliminate_zeros()
+    # NOTE: the zeroed off-diagonals are deliberately kept as explicitly stored zeros.
+    # This preserves the sparsity pattern, so the assembled CSR matrix can be updated
+    # in place across iterations and direct solvers can reuse their symbolic
+    # factorization. (Direct solvers handle stored zeros without issues.)
     return K

--- a/edelweissfe/solvers/base/nonlinearsolverbase.py
+++ b/edelweissfe/solvers/base/nonlinearsolverbase.py
@@ -55,6 +55,10 @@ class NonlinearSolverBase(ABC):
 
     SolverSpecificOptions = {}
 
+    #: Cache for :meth:`findDirichletIndices`; lazily initialized since not all
+    #: subclasses call ``super().__init__()``.
+    _dirichletIndicesCache = None
+
     def __init__(self, jobInfo, journal, **kwargs):
         pass
 
@@ -244,7 +248,11 @@ class NonlinearSolverBase(ABC):
         csr_matrix
             The system matrix in compressed sparse row format.
         """
-        KCsr = self.csrGenerator.updateCSR(K)
+        # In-place update: the returned matrix is the generator's internal CSR matrix.
+        # This is safe since no solver retains it across iterations, and the subsequent
+        # Dirichlet application only modifies values (the pattern is preserved), which
+        # are fully overwritten again on the next update.
+        KCsr = self.csrGenerator.updateInPlace(K)
         return KCsr
 
     def computeSpatialAveragedFluxes(self, F: DofVector) -> dict[str, float]:
@@ -405,6 +413,20 @@ class NonlinearSolverBase(ABC):
         field = dirichlet.field
         components = dirichlet.components
 
-        fieldIndices = self.theDofManager.idcsOfFieldsOnNodeSetsInDofVector[field][nSet]
+        # The result is fully determined by the boundary condition, its (mutable)
+        # components, and the current DofManager, so it is memoized. It is requested
+        # multiple times per Newton iteration (residual zeroing and system matrix
+        # modification), but only changes when the equation system is rebuilt or the
+        # boundary condition is updated between steps.
+        cache = self._dirichletIndicesCache
+        if cache is None:
+            cache = self._dirichletIndicesCache = {}
 
-        return fieldIndices.reshape((len(nSet), -1))[:, components].flatten()
+        key = (dirichlet, self.theDofManager, tuple(components))
+        indices = cache.get(key)
+        if indices is None:
+            fieldIndices = self.theDofManager.idcsOfFieldsOnNodeSetsInDofVector[field][nSet]
+
+            indices = cache[key] = fieldIndices.reshape((len(nSet), -1))[:, components].flatten()
+
+        return indices

--- a/edelweissfe/solvers/base/parallelelementcomputation.py
+++ b/edelweissfe/solvers/base/parallelelementcomputation.py
@@ -27,13 +27,12 @@
 #  the top level directory of EdelweissFE.
 #  ---------------------------------------------------------------------
 
-import concurrent.futures
 import itertools
 
-from edelweissfe.elements.base.baseelement import BaseElement
 from edelweissfe.numerics.dofmanager import DofVector, VIJSystemMatrix
 from edelweissfe.numerics.parallelizationutilities import (
     getNumberOfThreads,
+    getThreadPool,
     isFreeThreadingSupported,
 )
 from edelweissfe.timesteppers.timestep import TimeStep
@@ -79,17 +78,23 @@ def computeElementsInParallel(
     time = timeStep.totalTime
     dT = timeStep.timeIncrement
 
-    def computeElementsWorker(element: BaseElement):
-        Pe = scatter_P[element]
-        Ue = Un1[element]
-        dUe = dU[element]
-        Ke = K[element]
-        element.computeKernels(Ke, Pe, Ue, dUe, time, dT)
+    # Process a CHUNK of elements per task, not just one, to keep the per-task
+    # dispatch overhead negligible compared to the actual element computation.
+    def computeElementsWorker(elementChunk):
+        for element in elementChunk:
+            Pe = scatter_P[element]
+            Ue = Un1[element]
+            dUe = dU[element]
+            Ke = K[element]
+            element.computeKernels(Ke, Pe, Ue, dUe, time, dT)
 
     numThreads = getNumberOfThreads() if isFreeThreadingSupported() else 1
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=numThreads) as executor:
-        list(executor.map(computeElementsWorker, elements.values()))
+    chunkSize = max(1, len(elements) // (numThreads * 4))
+    chunks = chunked_iterable(elements.values(), chunkSize)
+
+    executor = getThreadPool(numThreads)
+    list(executor.map(computeElementsWorker, chunks))
 
     scatter_P.assembleInto(P)
     scatter_P.assembleInto(F, absolute=True)
@@ -134,11 +139,9 @@ def computeElementsInParallelForExplicit(
     chunk_size = max(1, len(elements) // (numThreads * 4))
     chunks = chunked_iterable(elements.values(), chunk_size)
 
-    psi_total = 0.0
-    with concurrent.futures.ThreadPoolExecutor(max_workers=numThreads) as executor:
-        # map returns the chunk_psi from each worker
-        results = executor.map(compute_chunk, chunks)
-        psi_total = sum(results)
+    executor = getThreadPool(numThreads)
+    # map returns the chunk_psi from each worker
+    psi_total = sum(executor.map(compute_chunk, chunks))
 
     scatter_P.assembleInto(P)
 

--- a/edelweissfe/solvers/base/parallelelementcomputation.py
+++ b/edelweissfe/solvers/base/parallelelementcomputation.py
@@ -90,11 +90,15 @@ def computeElementsInParallel(
 
     numThreads = getNumberOfThreads() if isFreeThreadingSupported() else 1
 
-    chunkSize = max(1, len(elements) // (numThreads * 4))
-    chunks = chunked_iterable(elements.values(), chunkSize)
+    if numThreads == 1:
+        # avoid ThreadPoolExecutor/task dispatch overhead when there is nothing to parallelize
+        computeElementsWorker(elements.values())
+    else:
+        chunkSize = max(1, len(elements) // (numThreads * 4))
+        chunks = chunked_iterable(elements.values(), chunkSize)
 
-    executor = getThreadPool(numThreads)
-    list(executor.map(computeElementsWorker, chunks))
+        executor = getThreadPool(numThreads)
+        list(executor.map(computeElementsWorker, chunks))
 
     scatter_P.assembleInto(P)
     scatter_P.assembleInto(F, absolute=True)
@@ -135,13 +139,17 @@ def computeElementsInParallelForExplicit(
 
     numThreads = getNumberOfThreads() if isFreeThreadingSupported() else 1
 
-    # Target ~1000 to 5000 elements per chunk depending on mesh size
-    chunk_size = max(1, len(elements) // (numThreads * 4))
-    chunks = chunked_iterable(elements.values(), chunk_size)
+    if numThreads == 1:
+        # avoid ThreadPoolExecutor/task dispatch overhead when there is nothing to parallelize
+        psi_total = compute_chunk(elements.values())
+    else:
+        # Target ~1000 to 5000 elements per chunk depending on mesh size
+        chunk_size = max(1, len(elements) // (numThreads * 4))
+        chunks = chunked_iterable(elements.values(), chunk_size)
 
-    executor = getThreadPool(numThreads)
-    # map returns the chunk_psi from each worker
-    psi_total = sum(executor.map(compute_chunk, chunks))
+        executor = getThreadPool(numThreads)
+        # map returns the chunk_psi from each worker
+        psi_total = sum(executor.map(compute_chunk, chunks))
 
     scatter_P.assembleInto(P)
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,10 @@ directives = {
     "wraparound": False,
     "nonecheck": False,
     "initializedcheck": False,
+    # Declare all extensions safe for free-threading CPython builds. Without this,
+    # importing any of them silently re-enables the GIL process-wide, which disables
+    # the thread-parallel element loops of the parallel solvers.
+    "freethreading_compatible": True,
 }
 
 default_install_prefix = sys.prefix
@@ -74,6 +78,7 @@ extensions = [
         library_dirs=[join(marmot_dir, "lib")],
         runtime_library_dirs=[join(marmot_dir, "lib")],
         language="c++",
+        extra_compile_args=["-O3", "-march=native"],
     )
 ]
 
@@ -114,6 +119,7 @@ extensions += [
         ["edelweissfe/utils/elementresultcollector.pyx"],
         include_dirs=[numpy.get_include()],
         language="c++",
+        extra_compile_args=["-O3", "-march=native"],
     )
 ]
 
@@ -147,6 +153,8 @@ extensions += [
         include_dirs=[numpy.get_include()],
         language="c++",
         extra_compile_args=[
+            "-O3",
+            "-march=native",
             "-fopenmp",
             "-Wno-maybe-uninitialized",
         ],


### PR DESCRIPTION
Some improvements for performance:

1. perf(build) — freethreading_compatible directive for all Cython extensions (the GIL now stays off without PYTHON_GIL=0), plus -O3 -march=native for the marmotelement, resultcollector, and dirichlet extensions.
2. perf(linsolve) — stateful PardisoSolver class: symbolic factorization runs once per sparsity pattern (auto re-analysis on pattern change), only numeric factorization + back-substitution per solve. Also fixed along the way: the dead thread-count iparm code, silent error swallowing (now returns NaNs so the solvers cut back), and a latent multi-RHS crash with C-contiguous right-hand sides (the arc-length path).
3. perf(solvers) — dropped the per-iteration eliminate_zeros() CSR rebuild (stored zeros keep the pattern intact, which is also what lets Pardiso reuse its factorization), switched assembly to updateInPlace (no O(nnz) copy per iteration), memoized findDirichletIndices.
4. perf(numerics) — chunked implicit element loop (was one Python task per element), persistent thread pools, cached ScatterDofVectorTemplate (the scatter layout was rebuilt in Python every iteration), np.bincount instead of np.add.at, entity-first __getitem__ fast paths.
5. perf: import gstools lazily — a discovery during verification: gstools was imported at startup via the input-language registration and its extension re-enables the GIL process-wide, which would have silently negated fix #1 for every simulation. It's now imported only when a random field / random thickness section is actually used.