### PR TITLE
refactor: Step managment system

### DIFF
--- a/edelweissfe/config/steps.py
+++ b/edelweissfe/config/steps.py
@@ -25,40 +25,48 @@
 #  The full text of the license can be found in the file LICENSE.md at
 #  the top level directory of EdelweissFE.
 #  ---------------------------------------------------------------------
-# Created on Mon Jan 23 13:05:53 2017
-
-# @author: Matthias Neuner
 """
-Step actions define actions run during a simulation.
-They are defined within a ``*step`` definition, line by line,
-by specifying their ``name`` and a list of ``option=value``, for example
+Steps are defined via the ``*step`` keyword, and the step type is chosen
+via the ``type`` option:
 
 .. code-block:: edelweiss
 
-    *step, solver=mySolver
-    >>dirichlet, name=bottom,   nSet=bottom,   field=displacement, 2=0, 1=0
-    >>dirichlet, name=rightTop, nSet=rightTop, field=displacement, 2=0,
-    >>distributedload, name=dload1, surface=top,  type=pressure, magnitude=10, f(t)=t*2
-    >>distributedload, name=dload2, surface=left, type=pressure, magnitude=50, f(t)=t
+    *step, solver=mySolver, type=adaptive
 """
 
 import importlib
 
+stepLibrary = {
+    "adaptive": ("edelweissfe.steps.adaptivestep", "AdaptiveStep"),
+    "adaptiveForExplicitSimulations": (
+        "edelweissfe.steps.adaptivestepforexplicitsimulations",
+        "AdaptiveStepForExplicitSimulations",
+    ),
+}
 
-def stepActionFactory(name: str) -> type:
-    """Get the class type of the requested step action.
+
+def getStepClassByType(stepType: str) -> type:
+    """Get the class type of the requested step type.
 
     Parameters
     ----------
-    name
-        The name of the step action to load.
+    stepType
+        The type of the step to load (case insensitive).
 
     Returns
     -------
     type
-        The step action class type.
+        The step class type.
     """
 
-    module = importlib.import_module("edelweissfe.stepactions." + name.lower())
+    casefoldedStepLibrary = {key.casefold(): value for key, value in stepLibrary.items()}
 
-    return module.StepAction
+    try:
+        moduleName, className = casefoldedStepLibrary[stepType.casefold()]
+    except KeyError:
+        raise KeyError(
+            f"Step type {stepType} not found in library. Available step types: " + ", ".join(stepLibrary.keys())
+        )
+
+    module = importlib.import_module(moduleName)
+    return getattr(module, className)

--- a/edelweissfe/drivers/inputfiledrivensimulation.py
+++ b/edelweissfe/drivers/inputfiledrivensimulation.py
@@ -165,7 +165,7 @@ def finiteElementSimulation(
     solvers["default"] = defaultSolver(jobInfo, journal)
 
     try:
-        for step in stepManager.dequeueStep(jobInfo, model, fieldOutputController, journal, solvers, outputManagers):
+        for step in stepManager.generateSteps(jobInfo, model, fieldOutputController, journal, solvers, outputManagers):
             tic = getCurrentTime()
             step.solve()
             toc = getCurrentTime()

--- a/edelweissfe/helpers/inputfilehelpers.py
+++ b/edelweissfe/helpers/inputfilehelpers.py
@@ -35,7 +35,6 @@ from edelweissfe.config.solvers import getSolverByName
 from edelweissfe.generators.abqmodelconstructor import AbqModelConstructor
 from edelweissfe.journal.journal import Journal
 from edelweissfe.models.femodel import FEModel
-from edelweissfe.steps.adaptivestep import inputLanguage
 from edelweissfe.steps.stepmanager import (
     StepActionDefinition,
     StepDefinition,
@@ -43,7 +42,7 @@ from edelweissfe.steps.stepmanager import (
 )
 from edelweissfe.utils.caseinsensitivedict import CaseInsensitiveDict
 from edelweissfe.utils.fieldoutput import FieldOutputController
-from edelweissfe.utils.inputfileparser import inputLanguage  # noqa: F811
+from edelweissfe.utils.inputfileparser import inputLanguage
 from edelweissfe.utils.inputlanguage import (
     keywordIdentifier,
     moduleLevelKeywordIdentifier,
@@ -266,33 +265,42 @@ def createStepManagerFromInputFile(inputfile: dict):
     """
     stepManager = StepManager()
 
-    for stepDefinition in inputfile["step"]:
-        stepType = stepDefinition.pop("type")
-        stepActionLines = stepDefinition.pop("moduleOptions")
+    autoNameCounter = 0
 
-        inputFile = stepDefinition.pop("inputfile")  # noqa F841
-        data = stepDefinition.pop("datalines")  # noqa F841
+    for stepOptions in inputfile["step"]:
+        stepType = stepOptions.pop("type")
+        stepActionLines = stepOptions.pop("moduleOptions")
+
+        stepOptions.pop("inputfile")
+        data = stepOptions.pop("datalines")
 
         stepActionDefinitions = []
 
-        module = inputLanguage["step"].getModule(stepType)
-        args, kwargs = module.parseDatalines(data)
+        stepModule = inputLanguage["step"].getModule(stepType)
+        args, kwargs = stepModule.parseDatalines(data)
 
-        stepDefinition.update(kwargs)
+        if args:
+            raise ValueError(
+                f"Unexpected positional options {args} in the datalines of *step; only key=value options are allowed."
+            )
 
-        for module, definitions in stepActionLines.items():
+        stepOptions.update(kwargs)
+
+        for actionModule, definitions in stepActionLines.items():
             for definition in definitions:
-                try:
-                    name = definition.pop("name")
-                except KeyError:
-                    num = 0
-                    for stepDef in stepManager.stepDefinitions:
-                        num += len(stepDef.stepActionDefinitions)
-                    num += len(stepActionDefinitions)
-                    name = f"StepAction-{num}"
-                stepActionDefinitions.append(StepActionDefinition(name, module, definition))
+                # metadata added by the parser, of no relevance for the step actions:
+                definition.pop("inputfile", None)
 
-        stepDefinition = StepDefinition(stepType, stepDefinition, stepActionDefinitions)
+                # unnamed actions are identified by their category (e.g., 'options'
+                # step actions), or get an auto-generated unique name:
+                name = definition.pop("name", None) or definition.get("category")
+                if name is None:
+                    name = f"{actionModule}-{autoNameCounter}"
+                    autoNameCounter += 1
+
+                stepActionDefinitions.append(StepActionDefinition(name, actionModule, definition))
+
+        stepDefinition = StepDefinition(stepType, stepOptions, stepActionDefinitions)
 
         stepManager.enqueueStepDefinition(stepDefinition)
 

--- a/edelweissfe/outputmanagers/ensight.py
+++ b/edelweissfe/outputmanagers/ensight.py
@@ -41,6 +41,7 @@ from edelweissfe.outputmanagers.base.outputmanagerbase import OutputManagerBase
 from edelweissfe.points.node import Node
 from edelweissfe.sets.elementset import ElementSet
 from edelweissfe.sets.nodeset import NodeSet
+from edelweissfe.stepactions.options import getOptionsOfCategory, registerOptionsArg
 from edelweissfe.utils.caseinsensitivedict import CaseInsensitiveDict
 from edelweissfe.utils.fieldoutput import (
     ElementFieldOutput,
@@ -90,15 +91,8 @@ kw.addOptionalArg("transient", "Set transient ensight output.", bool, True)
 documentation = [module]
 
 
-keyword = "step"
-if keyword in inputLanguage:
-    modules = [
-        inputLanguage["step"].getModule("adaptive").getKeyword("options"),
-        inputLanguage["step"].getModule("adaptiveForExplicitSimulations").getKeyword("options"),
-    ]
-    for optionsModule in modules:
-        optionsModule.addOptionalArg("intermediateSaveInterval", "", float, None)
-        optionsModule.addOptionalArg("minDTForOutput", "", float, None)
+registerOptionsArg("intermediateSaveInterval", "Set the intermediate save interval for the Ensight export.", float)
+registerOptionsArg("minDTForOutput", "Set the minimum time between two Ensight exports.", float)
 
 
 def writeCFloat(f, ndarray):
@@ -966,8 +960,8 @@ class OutputManager(OutputManagerBase):
         self.ensightCase.writeGeometryTrendChunk(geometry, geometryTimesetNumber)
 
     def initializeStep(self, step):
-        if self.name in step.actions["options"] or "Ensight" in step.actions["options"]:
-            options = step.actions["options"].get(self.name, False) or step.actions["options"]["Ensight"].options
+        options = getOptionsOfCategory(step.actions, self.name) or getOptionsOfCategory(step.actions, "Ensight")
+        if options:
             self.intermediateSaveInterval = int(options.get("intermediateSaveInterval", self.intermediateSaveInterval))
             self.minDTForOutput = float(options.get("minDTForOutput", self.minDTForOutput))
 

--- a/edelweissfe/solvers/nonlinearexplicitdynamic.py
+++ b/edelweissfe/solvers/nonlinearexplicitdynamic.py
@@ -38,6 +38,7 @@ from edelweissfe.numerics.dofmanager import DofManager, DofVector, VIJSystemMatr
 from edelweissfe.outputmanagers.base.outputmanagerbase import OutputManagerBase
 from edelweissfe.solvers.base.nonlinearsolverbase import NonlinearSolverBase
 from edelweissfe.stepactions.base.stepactionbase import StepActionBase
+from edelweissfe.stepactions.options import getOptionsOfCategory
 from edelweissfe.timesteppers.timestep import TimeStep
 from edelweissfe.utils.exceptions import (
     ConditionalStop,
@@ -148,8 +149,7 @@ class NED(NonlinearSolverBase):
                 "scalar variables",
             ]
 
-        if "NEDSolver" in step.actions["options"].keys():
-            self._updateOptions(step.actions["options"]["NEDSolver"].options, self.journal)
+        self._updateOptions(getOptionsOfCategory(step.actions, "NEDSolver"), self.journal)
 
         # initialize mass and damping matrices
         M = self.theDofManager.constructDofVector()  # initialize lumped mass matrix

--- a/edelweissfe/solvers/nonlinearexplicitstatic.py
+++ b/edelweissfe/solvers/nonlinearexplicitstatic.py
@@ -38,6 +38,7 @@ from edelweissfe.numerics.csrgeneratorv2 import CSRGenerator
 from edelweissfe.numerics.dofmanager import DofManager, DofVector, VIJSystemMatrix
 from edelweissfe.outputmanagers.base.outputmanagerbase import OutputManagerBase
 from edelweissfe.solvers.nonlinearimplicitstatic import NIST
+from edelweissfe.stepactions.options import getOptionsOfCategory, registerOptionsArg
 from edelweissfe.timesteppers.timestep import TimeStep
 from edelweissfe.utils.exceptions import (
     ConditionalStop,
@@ -47,6 +48,10 @@ from edelweissfe.utils.exceptions import (
     StepFailed,
 )
 from edelweissfe.utils.fieldoutput import FieldOutputController
+
+registerOptionsArg("runge-kutta-stages", "The number of Runge-Kutta stages.", int)
+registerOptionsArg("runge-kutta-error-tolerance", "The error tolerance for the Runge-Kutta error control.", float)
+registerOptionsArg("runge-kutta-error-control", "Activate the Runge-Kutta error control (on|off).", str)
 
 
 def getRungeKuttaParameters(rungeKuttaStages: int) -> tuple[dict, dict, dict]:
@@ -229,8 +234,7 @@ class NEST(NIST):
 
         self.computationTimes = createTimingDict()
 
-        _optionsUpdate = step.actions["options"].get("NESTSolver", {})
-        self._updateOptions(_optionsUpdate, self.journal)
+        self._updateOptions(getOptionsOfCategory(step.actions, "NESTSolver"), self.journal)
 
         # get parameters for runge kutta scheme
         self.rkAlpha, self.rkOmega, self.rkLambda = getRungeKuttaParameters(self.options.get("runge-kutta-stages", 2))

--- a/edelweissfe/solvers/nonlinearimplicitstatic.py
+++ b/edelweissfe/solvers/nonlinearimplicitstatic.py
@@ -44,7 +44,7 @@ from edelweissfe.outputmanagers.base.outputmanagerbase import OutputManagerBase
 from edelweissfe.solvers.base.dirichlet import applyDirichletK
 from edelweissfe.solvers.base.nonlinearsolverbase import NonlinearSolverBase
 from edelweissfe.stepactions.base.stepactionbase import StepActionBase
-from edelweissfe.stepactions.options import inputLanguage
+from edelweissfe.stepactions.options import getOptionsOfCategory, registerOptionsArg
 from edelweissfe.timesteppers.timestep import TimeStep
 from edelweissfe.utils.exceptions import (
     ConditionalStop,
@@ -57,13 +57,12 @@ from edelweissfe.utils.exceptions import (
 )
 from edelweissfe.utils.fieldoutput import FieldOutputController
 
-kw = inputLanguage["step"].getModule("adaptive").getKeyword("options")
-kw.addOptionalArg("defaultMaxIter", "", int, 10)
-kw.addOptionalArg("defaultCriticalIter", "", int, 5)
-kw.addOptionalArg("defaultMaxGrowingIter", "", int, 10)
-kw.addOptionalArg("extrapolation", "", str, "linear")
-kw.addOptionalArg("linsolver", "", str, "pardiso")
-kw.addOptionalArg("linsolverConfigFile", "", str, "")
+registerOptionsArg("defaultMaxIter", "The default maximum number of iterations.", int)
+registerOptionsArg("defaultCriticalIter", "The default number of critical iterations.", int)
+registerOptionsArg("defaultMaxGrowingIter", "The default number of allowed residual growths.", int)
+registerOptionsArg("extrapolation", "The extrapolation strategy for new increments (off|linear).", str)
+registerOptionsArg("linsolver", "The linear solver to be used.", str)
+registerOptionsArg("linsolverConfigFile", "A JSON configuration file for the linear solver.", str)
 
 
 class NIST(NonlinearSolverBase):
@@ -154,10 +153,7 @@ class NIST(NonlinearSolverBase):
 
         self.csrGenerator = CSRGenerator(K)
 
-        try:
-            self._updateOptions(step.actions["options"]["NISTSolver"].options, self.journal)
-        except KeyError:
-            pass
+        self._updateOptions(getOptionsOfCategory(step.actions, "NISTSolver"), self.journal)
 
         extrapolation = self.options["extrapolation"]
         linsolverOptions = self.options["linsolverConfigFile"]

--- a/edelweissfe/solvers/nonlinearimplicitstaticparallelarclength.py
+++ b/edelweissfe/solvers/nonlinearimplicitstaticparallelarclength.py
@@ -38,7 +38,7 @@ from edelweissfe.numerics.dofmanager import DofVector, VIJSystemMatrix
 from edelweissfe.outputmanagers.base.outputmanagerbase import OutputManagerBase
 from edelweissfe.solvers.nonlinearimplicitstaticparallel import NISTParallel
 from edelweissfe.stepactions.base.stepactionbase import StepActionBase
-from edelweissfe.stepactions.options import inputLanguage
+from edelweissfe.stepactions.options import getOptionsOfCategory, registerOptionsArg
 from edelweissfe.timesteppers.timestep import TimeStep
 from edelweissfe.utils.exceptions import (
     ConditionalStop,
@@ -48,9 +48,8 @@ from edelweissfe.utils.exceptions import (
 from edelweissfe.utils.fieldoutput import FieldOutputController
 from edelweissfe.utils.math import createModelAccessibleFunction
 
-kw = inputLanguage["step"].getModule("adaptive").getKeyword("options")
-kw.addOptionalArg("arcLengthController", "", str, None)
-kw.addOptionalArg("stopCondition", "", str, None)
+registerOptionsArg("arcLengthController", "The step action module serving as the arc length controller.", str)
+registerOptionsArg("stopCondition", "A model accessible expression defining a conditional stop.", str)
 
 
 class NISTPArcLength(NISTParallel):
@@ -76,29 +75,21 @@ class NISTPArcLength(NISTParallel):
         if "arc length parameter" in model.additionalParameters:
             self.Lambda = model.additionalParameters["arc length parameter"]
 
-        arcLengthControllerOptions = [
-            stepAction
-            for stepAction in step.actions["options"].values()
-            if stepAction.options["category"] == "NISTArcLength"
-        ]
-        if not len(arcLengthControllerOptions) < 2:
-            raise Exception("Too many option definitions.")
+        arcLengthControllerOptions = getOptionsOfCategory(step.actions, "NISTArcLength")
 
-        # arcLengthControllerOptions = step.actions["options"].get("NISTArcLength")
         if arcLengthControllerOptions:
-            arcLengthControllerOptions = arcLengthControllerOptions[0].options
             arcLengthController = arcLengthControllerOptions.get("arcLengthController")
             if arcLengthController:
                 try:
                     arcLengthControllerStepAction = [action for action in step.actions["indirectcontrol"].values()][0]
                     self.arcLengthController = arcLengthControllerStepAction
                     self.dLambda = 0.0
-                except KeyError:
+                except (KeyError, IndexError):
                     self.journal.errorMessage(
                         f'Arc length controller "{arcLengthController}" not found in current step or not configured correctly',
                         self.identification,
                     )
-                    raise KeyError
+                    raise KeyError(f'Arc length controller "{arcLengthController}" not found in current step')
             else:
                 self.journal.message(
                     "No ArcLengthController specified in current step",
@@ -232,8 +223,8 @@ class NISTPArcLength(NISTParallel):
         zeroTimeStep = TimeStep(timeStep.number, 0.0, 0.0, 0.0, 0.0, 0.0)
 
         while True:
-            for geostatic in stepActions["geostatics"]:
-                geostatic.apply()
+            for geostatic in stepActions["geostatic"].values():
+                geostatic.applyAtIterationStart()
 
             U_np[:] = U_n
             U_np += dU
@@ -405,7 +396,7 @@ class NISTPArcLength(NISTParallel):
                 stepAction.applyAtStepEnd(model, stepMagnitude=self.Lambda)
             for stepAction in stepActions["distributedload"].values():
                 stepAction.applyAtStepEnd(model, stepMagnitude=self.Lambda)
-            for stepAction in stepActions["bodeforce"].values():
+            for stepAction in stepActions["bodyforce"].values():
                 stepAction.applyAtStepEnd(model, stepMagnitude=self.Lambda)
 
         return super().applyStepActionsAtStepEnd(model, stepActions)

--- a/edelweissfe/stepactions/base/stepactionbase.py
+++ b/edelweissfe/stepactions/base/stepactionbase.py
@@ -35,8 +35,8 @@ from edelweissfe.utils.fieldoutput import FieldOutputController
 
 
 class StepActionBase(ABC):
-    """This is the abase class for all step actions.
-    User defined step actions can override the methods.
+    """This is the base class for all step actions.
+    User defined step actions must implement the methods.
 
     Parameters
     ----------
@@ -47,9 +47,9 @@ class StepActionBase(ABC):
     jobInfo
         A dictionary containing the information about the job.
     model
-        A dictionary containing the model tree.
+        The model tree.
     fieldOutputController
-        The fieldput controlling object.
+        The field output controlling object.
     journal
         The journal object for logging.
     """
@@ -61,7 +61,6 @@ class StepActionBase(ABC):
         jobInfo: dict,
         model: FEModel,
         fieldOutputController: FieldOutputController,
-        dofmanager,
         journal: Journal,
     ):
         pass
@@ -72,58 +71,49 @@ class StepActionBase(ABC):
         jobInfo: dict,
         model: FEModel,
         fieldOutputController: FieldOutputController,
-        dofmanager,
         journal: Journal,
     ):
         """Is called when an updated definition is present for a new step.
 
         Parameters
         ----------
-        name
-            The name of this step action.
         definition
             A dictionary containing the options for this step action.
         jobInfo
             A dictionary containing the information about the job.
         model
-            A dictionary containing the model tree.
+            The model tree.
         fieldOutputController
-            The fieldput controlling object.
+            The field output controlling object.
         journal
             The journal object for logging.
         """
 
-    def applyAtStepStart(self, model):
+    def applyAtStepStart(self, model: FEModel):
         """Is called when a step starts.
 
         Parameters
         ----------
-        U
-            The current solution vector.
-        P
-            The current reaction force vector.
+        model
+            The current state of the model.
         """
 
-    def applyAtStepEnd(self, model):
+    def applyAtStepEnd(self, model: FEModel):
         """Is called when a step successfully finished.
 
         Parameters
         ----------
-        U
-            The current solution vector.
-        P
-            The current reaction force vector.
+        model
+            The current state of the model.
         """
 
-    def applyAtIncrementStart(self, model, timeStep: TimeStep):
+    def applyAtIncrementStart(self, model: FEModel, timeStep: TimeStep):
         """Is called when a step increment starts.
 
         Parameters
         ----------
-        U_n
-            The current converged solution vector at start of the increment.
-        P
-            The current reaction force vector.
-        increment
-            The defintion of the time increment.
+        model
+            The current state of the model.
+        timeStep
+            The definition of the time increment.
         """

--- a/edelweissfe/stepactions/bodyforce.py
+++ b/edelweissfe/stepactions/bodyforce.py
@@ -33,8 +33,8 @@ import numpy as np
 import sympy as sp
 
 from edelweissfe.stepactions.base.bodyloadbase import BodyLoadBase
-from edelweissfe.steps.adaptivestep import InputLanguage
 from edelweissfe.timesteppers.timestep import TimeStep
+from edelweissfe.utils.inputlanguage import InputLanguage
 
 """
 Simple body force load.
@@ -43,10 +43,9 @@ If not modified in subsequent steps, the load held constant.
 
 
 inputLanguage = InputLanguage()
-modules = [
-    inputLanguage["step"].getModule("adaptive"),
-    inputLanguage["step"].getModule("adaptiveForExplicitSimulations"),
-]
+# Register this step action for all available step types. This requires the step type
+# modules to be imported before the step actions, as done in the input file parser.
+modules = inputLanguage["step"].modules if "step" in inputLanguage else []
 
 documentation = []
 

--- a/edelweissfe/stepactions/changematerialproperty.py
+++ b/edelweissfe/stepactions/changematerialproperty.py
@@ -29,9 +29,9 @@
 import sympy as sp
 
 from edelweissfe.stepactions.base.stepactionbase import StepActionBase
-from edelweissfe.steps.adaptivestep import InputLanguage
 from edelweissfe.timesteppers.timestep import TimeStep
 from edelweissfe.utils.caseinsensitivedict import CaseInsensitiveDict
+from edelweissfe.utils.inputlanguage import InputLanguage
 
 """
 Stepaction to change material properties.
@@ -41,10 +41,9 @@ Stepaction to change material properties.
 
 inputLanguage = InputLanguage()
 
-modules = [
-    inputLanguage["step"].getModule("adaptive"),
-    inputLanguage["step"].getModule("adaptiveForExplicitSimulations"),
-]
+# Register this step action for all available step types. This requires the step type
+# modules to be imported before the step actions, as done in the input file parser.
+modules = inputLanguage["step"].modules if "step" in inputLanguage else []
 
 documentation = []
 

--- a/edelweissfe/stepactions/dirichlet.py
+++ b/edelweissfe/stepactions/dirichlet.py
@@ -34,8 +34,8 @@ import sympy as sp
 
 from edelweissfe.config.phenomena import getFieldSize
 from edelweissfe.stepactions.base.dirichletbase import DirichletBase
-from edelweissfe.steps.adaptivestep import InputLanguage
 from edelweissfe.timesteppers.timestep import TimeStep
+from edelweissfe.utils.inputlanguage import InputLanguage
 
 """
 Standard Dirichlet boundary condition.
@@ -44,57 +44,46 @@ If not modified in subsequent steps, the BC is held constant.
 
 inputLanguage = InputLanguage()
 
-modules = [
-    inputLanguage["step"].getModule("adaptive"),
-    inputLanguage["step"].getModule("adaptiveForExplicitSimulations"),
-]
+# Register this step action for all available step types. This requires the step type
+# modules to be imported before the step actions, as done in the input file parser.
+modules = inputLanguage["step"].modules if "step" in inputLanguage else []
 
 documentation = []
+
+
+def _addPrescriptionArgs(kw):
+    """Register the value prescription arguments, which are shared by the
+    'dirichlet' and 'updateDirichlet' keywords."""
+
+    kw.addOptionalArg("1", "Prescribe first component of field.", float, None)
+    kw.addOptionalArg("2", "Prescribe second component of field.", float, None)
+    kw.addOptionalArg("3", "Prescribe third component of field.", float, None)
+    kw.addOptionalArg("4", "Prescribe fourth component of field.", float, None)
+    kw.addOptionalArg("5", "Prescribe fifth component of field.", float, None)
+    kw.addOptionalArg("6", "Prescribe sixth component of field.", float, None)
+
+    kw.addOptionalArg(
+        "components",
+        "Prescribe values using a numpy ndarray for representation; use 'x' for ignored values.",
+        str,
+        None,
+    )
+    kw.addOptionalArg("analyticalField", "Scales the defined boundary condition", str, None)
+    kw.addOptionalArg("f(t)", "Define an amplitude in the step progress interval [0...1]", str, None)
+
 
 for module in modules:
     kw = module.addOptionalKeyword("dirichlet", "Standard Dirichlet boundary condition.")
     kw.addRequiredArg("name", "Name of the step action.", str)
     kw.addRequiredArg("nSet", "The node set for application of the boundary condition.", str)
     kw.addRequiredArg("field", "Field for which the boundary condition is active.", str)
-
-    kw.addOptionalArg("1", "Prescribe first component of field.", float, None)
-    kw.addOptionalArg("2", "Prescribe second component of field.", float, None)
-    kw.addOptionalArg("3", "Prescribe third component of field.", float, None)
-    kw.addOptionalArg("4", "Prescribe fourth component of field.", float, None)
-    kw.addOptionalArg("5", "Prescribe fifth component of field.", float, None)
-    kw.addOptionalArg("6", "Prescribe sixth component of field.", float, None)
-
-    kw.addOptionalArg(
-        "components",
-        "Prescribe values using a numpy ndarray for representation; use 'x' for ignored values.",
-        str,
-        None,
-    )
-    kw.addOptionalArg("analyticalField", "Scales the defined boundary condition", str, None)
-    kw.addOptionalArg("f(t)", "Define an amplitude in the step progress interval [0...1]", str, None)
+    _addPrescriptionArgs(kw)
 
     documentation.append(kw)
 
     kw = module.addOptionalKeyword("updateDirichlet", "Update a previously defined dirichlet definition.")
     kw.addRequiredArg("name", "Name of the step action to update.", str)
-    # kw.addRequiredArg("nSet", "The node set for application of the boundary condition.", str)
-    # kw.addRequiredArg("field", "Field for which the boundary condition is active.", str)
-
-    kw.addOptionalArg("1", "Prescribe first component of field.", float, None)
-    kw.addOptionalArg("2", "Prescribe second component of field.", float, None)
-    kw.addOptionalArg("3", "Prescribe third component of field.", float, None)
-    kw.addOptionalArg("4", "Prescribe fourth component of field.", float, None)
-    kw.addOptionalArg("5", "Prescribe fifth component of field.", float, None)
-    kw.addOptionalArg("6", "Prescribe sixth component of field.", float, None)
-
-    kw.addOptionalArg(
-        "components",
-        "Prescribe values using a numpy ndarray for representation; use 'x' for ignored values.",
-        str,
-        None,
-    )
-    kw.addOptionalArg("analyticalField", "Scales the defined boundary condition", str, None)
-    kw.addOptionalArg("f(t)", "Define an amplitude in the step progress interval [0...1]", str, None)
+    _addPrescriptionArgs(kw)
 
     documentation.append(kw)
 

--- a/edelweissfe/stepactions/distributedload.py
+++ b/edelweissfe/stepactions/distributedload.py
@@ -33,8 +33,8 @@ import numpy as np
 import sympy as sp
 
 from edelweissfe.stepactions.base.distributedloadbase import DistributedLoadBase
-from edelweissfe.steps.adaptivestep import InputLanguage
 from edelweissfe.timesteppers.timestep import TimeStep
+from edelweissfe.utils.inputlanguage import InputLanguage
 
 """
 Standard distributed load, applied on a surface set.
@@ -43,10 +43,9 @@ If not modified in subsequent steps, the load held constant.
 
 inputLanguage = InputLanguage()
 
-modules = [
-    inputLanguage["step"].getModule("adaptive"),
-    inputLanguage["step"].getModule("adaptiveForExplicitSimulations"),
-]
+# Register this step action for all available step types. This requires the step type
+# modules to be imported before the step actions, as done in the input file parser.
+modules = inputLanguage["step"].modules if "step" in inputLanguage else []
 
 
 documentation = []

--- a/edelweissfe/stepactions/geostatic.py
+++ b/edelweissfe/stepactions/geostatic.py
@@ -37,14 +37,13 @@ Initialize materials to an geostatic stress state
 import numpy as np
 
 from edelweissfe.stepactions.base.stepactionbase import StepActionBase
-from edelweissfe.steps.adaptivestep import InputLanguage
+from edelweissfe.utils.inputlanguage import InputLanguage
 
 inputLanguage = InputLanguage()
 
-modules = [
-    inputLanguage["step"].getModule("adaptive"),
-    inputLanguage["step"].getModule("adaptiveForExplicitSimulations"),
-]
+# Register this step action for all available step types. This requires the step type
+# modules to be imported before the step actions, as done in the input file parser.
+modules = inputLanguage["step"].modules if "step" in inputLanguage else []
 
 documentation = []
 

--- a/edelweissfe/stepactions/indirectcontractioncontrol.py
+++ b/edelweissfe/stepactions/indirectcontractioncontrol.py
@@ -32,8 +32,8 @@
 import numpy as np
 
 from edelweissfe.stepactions.base.stepactionbase import StepActionBase
-from edelweissfe.steps.adaptivestep import InputLanguage
 from edelweissfe.timesteppers.timestep import TimeStep
+from edelweissfe.utils.inputlanguage import InputLanguage
 
 """
 Indirect (displacement) controller for the NISTArcLength solver
@@ -47,10 +47,9 @@ The center is autotically computed from the bounding node coordinates.
 
 inputLanguage = InputLanguage()
 
-modules = [
-    inputLanguage["step"].getModule("adaptive"),
-    inputLanguage["step"].getModule("adaptiveForExplicitSimulations"),
-]
+# Register this step action for all available step types. This requires the step type
+# modules to be imported before the step actions, as done in the input file parser.
+modules = inputLanguage["step"].modules if "step" in inputLanguage else []
 
 documentation = []
 
@@ -76,27 +75,49 @@ class StepAction(StepActionBase):
         self.journal = journal
 
         self.currentL0 = 0.0
+        self._currentL = 0.0
 
         self.L = action["L"]
 
-        self.generateCVectorAndIndices(action, jobInfo, model, fieldOutputController, journal)
+        self.generateCVector(action, jobInfo, model, fieldOutputController, journal)
 
         if action["exportCVector"] is not None:
             np.savetxt(action["exportCVector"] + ".csv", self.cVector)
 
         self.absolute = action["absolute"]
 
-    def computeDDLambda(self, dU, ddU_0, ddU_f, timeStep: TimeStep):
+    def _getIdcsInDofVector(self, dofManager) -> np.ndarray:
+        """Determine the indices of the contraction ring displacements in the dof vector.
+
+        Parameters
+        ----------
+        dofManager
+            The dof manager of the current equation system.
+
+        Returns
+        -------
+        np.ndarray
+            The indices in the dof vector.
+        """
+
+        return np.hstack(
+            [dofManager.idcsOfFieldVariablesInDofVector[n.fields["displacement"]][:2] for n in self.contractionNSet]
+        )
+
+    def computeDDLambda(self, dU, ddU_0, ddU_f, timeStep: TimeStep, dofManager):
+        idcs = self._getIdcsInDofVector(dofManager)
+
         dL = timeStep.stepProgressIncrement * self.L
 
-        ddLambda = (dL - self.cVector.dot(dU[self.idcs] + ddU_0[self.idcs])) / self.cVector.dot(ddU_f[self.idcs])
+        ddLambda = (dL - self.cVector.dot(dU[idcs] + ddU_0[idcs])) / self.cVector.dot(ddU_f[idcs])
         return ddLambda
 
-    def finishIncrement(self, U, dU, dLambda):
-        pass
+    def finishIncrement(self, U, dU, dLambda, timeStep: TimeStep, dofManager):
+        idcs = self._getIdcsInDofVector(dofManager)
+        self._currentL = self.cVector.dot(U[idcs] + dU[idcs])
 
-    def applyAtStepEnd(self, U, P):
-        self.currentL0 = self.cVector.dot(U[self.idcs])
+    def applyAtStepEnd(self, model):
+        self.currentL0 = self._currentL
 
     def updateStepAction(self, action, jobInfo, model, fieldOutputController, journal):
         if self.absolute:
@@ -104,9 +125,9 @@ class StepAction(StepActionBase):
         else:
             self.L = action["L"]
 
-        self.generateCVectorAndIndices(action, jobInfo, model, fieldOutputController, journal)
+        self.generateCVector(action, jobInfo, model, fieldOutputController, journal)
 
-    def generateCVectorAndIndices(self, action, jobInfo, model, fieldOutputController, journal):
+    def generateCVector(self, action, jobInfo, model, fieldOutputController, journal):
         contractionNSet = model.nodeSets[action["contractionNSet"]]
 
         nNodes = len(contractionNSet)
@@ -122,7 +143,6 @@ class StepAction(StepActionBase):
         y_center = 0.5 * (y_max + y_min)
 
         cVector = []
-        idcsInDofVector = []
 
         for n in contractionNSet:
             vec_n_to_center = np.array([x_center - n.coordinates[0], y_center - n.coordinates[1]])
@@ -132,11 +152,9 @@ class StepAction(StepActionBase):
 
             cVector.append(vec_n_to_center_normalized)
 
-            idcsInDofVector.append([n.fields["displacement"][dim] for dim in range(2)])
-
         self.cVector = np.hstack(cVector)
 
         # dividing c vector to make 'average' contraction of ring:
         self.cVector *= 1.0 / nNodes
 
-        self.idcs = np.hstack(idcsInDofVector)
+        self.contractionNSet = contractionNSet

--- a/edelweissfe/stepactions/indirectcontrol.py
+++ b/edelweissfe/stepactions/indirectcontrol.py
@@ -34,8 +34,8 @@ import numpy as np
 from edelweissfe.numerics.dofmanager import DofManager
 from edelweissfe.solvers.nonlinearimplicitstaticparallelarclength import NISTPArcLength
 from edelweissfe.stepactions.base.stepactionbase import StepActionBase
-from edelweissfe.steps.adaptivestep import InputLanguage
 from edelweissfe.timesteppers.timestep import TimeStep
+from edelweissfe.utils.inputlanguage import InputLanguage
 from edelweissfe.utils.math import evalModelAccessibleExpression
 
 """
@@ -45,10 +45,9 @@ Indirect (displacement) controller for the NISTArcLength solver
 
 inputLanguage = InputLanguage()
 
-modules = [
-    inputLanguage["step"].getModule("adaptive"),
-    inputLanguage["step"].getModule("adaptiveForExplicitSimulations"),
-]
+# Register this step action for all available step types. This requires the step type
+# modules to be imported before the step actions, as done in the input file parser.
+modules = inputLanguage["step"].modules if "step" in inputLanguage else []
 
 documentation = []
 

--- a/edelweissfe/stepactions/initializematerial.py
+++ b/edelweissfe/stepactions/initializematerial.py
@@ -35,14 +35,13 @@ Let materials initialize themselves (e.g., state vars depending on material para
 import numpy as np
 
 from edelweissfe.stepactions.base.stepactionbase import StepActionBase
-from edelweissfe.steps.adaptivestep import InputLanguage
+from edelweissfe.utils.inputlanguage import InputLanguage
 
 inputLanguage = InputLanguage()
 
-modules = [
-    inputLanguage["step"].getModule("adaptive"),
-    inputLanguage["step"].getModule("adaptiveForExplicitSimulations"),
-]
+# Register this step action for all available step types. This requires the step type
+# modules to be imported before the step actions, as done in the input file parser.
+modules = inputLanguage["step"].modules if "step" in inputLanguage else []
 
 documentation = []
 

--- a/edelweissfe/stepactions/modelupdate.py
+++ b/edelweissfe/stepactions/modelupdate.py
@@ -30,7 +30,7 @@
 # @author: Matthias Neuner
 
 from edelweissfe.stepactions.base.stepactionbase import StepActionBase
-from edelweissfe.steps.adaptivestep import InputLanguage
+from edelweissfe.utils.inputlanguage import InputLanguage
 from edelweissfe.utils.math import execModelAccessibleExpression
 
 """This step action may be used for updating something in the model at the beginning
@@ -40,10 +40,9 @@ of a step.
 
 inputLanguage = InputLanguage()
 
-modules = [
-    inputLanguage["step"].getModule("adaptive"),
-    inputLanguage["step"].getModule("adaptiveForExplicitSimulations"),
-]
+# Register this step action for all available step types. This requires the step type
+# modules to be imported before the step actions, as done in the input file parser.
+modules = inputLanguage["step"].modules if "step" in inputLanguage else []
 
 documentation = []
 

--- a/edelweissfe/stepactions/nodeforces.py
+++ b/edelweissfe/stepactions/nodeforces.py
@@ -35,8 +35,8 @@ import sympy as sp
 from edelweissfe.config.phenomena import getFieldSize
 from edelweissfe.sets.nodeset import NodeSet
 from edelweissfe.stepactions.base.nodalloadbase import NodalLoadBase
-from edelweissfe.steps.adaptivestep import InputLanguage
 from edelweissfe.timesteppers.timestep import TimeStep
+from edelweissfe.utils.inputlanguage import InputLanguage
 
 """
 Apply node forces on a nSet.
@@ -45,10 +45,9 @@ Apply node forces on a nSet.
 
 inputLanguage = InputLanguage()
 
-modules = [
-    inputLanguage["step"].getModule("adaptive"),
-    inputLanguage["step"].getModule("adaptiveForExplicitSimulations"),
-]
+# Register this step action for all available step types. This requires the step type
+# modules to be imported before the step actions, as done in the input file parser.
+modules = inputLanguage["step"].modules if "step" in inputLanguage else []
 
 documentation = []
 

--- a/edelweissfe/stepactions/options.py
+++ b/edelweissfe/stepactions/options.py
@@ -14,7 +14,6 @@
 #  2017 - today
 #
 #  Matthias Neuner matthias.neuner@uibk.ac.at
-#  Paul Hofer Paul.Hofer@uibk.ac.at
 #
 #  This file is part of EdelweissFE.
 #
@@ -28,19 +27,28 @@
 #  ---------------------------------------------------------------------
 
 """This stepaction serves as a simple case insensitive container for
-storing step options for various modules.
+storing step options for various modules, grouped by a category, e.g.,
+
+.. code-block:: edelweiss
+
+    *step, solver=mySolver
+    >>options, category=NISTSolver, extrapolation=linear
+
+Consumers (e.g., solvers and output managers) declare their available options
+via :func:`registerOptionsArg`, and retrieve the options defined for their
+category via :func:`getOptionsOfCategory`.
 """
 
 from edelweissfe.stepactions.base.stepactionbase import StepActionBase
-from edelweissfe.steps.adaptivestep import InputLanguage
 from edelweissfe.utils.caseinsensitivedict import CaseInsensitiveDict
+from edelweissfe.utils.inputlanguage import InputLanguage
+from edelweissfe.utils.misc import strCaseCmp
 
 inputLanguage = InputLanguage()
 
-modules = [
-    inputLanguage["step"].getModule("adaptive"),
-    inputLanguage["step"].getModule("adaptiveForExplicitSimulations"),
-]
+# Register this step action for all available step types. This requires the step type
+# modules to be imported before the step actions, as done in the input file parser.
+modules = inputLanguage["step"].modules if "step" in inputLanguage else []
 
 documentation = []
 
@@ -54,7 +62,67 @@ for module in modules:
     documentation.append(kw)
 
 
+def registerOptionsArg(name: str, description: str, dataType: type):
+    """Register an available option on the ``options`` keyword of all step types.
+
+    The default value is always None, which marks the option as not specified by
+    the user; :func:`getOptionsOfCategory` strips unspecified options, such that
+    consumers receive only the options which were actually defined in the input file.
+
+    Parameters
+    ----------
+    name
+        The name of the option.
+    description
+        The description of the option.
+    dataType
+        The data type of the option.
+    """
+
+    if "step" not in inputLanguage:
+        return
+
+    for stepModule in inputLanguage["step"].modules:
+        stepModule.getKeyword("options").addOptionalArg(name, description, dataType, None)
+
+
+def getOptionsOfCategory(stepActions, category: str) -> CaseInsensitiveDict:
+    """Collect the options of a given category defined via ``options`` step actions.
+
+    Parameters
+    ----------
+    stepActions
+        The collection of step actions, grouped by step action module.
+    category
+        The requested option category.
+
+    Returns
+    -------
+    CaseInsensitiveDict
+        The options specified by the user for this category. Empty if no ``options``
+        step action of this category is present.
+    """
+
+    matches = [action for action in stepActions["options"].values() if strCaseCmp(action.options["category"], category)]
+
+    if len(matches) > 1:
+        raise ValueError(f"Multiple 'options' step action definitions for category {category}.")
+
+    if not matches:
+        return CaseInsensitiveDict()
+
+    return CaseInsensitiveDict(
+        {
+            key: value
+            for key, value in matches[0].options.items()
+            if value is not None and not strCaseCmp(key, "category")
+        }
+    )
+
+
 class StepAction(StepActionBase):
+    """A case insensitive container for storing step options of a category."""
+
     def __init__(self, name, options, jobInfo, model, fieldOutputController, journal):
         self.name = name
         self.options = CaseInsensitiveDict(options)
@@ -69,7 +137,7 @@ class StepAction(StepActionBase):
 
     def __getitem__(self, *args):
         """wrapper method for CaseInsensitiveDict"""
-        self.options.__getitem__(*args)
+        return self.options.__getitem__(*args)
 
     def __setitem__(self, *args):
         """wrapper method for CaseInsensitiveDict"""

--- a/edelweissfe/stepactions/setfield.py
+++ b/edelweissfe/stepactions/setfield.py
@@ -34,7 +34,7 @@ import numpy as np
 from edelweissfe.stepactions.base.stepactionbase import StepActionBase
 
 # from edelweissfe.utils.inputlanguage import InputLanguage
-from edelweissfe.steps.adaptivestep import InputLanguage
+from edelweissfe.utils.inputlanguage import InputLanguage
 
 """
 Set a field (via fieldOutput) to a predefined value.
@@ -42,10 +42,9 @@ Set a field (via fieldOutput) to a predefined value.
 
 inputLanguage = InputLanguage()
 
-modules = [
-    inputLanguage["step"].getModule("adaptive"),
-    inputLanguage["step"].getModule("adaptiveForExplicitSimulations"),
-]
+# Register this step action for all available step types. This requires the step type
+# modules to be imported before the step actions, as done in the input file parser.
+modules = inputLanguage["step"].modules if "step" in inputLanguage else []
 
 documentation = []
 

--- a/edelweissfe/stepactions/setinitialconditions.py
+++ b/edelweissfe/stepactions/setinitialconditions.py
@@ -35,14 +35,13 @@ Pass initial conditions to elements.
 import numpy as np
 
 from edelweissfe.stepactions.base.stepactionbase import StepActionBase
-from edelweissfe.steps.adaptivestep import InputLanguage
+from edelweissfe.utils.inputlanguage import InputLanguage
 
 inputLanguage = InputLanguage()
 
-modules = [
-    inputLanguage["step"].getModule("adaptive"),
-    inputLanguage["step"].getModule("adaptiveForExplicitSimulations"),
-]
+# Register this step action for all available step types. This requires the step type
+# modules to be imported before the step actions, as done in the input file parser.
+modules = inputLanguage["step"].modules if "step" in inputLanguage else []
 
 documentation = []
 

--- a/edelweissfe/steps/adaptivestep.py
+++ b/edelweissfe/steps/adaptivestep.py
@@ -26,20 +26,19 @@
 #  the top level directory of EdelweissFE.
 #  ---------------------------------------------------------------------
 
-from edelweissfe.journal.journal import Journal
-from edelweissfe.models.femodel import FEModel
-from edelweissfe.steps.base.stepbase import StepBase
+from edelweissfe.steps.base.stepbase import (
+    StepBase,
+    addIncrementationOptionsToModule,
+    getModuleArgNames,
+)
 from edelweissfe.timesteppers.adaptivetimestepper import AdaptiveTimeStepper
-from edelweissfe.timesteppers.timestep import TimeStep
-from edelweissfe.utils.caseinsensitivedict import CaseInsensitiveDict
-from edelweissfe.utils.fieldoutput import FieldOutputController
 from edelweissfe.utils.inputlanguage import InputLanguage, Module
 from edelweissfe.utils.misc import (
     caseInsensitiveKwargsChecker,
     castKwargsValuesAndAddDefaults,
 )
 
-module = Module("adaptive", "A standard adaptive incremental step to be used in nonlinear simulations.")
+module = Module("adaptive", "An adaptive incremental step for nonlinear simulations with implicit time integration.")
 
 inputLanguage = InputLanguage()
 
@@ -47,26 +46,9 @@ keyword = "step"
 if keyword in inputLanguage:
     inputLanguage[keyword].addModule(module)
 
+addIncrementationOptionsToModule(module)
 
-kw = module.addOptionalArg("stepLength", "The durcation of the step.", float, 1.0)
-kw = module.addOptionalArg("startInc", "The initial fraction of the step to be computed.", float, 1.0)
-kw = module.addOptionalArg("maxInc", "The maximal fraction of the step to be computed.", float, 1.0)
-kw = module.addOptionalArg("minInc", "The minimal fraction of the step to be computed.", float, 1e-4)
-kw = module.addOptionalArg("maxNumInc", "The maximal number of increments allowed.", int, 1000)
-kw = module.addOptionalArg("maxIter", "The maximal number of iterations allowed.", int, 10)
-kw = module.addOptionalArg(
-    "criticalIter", "The number of critical iterations after which the next increment is reduced.", int, 5
-)
-kw = module.addOptionalArg("maxGrowIter", "The number of residual growths before the increment is discarded.", int, 10)
-kw = module.addOptionalArg(
-    "cutbackFactor", "Factor by which the increment size is reduced if no convergence was achieved.", float, 0.25
-)
-
-required = [kw.name for kw in module.requiredArgs]
-required += [kw.name for kw in module.requiredKeywords]
-
-optional = [kw.name for kw in module.optionalArgs]
-optional += [kw.name for kw in module.optionalKeywords]
+required, optional = getModuleArgNames(module)
 
 
 class AdaptiveStep(StepBase):
@@ -76,81 +58,16 @@ class AdaptiveStep(StepBase):
 
     @caseInsensitiveKwargsChecker(required, optional)
     @castKwargsValuesAndAddDefaults(module)
-    def __init__(
-        self,
-        number: int,
-        model: FEModel,
-        fieldOutputController: FieldOutputController,
-        journal: Journal,
-        jobInfo: dict,
-        solver,
-        outputManagers: list,
-        stepActions: dict,
-        **kwargs,
-    ):
-        kwargs = CaseInsensitiveDict(kwargs)
-        self.number = number  #: The (unique) number of the step.
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-        self.model = model
-        self.fieldOutputController = fieldOutputController
-        self.journal = journal
-        self.solver = solver
-        self.outputManagers = outputManagers
-
-        self.length = kwargs.get("stepLength", 1.0)  #: The durcation of the step.
-        self.startIncrementSize = kwargs["startInc"]
-        self.maxIncrementSize = kwargs["maxInc"]
-        self.minIncrementSize = kwargs["minInc"]
-        self.maxNumberIncrements = kwargs["maxNumInc"]
-        self.maxIter = kwargs["maxIter"]
-        self.criticalIter = kwargs["criticalIter"]
-        self.maxGrowIter = kwargs["maxGrowIter"]
-        self.cutbackFactor = kwargs["cutbackFactor"]
-
-        self.incrementGenerator = AdaptiveTimeStepper(
-            model.time,
+    def _createTimeStepper(self) -> AdaptiveTimeStepper:
+        return AdaptiveTimeStepper(
+            self.model.time,
             self.length,
             self.startIncrementSize,
             self.maxIncrementSize,
             self.minIncrementSize,
             self.maxNumberIncrements,
-            journal,
+            self.journal,
         )
-
-        self.actions = stepActions
-
-    def solve(
-        self,
-    ):
-        model = self.model
-        fieldOutputController = self.fieldOutputController
-        journal = self.journal
-        outputManagers = self.outputManagers
-
-        try:
-            for modelUpdate in self.actions["modelupdate"].values():
-                model = modelUpdate.updateModel(model, fieldOutputController, journal)
-
-            fieldOutputController.initializeStep(self)
-            for manager in outputManagers:
-                manager.initializeStep(self)
-
-            self.solver.solveStep(self, model, fieldOutputController, outputManagers)
-
-        finally:
-            fieldOutputController.finalizeStep()
-            for manager in outputManagers:
-                manager.finalizeStep()
-
-    def getTimeStep(
-        self,
-    ) -> TimeStep:
-        return self.incrementGenerator.generateTimeStep()
-
-    def discardAndChangeIncrement(self, cutbackFactor: float):
-        return self.incrementGenerator.discardAndChangeIncrement(cutbackFactor)
-
-    def preventIncrementIncrease(
-        self,
-    ):
-        return self.incrementGenerator.preventIncrementIncrease()

--- a/edelweissfe/steps/adaptivestepforexplicitsimulations.py
+++ b/edelweissfe/steps/adaptivestepforexplicitsimulations.py
@@ -26,13 +26,12 @@
 #  the top level directory of EdelweissFE.
 #  ---------------------------------------------------------------------
 
-from edelweissfe.journal.journal import Journal
-from edelweissfe.models.femodel import FEModel
-from edelweissfe.steps.base.stepbase import StepBase
+from edelweissfe.steps.base.stepbase import (
+    StepBase,
+    addIncrementationOptionsToModule,
+    getModuleArgNames,
+)
 from edelweissfe.timesteppers.simpletimestepper import SimpleTimeStepper
-from edelweissfe.timesteppers.timestep import TimeStep
-from edelweissfe.utils.caseinsensitivedict import CaseInsensitiveDict
-from edelweissfe.utils.fieldoutput import FieldOutputController
 from edelweissfe.utils.inputlanguage import InputLanguage, Module
 from edelweissfe.utils.misc import (
     caseInsensitiveKwargsChecker,
@@ -40,7 +39,8 @@ from edelweissfe.utils.misc import (
 )
 
 module = Module(
-    "adaptiveForExplicitSimulations", "A standard adaptive incremental step to be used in nonlinear simulations."
+    "adaptiveForExplicitSimulations",
+    "An adaptive incremental step for nonlinear simulations with explicit time integration.",
 )
 
 inputLanguage = InputLanguage()
@@ -49,25 +49,9 @@ keyword = "step"
 if keyword in inputLanguage:
     inputLanguage[keyword].addModule(module)
 
-kw = module.addOptionalArg("stepLength", "The durcation of the step.", float, 1.0)
-kw = module.addOptionalArg("startInc", "The initial fraction of the step to be computed.", float, 1.0)
-kw = module.addOptionalArg("maxInc", "The maximal fraction of the step to be computed.", float, 1.0)
-kw = module.addOptionalArg("minInc", "The minimal fraction of the step to be computed.", float, 1e-4)
-kw = module.addOptionalArg("maxNumInc", "The maximal number of increments allowed.", int, 1000)
-kw = module.addOptionalArg("maxIter", "The maximal number of iterations allowed.", int, 10)
-kw = module.addOptionalArg(
-    "criticalIter", "The number of critical iterations after which the next increment is reduced.", int, 5
-)
-kw = module.addOptionalArg("maxGrowIter", "The number of residual growths before the increment is discarded.", int, 10)
-kw = module.addOptionalArg(
-    "cutbackFactor", "Factor by which the increment size is reduced if no convergence was achieved.", float, 0.25
-)
+addIncrementationOptionsToModule(module)
 
-required = [kw.name for kw in module.requiredArgs]
-required += [kw.name for kw in module.requiredKeywords]
-
-optional = [kw.name for kw in module.optionalArgs]
-optional += [kw.name for kw in module.optionalKeywords]
+required, optional = getModuleArgNames(module)
 
 
 class AdaptiveStepForExplicitSimulations(StepBase):
@@ -77,82 +61,16 @@ class AdaptiveStepForExplicitSimulations(StepBase):
 
     @caseInsensitiveKwargsChecker(required, optional)
     @castKwargsValuesAndAddDefaults(module)
-    def __init__(
-        self,
-        number: int,
-        model: FEModel,
-        fieldOutputController: FieldOutputController,
-        journal: Journal,
-        jobInfo: dict,
-        solver,
-        outputManagers: list,
-        stepActions: dict,
-        **kwargs,
-    ):
-        kwargs = CaseInsensitiveDict(kwargs)
-        self.number = number  #: The (unique) number of the step.
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-        self.model = model
-        self.fieldOutputController = fieldOutputController
-        self.journal = journal
-        self.solver = solver
-        self.outputManagers = outputManagers
-
-        self.length = kwargs.get("stepLength", 1.0)  #: The durcation of the step.
-        self.startIncrementSize = kwargs["startInc"]
-        self.maxIncrementSize = kwargs["maxInc"]
-        self.minIncrementSize = kwargs["minInc"]
-        self.maxNumberIncrements = kwargs["maxNumInc"]
-        self.maxIter = kwargs["maxIter"]
-        self.criticalIter = kwargs["criticalIter"]
-        self.maxGrowIter = kwargs["maxGrowIter"]
-        self.cutbackFactor = kwargs["cutbackFactor"]
-
-        self.incrementGenerator = SimpleTimeStepper(
-            model.time,
+    def _createTimeStepper(self) -> SimpleTimeStepper:
+        return SimpleTimeStepper(
+            self.model.time,
             self.length,
             self.startIncrementSize,
             self.maxIncrementSize,
             self.minIncrementSize,
             self.maxNumberIncrements,
-            journal,
+            self.journal,
         )
-
-        self.actions = stepActions
-
-    def solve(
-        self,
-    ):
-        model = self.model
-        fieldOutputController = self.fieldOutputController
-        journal = self.journal
-        outputManagers = self.outputManagers
-
-        try:
-            for modelUpdate in self.actions["modelupdate"].values():
-                model = modelUpdate.updateModel(model, fieldOutputController, journal)
-
-            fieldOutputController.initializeStep(self)
-            for manager in outputManagers:
-                manager.initializeStep(self)
-
-            self.solver.solveStep(self, model, fieldOutputController, outputManagers)
-
-        finally:
-            fieldOutputController.finalizeStep()
-            for manager in outputManagers:
-                manager.finalizeStep()
-
-    def getTimeStep(self, enforcedTimeIncrement=None) -> TimeStep:
-        return self.incrementGenerator.generateTimeStep(enforcedTimeIncrement=enforcedTimeIncrement)
-
-    def discardAndChangeIncrement(self, cutbackFactor: float):
-        return self.incrementGenerator.discardAndChangeIncrement(cutbackFactor)
-
-    def changeIncrementSize(self, scaleFactor: float):
-        return self.incrementGenerator.changeIncrementSize(scaleFactor)
-
-    def preventIncrementIncrease(
-        self,
-    ):
-        return self.incrementGenerator.preventIncrementIncrease()

--- a/edelweissfe/steps/base/stepbase.py
+++ b/edelweissfe/steps/base/stepbase.py
@@ -29,21 +29,77 @@
 have a distinct (physical) runtime, and may contain multiple StepActions.
 Subsequent Steps inherit StepActions, and they may be updated."""
 
+from abc import ABC, abstractmethod
+
 from edelweissfe.journal.journal import Journal
 from edelweissfe.models.femodel import FEModel
+from edelweissfe.timesteppers.base.timestepperbase import TimeStepperBase
+from edelweissfe.timesteppers.timestep import TimeStep
+from edelweissfe.utils.caseinsensitivedict import CaseInsensitiveDict
 from edelweissfe.utils.fieldoutput import FieldOutputController
+from edelweissfe.utils.inputlanguage import Module
 
 
-class StepBase:
+def addIncrementationOptionsToModule(module: Module):
+    """Register the standard incrementation options, which are common to all step types,
+    for the given input language module.
+
+    Parameters
+    ----------
+    module
+        The input language module describing the step type.
     """
-    This is a simulation step.
 
-    It has a specific runtime, and it holds StepActions to executed.
+    module.addOptionalArg("stepLength", "The duration of the step.", float, 1.0)
+    module.addOptionalArg("startInc", "The initial fraction of the step to be computed.", float, 1.0)
+    module.addOptionalArg("maxInc", "The maximal fraction of the step to be computed.", float, 1.0)
+    module.addOptionalArg("minInc", "The minimal fraction of the step to be computed.", float, 1e-4)
+    module.addOptionalArg("maxNumInc", "The maximal number of increments allowed.", int, 1000)
+    module.addOptionalArg("maxIter", "The maximal number of iterations allowed.", int, 10)
+    module.addOptionalArg(
+        "criticalIter", "The number of critical iterations after which the next increment is reduced.", int, 5
+    )
+    module.addOptionalArg("maxGrowIter", "The number of residual growths before the increment is discarded.", int, 10)
+    module.addOptionalArg(
+        "cutbackFactor", "Factor by which the increment size is reduced if no convergence was achieved.", float, 0.25
+    )
+
+
+def getModuleArgNames(module: Module) -> tuple[list[str], list[str]]:
+    """Collect the required and optional argument names of an input language module,
+    e.g., for use with the kwargs checking decorators.
+
+    Parameters
+    ----------
+    module
+        The input language module describing the step type.
+
+    Returns
+    -------
+    tuple[list[str], list[str]]
+        The lists of required and optional argument names.
+    """
+
+    required = [arg.name for arg in module.requiredArgs]
+    required += [kw.name for kw in module.requiredKeywords]
+
+    optional = [arg.name for arg in module.optionalArgs]
+    optional += [kw.name for kw in module.optionalKeywords]
+
+    return required, optional
+
+
+class StepBase(ABC):
+    """Base class for simulation steps.
+
+    A step has a specific runtime, holds the StepActions to be executed,
+    and delegates the incrementation to a time stepper, which is created by the
+    concrete step type.
 
     Parameters
     ----------
     number
-        The number of this step. For information purposes only.
+        The (unique) number of this step.
     model
         The current state of the model.
     fieldOutputController
@@ -51,15 +107,15 @@ class StepBase:
     journal
         The Journal instance for logging purposes.
     jobInfo
-        Additional information about the job
-    solvers
-        The instances of solvers available to this step.
+        Additional information about the job.
+    solver
+        The solver instance to be used for this step.
     outputManagers
         The OutputManagers used.
     stepActions
-        The collection of actions for this step.
+        The collection of actions for this step, grouped by action type.
     **kwargs
-        Additional options for the step.
+        The options for this step.
     """
 
     def __init__(
@@ -74,19 +130,101 @@ class StepBase:
         stepActions: dict,
         **kwargs,
     ):
-        pass
+        kwargs = CaseInsensitiveDict(kwargs)
 
-    def solve(
-        self,
-    ) -> FEModel:
-        """
-        Let a step be solved.
+        self.number = number  #: The (unique) number of the step.
+        self.model = model
+        self.fieldOutputController = fieldOutputController
+        self.journal = journal
+        self.solver = solver
+        self.outputManagers = outputManagers
+        self.actions = stepActions
 
-        Parameters
-        ----------
+        self.length = kwargs["stepLength"]  #: The duration of the step.
+        self.startIncrementSize = kwargs["startInc"]
+        self.maxIncrementSize = kwargs["maxInc"]
+        self.minIncrementSize = kwargs["minInc"]
+        self.maxNumberIncrements = kwargs["maxNumInc"]
+        self.maxIter = kwargs["maxIter"]
+        self.criticalIter = kwargs["criticalIter"]
+        self.maxGrowIter = kwargs["maxGrowIter"]
+        self.cutbackFactor = kwargs["cutbackFactor"]
+
+        self.timeStepper = self._createTimeStepper()
+
+    @abstractmethod
+    def _createTimeStepper(self) -> TimeStepperBase:
+        """Create the time stepper for this step type.
 
         Returns
         -------
-        FEModel
-            The updated model.
+        TimeStepperBase
+            The time stepper controlling the incrementation of this step.
         """
+
+    def solve(self):
+        """Let this step be solved by its solver, including the surrounding
+        bookkeeping of field outputs and output managers."""
+
+        model = self.model
+        fieldOutputController = self.fieldOutputController
+        journal = self.journal
+        outputManagers = self.outputManagers
+
+        try:
+            for modelUpdate in self.actions["modelupdate"].values():
+                model = modelUpdate.updateModel(model, fieldOutputController, journal)
+
+            fieldOutputController.initializeStep(self)
+            for manager in outputManagers:
+                manager.initializeStep(self)
+
+            self.solver.solveStep(self, model, fieldOutputController, outputManagers)
+
+        finally:
+            fieldOutputController.finalizeStep()
+            for manager in outputManagers:
+                manager.finalizeStep()
+
+    def getTimeStep(self, enforcedTimeIncrement: float = None) -> TimeStep:
+        """Generate the sequence of time steps for this step.
+
+        Parameters
+        ----------
+        enforcedTimeIncrement
+            If given, enforce this time increment size (if supported by the time stepper).
+
+        Returns
+        -------
+        TimeStep
+            The generated time steps (generator).
+        """
+
+        return self.timeStepper.generateTimeStep(enforcedTimeIncrement=enforcedTimeIncrement)
+
+    def discardAndChangeIncrement(self, cutbackFactor: float):
+        """Discard the current increment and modify the increment size by a given scale factor.
+
+        Parameters
+        ----------
+        cutbackFactor
+            The factor for scaling based on the discarded increment.
+        """
+
+        return self.timeStepper.discardAndChangeIncrement(cutbackFactor)
+
+    def changeIncrementSize(self, scaleFactor: float):
+        """Modify the size of the next increment by a given scale factor.
+
+        Parameters
+        ----------
+        scaleFactor
+            The factor for scaling based on the current increment.
+        """
+
+        return self.timeStepper.changeIncrementSize(scaleFactor)
+
+    def preventIncrementIncrease(self):
+        """Prevent an automatic increase of the increment size for the next increment."""
+
+        return self.timeStepper.preventIncrementIncrease()

--- a/edelweissfe/steps/stepmanager.py
+++ b/edelweissfe/steps/stepmanager.py
@@ -26,22 +26,31 @@
 #  the top level directory of EdelweissFE.
 #  ---------------------------------------------------------------------
 
+import importlib.util
 import textwrap
-from collections import defaultdict
 
 from edelweissfe.config.stepactions import stepActionFactory
+from edelweissfe.config.steps import getStepClassByType
 from edelweissfe.journal.journal import Journal
 from edelweissfe.models.femodel import FEModel
-from edelweissfe.steps.adaptivestep import AdaptiveStep
-from edelweissfe.steps.adaptivestepforexplicitsimulations import (
-    AdaptiveStepForExplicitSimulations,
-)
 from edelweissfe.steps.base.stepbase import StepBase
+from edelweissfe.utils.caseinsensitivedict import CaseInsensitiveDict
 from edelweissfe.utils.fieldoutput import FieldOutputController
-from edelweissfe.utils.misc import strCaseCmp
 
 
 class StepActionDefinition:
+    """A step action definition, as parsed from the input file.
+
+    Parameters
+    ----------
+    name
+        The name of the step action.
+    module
+        The step action module (type), e.g., 'dirichlet'.
+    kwargs
+        The options defining the step action.
+    """
+
     def __init__(self, name: str, module: str, kwargs: dict):
         self.name = name
         self.module = module
@@ -49,6 +58,18 @@ class StepActionDefinition:
 
 
 class StepDefinition:
+    """A step definition, as parsed from the input file.
+
+    Parameters
+    ----------
+    stepType
+        The type of the step, e.g., 'adaptive'.
+    stepOptions
+        The options defining the step.
+    stepActionDefinitions
+        The list of StepActionDefinitions for this step.
+    """
+
     def __init__(
         self,
         stepType: str,
@@ -60,15 +81,49 @@ class StepDefinition:
         self.stepActionDefinitions = stepActionDefinitions
 
 
-class StepManager:
-    """This manager for convenience parses all step defintions for the simulation
-    and calls the respective modules, which generate (or update) StepActions based on
-    computed results, model info and job information.
+class StepActionCollection:
+    """A collection of step actions, grouped by step action module (type).
 
-    Parameters
-    ----------
-    inputfile
-        The inputfile containing the step defintions.
+    Accessing a valid step action module without any defined actions yields an
+    empty dictionary, whereas accessing an unknown step action module raises a
+    KeyError. This ensures that typos in step action module names fail loudly
+    instead of being silently treated as empty collections.
+    """
+
+    def __init__(self):
+        self._actionsPerModule = dict()
+
+    def __getitem__(self, module: str) -> dict:
+        module = module.lower()
+
+        if module not in self._actionsPerModule:
+            if importlib.util.find_spec("edelweissfe.stepactions." + module) is None:
+                raise KeyError(f"'{module}' is not a known step action module")
+            self._actionsPerModule[module] = dict()
+
+        return self._actionsPerModule[module]
+
+    def __contains__(self, module: str) -> bool:
+        return module.lower() in self._actionsPerModule
+
+    def __iter__(self):
+        return iter(self._actionsPerModule)
+
+    def keys(self):
+        return self._actionsPerModule.keys()
+
+    def values(self):
+        return self._actionsPerModule.values()
+
+    def items(self):
+        return self._actionsPerModule.items()
+
+
+class StepManager:
+    """This manager holds all step definitions of the simulation,
+    and generates the Steps to be solved. Step actions are created
+    (or updated, if already existing from previous steps) based on
+    computed results, model info and job information.
     """
 
     identification = "StepManager"
@@ -76,7 +131,7 @@ class StepManager:
     def __init__(
         self,
     ):
-        self.stepActions = defaultdict(dict)
+        self.stepActions = StepActionCollection()
         self.stepDefinitions = []
 
     def enqueueStepDefinition(self, stepDefinition: StepDefinition):
@@ -89,7 +144,7 @@ class StepManager:
         """
         self.stepDefinitions.append(stepDefinition)
 
-    def dequeueStep(
+    def generateSteps(
         self,
         jobInfo: dict,
         model: FEModel,
@@ -98,7 +153,11 @@ class StepManager:
         solvers: dict,
         outputManagers: list,
     ) -> StepBase:
-        """Dequeue the next step.
+        """Generate the Steps to be solved from the enqueued step definitions.
+
+        The steps are generated lazily, i.e., every step (and its step actions)
+        is created just when it is requested, such that it is created based on
+        the current state of the model.
 
         Parameters
         ----------
@@ -106,21 +165,19 @@ class StepManager:
             A dictionary containing information on the job.
         model
             The model tree.
-        stepActions
-            A dictionary containing already existing step actions.
         fieldOutputController
             The field output controller.
         journal
             The journal instance for logging.
+        solvers
+            The dictionary of available solver instances.
         outputManagers
             The OutputManagers used.
-        stepActions
-            The collection of actions for this step.
 
-        Returns
-        -------
-        StepActionBase
-            The next Step.
+        Yields
+        ------
+        StepBase
+            The next Step to be solved.
         """
 
         def printActionDefinition(intro, options):
@@ -135,20 +192,21 @@ class StepManager:
                 )
 
         for stepNumber, stepDefinition in enumerate(self.stepDefinitions):
-            actionDefinitionsInThisStep = []
+            actionNamesInThisStep = set()
 
-            journal.message(
-                "StepAction definitions:",
-                self.identification,
-                1,
-            )
+            if stepDefinition.stepActionDefinitions:
+                journal.message(
+                    "StepAction definitions:",
+                    self.identification,
+                    1,
+                )
 
             for action in stepDefinition.stepActionDefinitions:
-                if action.name in actionDefinitionsInThisStep:
-                    raise Exception(
-                        "Warning: StepAction {:} has multiple definitions in step {:}".format(action.name, stepNumber)
+                if action.name in actionNamesInThisStep:
+                    raise ValueError(
+                        "StepAction {:} has multiple definitions in step {:}".format(action.name, stepNumber)
                     )
-                actionDefinitionsInThisStep.append(action.name)
+                actionNamesInThisStep.add(action.name)
 
                 if action.name in self.stepActions[action.module]:
                     self.stepActions[action.module][action.name].updateStepAction(
@@ -168,7 +226,8 @@ class StepManager:
                         journal,
                     )
 
-            solverName = stepDefinition.stepOptions.pop("solver")
+            stepOptions = CaseInsensitiveDict(stepDefinition.stepOptions)
+            solverName = stepOptions.pop("solver")
 
             try:
                 solver = solvers[solverName]
@@ -181,27 +240,16 @@ class StepManager:
                     mssg += " Define solver using *solver keyword."
                 raise KeyError(mssg)
 
-            if strCaseCmp(stepDefinition.type, "adaptive"):
-                yield AdaptiveStep(
-                    stepNumber,
-                    model,
-                    fieldOutputController,
-                    journal,
-                    jobInfo,
-                    solver,
-                    outputManagers,
-                    self.stepActions,
-                    **stepDefinition.stepOptions,
-                )
-            elif strCaseCmp(stepDefinition.type, "adaptiveForExplicitSimulations"):
-                yield AdaptiveStepForExplicitSimulations(
-                    stepNumber,
-                    model,
-                    fieldOutputController,
-                    journal,
-                    jobInfo,
-                    solver,
-                    outputManagers,
-                    self.stepActions,
-                    **stepDefinition.stepOptions,
-                )
+            stepClass = getStepClassByType(stepDefinition.type)
+
+            yield stepClass(
+                stepNumber,
+                model,
+                fieldOutputController,
+                journal,
+                jobInfo,
+                solver,
+                outputManagers,
+                self.stepActions,
+                **stepOptions,
+            )

--- a/edelweissfe/timesteppers/adaptivetimestepper.py
+++ b/edelweissfe/timesteppers/adaptivetimestepper.py
@@ -27,11 +27,12 @@
 # Created on Sat Jan  21 12:18:10 2017
 
 from edelweissfe.journal.journal import Journal
+from edelweissfe.timesteppers.base.timestepperbase import TimeStepperBase
 from edelweissfe.timesteppers.timestep import TimeStep
 from edelweissfe.utils.exceptions import ReachedMaxIncrements, ReachedMinIncrementSize
 
 
-class AdaptiveTimeStepper:
+class AdaptiveTimeStepper(TimeStepperBase):
     identification = "AdaptiveTimeStepper"
 
     def __init__(
@@ -94,15 +95,23 @@ class AdaptiveTimeStepper:
     def doesZeroIncrement(self):
         return True
 
-    def generateTimeStep(self) -> TimeStep:
+    def generateTimeStep(self, enforcedTimeIncrement: float = None) -> TimeStep:
         """
         Generate the next increment.
+
+        Parameters
+        ----------
+        enforcedTimeIncrement
+            Not supported by this time stepper; a ValueError is raised if it is given.
 
         Returns
         -------
         TimeStep
             The current time step.
         """
+
+        if enforcedTimeIncrement is not None:
+            raise ValueError("AdaptiveTimeStepper does not support enforced time increments")
 
         while self.finishedStepProgress < (1.0 - 1e-15):
 
@@ -150,6 +159,25 @@ class AdaptiveTimeStepper:
         automatically increasing, e.g. in case of bad convergency."""
 
         self.allowedToIncreasedNext = False
+
+    def changeIncrementSize(self, scaleFactor: float):
+        """Modify the size of the next increment by a given scale factor
+        within the bounds of the minimum and maximum increment size.
+
+        Parameters
+        ----------
+        scaleFactor
+            The factor for scaling based on the current increment.
+        """
+
+        newIncrement = self.increment * scaleFactor
+        self.increment = min(max(newIncrement, self.minIncrement), self.maxIncrement)
+
+        self.journal.message(
+            "New increment size {:}".format(self.increment),
+            self.identification,
+            2,
+        )
 
     def reduceNextIncrement(self, scaleFactor: float):
         """Reduce the increment size for the next increment."""

--- a/edelweissfe/timesteppers/base/timestepperbase.py
+++ b/edelweissfe/timesteppers/base/timestepperbase.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#  ---------------------------------------------------------------------
+#
+#  _____    _      _              _         _____ _____
+# | ____|__| | ___| |_      _____(_)___ ___|  ___| ____|
+# |  _| / _` |/ _ \ \ \ /\ / / _ \ / __/ __| |_  |  _|
+# | |__| (_| |  __/ |\ V  V /  __/ \__ \__ \  _| | |___
+# |_____\__,_|\___|_| \_/\_/ \___|_|___/___/_|   |_____|
+#
+#
+#  Unit of Strength of Materials and Structural Analysis
+#  University of Innsbruck,
+#  2017 - today
+#
+#  Matthias Neuner matthias.neuner@uibk.ac.at
+#
+#  This file is part of EdelweissFE.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2.1 of the License, or (at your option) any later version.
+#
+#  The full text of the license can be found in the file LICENSE.md at
+#  the top level directory of EdelweissFE.
+#  ---------------------------------------------------------------------
+"""Time steppers generate the sequence of :class:`~edelweissfe.timesteppers.timestep.TimeStep` s
+within a simulation step, and allow the solvers to control the incrementation
+(cutbacks, rescaling, freezing the increment size)."""
+
+from abc import ABC, abstractmethod
+
+from edelweissfe.timesteppers.timestep import TimeStep
+
+
+class TimeStepperBase(ABC):
+    """Base class for all time steppers.
+
+    It defines the interface which all solvers may rely on for controlling
+    the incrementation of a simulation step.
+    """
+
+    @abstractmethod
+    def generateTimeStep(self, enforcedTimeIncrement: float = None) -> TimeStep:
+        """Generate the (sequence of) time steps.
+
+        Parameters
+        ----------
+        enforcedTimeIncrement
+            If given, enforce this time increment size (e.g., a critical time step
+            in explicit simulations). Time steppers which do not support enforced
+            increments raise a ValueError if it is given.
+
+        Returns
+        -------
+        TimeStep
+            The generated time steps (generator).
+        """
+
+    @abstractmethod
+    def discardAndChangeIncrement(self, scaleFactor: float):
+        """Discard the current increment, and modify the increment size
+        by a given scale factor within the bounds of the minimum and maximum increment size.
+
+        Parameters
+        ----------
+        scaleFactor
+            The factor for scaling based on the discarded increment.
+        """
+
+    @abstractmethod
+    def changeIncrementSize(self, scaleFactor: float):
+        """Modify the size of the next increment by a given scale factor
+        within the bounds of the minimum and maximum increment size.
+
+        Parameters
+        ----------
+        scaleFactor
+            The factor for scaling based on the current increment.
+        """
+
+    @abstractmethod
+    def preventIncrementIncrease(self):
+        """May be called before an increment is requested, to prevent
+        an automatic increase of the increment size, e.g., in case of bad convergence."""

--- a/edelweissfe/timesteppers/simpletimestepper.py
+++ b/edelweissfe/timesteppers/simpletimestepper.py
@@ -27,11 +27,12 @@
 # Created on Sat Jan  21 12:18:10 2017
 
 from edelweissfe.journal.journal import Journal
+from edelweissfe.timesteppers.base.timestepperbase import TimeStepperBase
 from edelweissfe.timesteppers.timestep import TimeStep
 from edelweissfe.utils.exceptions import ReachedMaxIncrements, ReachedMinIncrementSize
 
 
-class SimpleTimeStepper:
+class SimpleTimeStepper(TimeStepperBase):
     identification = "SimpleTimeStepper"
 
     def __init__(
@@ -218,3 +219,7 @@ class SimpleTimeStepper:
             2,
         )
         self.totalIncrements -= 1
+
+    def preventIncrementIncrease(self):
+        """This time stepper never increases the increment size automatically,
+        hence this is a no-op."""

--- a/edelweissfe/utils/inputfileparser.py
+++ b/edelweissfe/utils/inputfileparser.py
@@ -139,17 +139,12 @@ def parseModuleKeywordLine(line, fileName, topLevelKeyword, topLevelOptions, fil
     try:
         options = checkKeywordInput(**options)
     except ValueError as e:
-        if (  # stepaction update
+        # A step action can be updated in a subsequent step by repeating the module
+        # level keyword with the same name as previously defined. Updates are validated
+        # against the dedicated 'update<keyword>' keyword, if the module provides one.
+        updateKeyword = None
+        if (
             topLevelKeyword == "step"
-            and module.name == "adaptive"
-            and kw.name
-            in [
-                # "bodyforce",
-                "dirichlet",
-                "distributedload",
-                # "geostatic",
-                "nodeforces",
-            ]  # these stepactions can be updated by repeating the module level keyword and using the same name as previously defined
             and "name" in options
             and options["name"].casefold()
             in [  # check if a step action with the same name already exists
@@ -157,9 +152,16 @@ def parseModuleKeywordLine(line, fileName, topLevelKeyword, topLevelOptions, fil
                 for step in fileDict["step"]
                 if keyword in step["moduleoptions"]
                 for item in step["moduleoptions"][keyword]
+                if "name" in item
             ]
         ):
-            kw = module.getKeyword("update" + keyword)
+            try:
+                updateKeyword = module.getKeyword("update" + keyword)
+            except ValueError:
+                updateKeyword = None
+
+        if updateKeyword is not None:
+            kw = updateKeyword
 
             @caseInsensitiveKwargsChecker([kw.name for kw in kw.requiredArgs], [kw.name for kw in kw.optionalArgs])
             @castKwargsValuesAndAddDefaults(kw)
@@ -339,8 +341,11 @@ from edelweissfe.stepactions.setfield import inputLanguage  # noqa: F811,E402
 from edelweissfe.stepactions.setinitialconditions import inputLanguage  # noqa: F811,E402
 
 from edelweissfe.stepactions.options import inputLanguage  # noqa: F811,E402
-from edelweissfe.solvers.nonlinearimplicitstatic import inputLanguage  # noqa: F811,E402
-from edelweissfe.solvers.nonlinearimplicitstaticparallelarclength import inputLanguage  # noqa: F811,E402
+
+# these modules register their available options on the 'options' keyword of all step types:
+import edelweissfe.solvers.nonlinearimplicitstatic  # noqa: F401,E402
+import edelweissfe.solvers.nonlinearimplicitstaticparallelarclength  # noqa: F401,E402
+import edelweissfe.solvers.nonlinearexplicitstatic  # noqa: F401,E402
 
 # isort: on
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,7 @@ where = ["."]
 [project.scripts]
 edelweissfe = "edelweissfe._cli._edelweissfe:main"
 run_tests_edelweissfe = "edelweissfe._cli._run_tests_edelweissfe:main"
+
+[tool.black]
+line-length = 120
+target-version = ["py312"]


### PR DESCRIPTION
Structural changes

- StepBase is now a real base class holding all shared step implementation (attributes, solve(), the full incrementation API). AdaptiveStep and AdaptiveStepForExplicitSimulations shrank to ~75-line subclasses that only choose their time stepper. A new TimeStepperBase defines the stepper interface; AdaptiveTimeStepper gained changeIncrementSize and SimpleTimeStepper gained preventIncrementIncrease, so any step type now works with any solver — the mid-run AttributeErrors are gone.
- Step types dispatch through a registry in config/steps.py (mirroring config/solvers.py); an unknown type now raises with the available types listed instead of silently skipping the step.
- Step actions register themselves against inputLanguage["step"].modules instead of hardcoding the two step-type names in every one of the 14 files — a new step type picks up all actions automatically. They also import InputLanguage from utils now, not from steps.adaptivestep.
- StepManager.dequeueStep became generateSteps — non-mutating (re-iterable definitions), proper ValueError for duplicate action names, and the actions live in a StepActionCollection that raises on unknown category names instead of defaultdict-swallowing typos.
- The parser's update mechanism (>>dirichlet with an existing name) is generalized: it now probes for a registered update<keyword> instead of the hardcoded adaptive-only action list, so updates work in explicit steps too.

Bugs fixed along the way

- The >>options regression: options actions are keyed by category again, and solver options are routed through new registerOptionsArg/getOptionsOfCategory helpers in stepactions/options.py. All option args register with a None default meaning "unspecified", so consumers receive exactly what the user typed — this also fixes a second latent problem where injected parse-time defaults would have crashed _updateOptions or reset *solver-dataline settings. I verified end-to-end that NIST now logs Updating option extrapolation=linear for an input using >>options. NEST's runge-kutta options are now registered (they were previously unparseable), and Ensight uses the same lookup.
- Arc-length solver: bodeforce → bodyforce (body forces got the wrong reference-load magnitude at step end), and stepActions["geostatics"] iterating keys and calling a nonexistent apply() → stepActions["geostatic"].values() + applyAtIterationStart().
- options.StepAction.__getitem__ missing return.
- indirectcontractioncontrol was triply bit-rotted (wrong computeDDLambda/finishIncrement arities, applyAtStepEnd(U, P), and stale node-field indexing); it now matches the controller interface and resolves dof indices through the current DofManager.