### PR TITLE
feat: improve dirichlet application clarity

### DIFF
--- a/edelweissfe/solvers/base/dirichlet.pyx
+++ b/edelweissfe/solvers/base/dirichlet.pyx
@@ -38,17 +38,22 @@ from scipy.sparse import csr_matrix
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def applyDirichletK(nls, K: csr_matrix, dirichlets: Iterable) -> csr_matrix:
-    """Apply the dirichlet bcs on the global stiffnes matrix
-    Is called by solveStep() before solving the global sys.
-    http://stackoverflux.com/questions/12129948/scipy-sparse-set-row-to-zeros
+def applyDirichletToStiffness(K: csr_matrix, dirichlets: Iterable) -> csr_matrix:
+    """Impose the Dirichlet BCs on the global stiffness matrix (row-replacement method).
+
+    For every constrained DOF (row) we set the whole row to zero and put 1.0 on
+    the diagonal. Solving  K ddU = R  then simply returns  ddU[row] = R[row],
+    i.e. the value that :func:`applyDirichletToResidual` wrote into R for that DOF.
+
+    The constrained DOF indices are precomputed once per step (by the solver's
+    ``locateConstrainedDofs``) and cached on each boundary condition, so here we
+    just read ``dirichlet.constrainedDofIndices``.
 
     Cythonized version for speed!
+    http://stackoverflux.com/questions/12129948/scipy-sparse-set-row-to-zeros
 
     Parameters
     ----------
-    nls: NonLinearSolverBase
-        The nonlinear solver.
     K: scipy.sparse.csr_matrix
         The system matrix.
     dirichlets: list
@@ -62,10 +67,10 @@ def applyDirichletK(nls, K: csr_matrix, dirichlets: Iterable) -> csr_matrix:
     if len(dirichlets) == 0:
         return K
 
-    # precompute the dirichlet indices for all dirichlet bcs
+    # gather the (precomputed) constrained DOF indices of all dirichlet bcs
     all_indices = []
     for d in dirichlets:
-        all_indices.append(nls.findDirichletIndices(d))
+        all_indices.append(d.constrainedDofIndices)
 
     cdef long[::1] dirichletIndices = np.concatenate(all_indices).astype(np.int64)
 

--- a/edelweissfe/solvers/base/nonlinearsolverbase.py
+++ b/edelweissfe/solvers/base/nonlinearsolverbase.py
@@ -55,10 +55,6 @@ class NonlinearSolverBase(ABC):
 
     SolverSpecificOptions = {}
 
-    #: Cache for :meth:`findDirichletIndices`; lazily initialized since not all
-    #: subclasses call ``super().__init__()``.
-    _dirichletIndicesCache = None
-
     def __init__(self, jobInfo, journal, **kwargs):
         pass
 
@@ -89,14 +85,19 @@ class NonlinearSolverBase(ABC):
         pass
 
     @performancetiming.timeit("dirichlet R")
-    def applyDirichlet(self, timeStep: TimeStep, R: DofVector, dirichlets: list[StepActionBase]):
-        """Apply the dirichlet bcs on the residual vector
-        Is called by solveStep() before solving the global equatuon system.
+    def applyDirichletToResidual(self, timeStep: TimeStep, R: DofVector, dirichlets: list[StepActionBase]):
+        """Impose the Dirichlet BCs on the residual using the row-replacement method.
+
+        For every constrained DOF we *overwrite* its residual entry with the
+        value we want the linear solve to return for that DOF's increment.
+        Together with :meth:`applyDirichletToStiffness` (which zeroes the DOF's
+        row of K and puts 1.0 on the diagonal), the linearized system
+        ``K ddU = R`` then reproduces exactly that increment for the DOF.
 
         Parameters
         ----------
-        increment
-            The increment.
+        timeStep
+            The current time step.
         R
             The residual vector of the global equation system to be modified.
         dirichlets
@@ -108,8 +109,7 @@ class NonlinearSolverBase(ABC):
             The modified residual vector.
         """
         for dirichlet in dirichlets:
-            delta = dirichlet.getDelta(timeStep)
-            R[self.findDirichletIndices(dirichlet)] = delta.flatten()
+            R[dirichlet.constrainedDofIndices] = dirichlet.getPrescribedIncrement(timeStep).flatten()
 
         return R
 
@@ -311,7 +311,7 @@ class NonlinearSolverBase(ABC):
 
         if extrapolation == "linear" and prevTimeStep and prevTimeStep.timeIncrement:
             dU *= timeStep.stepProgressIncrement / prevTimeStep.stepProgressIncrement
-            dU = self.applyDirichlet(timeStep, dU, dirichlets)
+            dU = self.applyDirichletToResidual(timeStep, dU, dirichlets)
             isExtrapolatedIncrement = True
         else:
             isExtrapolatedIncrement = False
@@ -408,25 +408,38 @@ class NonlinearSolverBase(ABC):
             for action in stepActionType.values():
                 action.applyAtIncrementStart(model, timeStep)
 
-    def findDirichletIndices(self, dirichlet):
-        nSet = dirichlet.nSet
-        field = dirichlet.field
-        components = dirichlet.components
+    def locateConstrainedDofs(self, dirichlets: list[StepActionBase]):
+        """Determine, up front, which global DOFs each Dirichlet BC constrains.
 
-        # The result is fully determined by the boundary condition, its (mutable)
-        # components, and the current DofManager, so it is memoized. It is requested
-        # multiple times per Newton iteration (residual zeroing and system matrix
-        # modification), but only changes when the equation system is rebuilt or the
-        # boundary condition is updated between steps.
-        cache = self._dirichletIndicesCache
-        if cache is None:
-            cache = self._dirichletIndicesCache = {}
+        Called once when a step's boundary conditions are established. The result
+        is cached on each BC as :attr:`~DirichletBase.constrainedDofIndices`, so
+        that the Newton loop can address the constrained DOFs directly, instead
+        of recomputing the mapping on every residual update and every stiffness
+        modification.
 
-        key = (dirichlet, self.theDofManager, tuple(components))
-        indices = cache.get(key)
-        if indices is None:
-            fieldIndices = self.theDofManager.idcsOfFieldsOnNodeSetsInDofVector[field][nSet]
+        Parameters
+        ----------
+        dirichlets
+            The list of dirichlet boundary conditions active in this step.
+        """
+        for dirichlet in dirichlets:
+            dirichlet.constrainedDofIndices = self._constrainedDofsOf(dirichlet)
 
-            indices = cache[key] = fieldIndices.reshape((len(nSet), -1))[:, components].flatten()
+    def _constrainedDofsOf(self, dirichlet: StepActionBase) -> np.ndarray:
+        """Return the global DOF indices prescribed by a single Dirichlet BC.
 
-        return indices
+        The DofManager knows every DOF of ``field`` on ``nSet``, laid out node
+        by node in a single flat array::
+
+            [ node0: (u_x u_y u_z),  node1: (u_x u_y u_z),  ... ]
+
+        A BC usually prescribes only some of the per-node components (given by
+        ``dirichlet.components``, e.g. just u_x and u_z). So we view the flat
+        array as one row per node, keep only the prescribed component columns,
+        and flatten it back into a plain list of global DOF indices. The order
+        stays node-major, matching ``getPrescribedIncrement().flatten()``.
+        """
+        dofsOfFieldOnNodeSet = self.theDofManager.idcsOfFieldsOnNodeSetsInDofVector[dirichlet.field][dirichlet.nSet]
+        perNodeDofs = dofsOfFieldOnNodeSet.reshape((-1, dirichlet.fieldSize))
+
+        return perNodeDofs[:, dirichlet.components].flatten()

--- a/edelweissfe/solvers/nonlinearexplicitdynamic.py
+++ b/edelweissfe/solvers/nonlinearexplicitdynamic.py
@@ -354,6 +354,9 @@ class NED(NonlinearSolverBase):
         distributedLoads = stepActions["distributedload"].values()
         bodyForces = stepActions["bodyforce"].values()
 
+        # Find which global DOFs the Dirichlet BCs constrain, once up front.
+        self.locateConstrainedDofs(dirichlets)
+
         if timeStep.timeIncrement == 0.0:
             return U_n, V, P
 
@@ -368,10 +371,14 @@ class NED(NonlinearSolverBase):
                 timeStep.totalTime - timeStep.timeIncrement,
             )
 
-        # enforce dirichlet boundary conditions
+        # Enforce the Dirichlet boundary conditions on the constrained DOFs:
+        # there is no free equilibrium there, so their force P is set to zero,
+        # and their velocity is prescribed as (prescribed increment) / (time step).
         for dirichlet in dirichlets:
-            P[self.findDirichletIndices(dirichlet)] = 0.0
-            V[self.findDirichletIndices(dirichlet)] = dirichlet.getDelta(timeStep).flatten() / timeStep.timeIncrement
+            P[dirichlet.constrainedDofIndices] = 0.0
+            V[dirichlet.constrainedDofIndices] = (
+                dirichlet.getPrescribedIncrement(timeStep).flatten() / timeStep.timeIncrement
+            )
 
         if self.ids_1st is not None:
             V[self.ids_1st] = Minv[self.ids_1st] * P[self.ids_1st]

--- a/edelweissfe/solvers/nonlinearexplicitstatic.py
+++ b/edelweissfe/solvers/nonlinearexplicitstatic.py
@@ -411,6 +411,9 @@ class NEST(NIST):
         distributedLoads = stepActions["distributedload"].values()
         bodyForces = stepActions["bodyforce"].values()
 
+        # Find which global DOFs the Dirichlet BCs constrain, once up front.
+        self.locateConstrainedDofs(dirichlets)
+
         self.applyStepActionsAtIncrementStart(model, timeStep, stepActions)
 
         for geostatic in stepActions["geostatic"].values():
@@ -439,10 +442,10 @@ class NEST(NIST):
             R[:] = -P
             R += PExt
 
-            R = self.applyDirichlet(timeStep, R, dirichlets)
+            R = self.applyDirichletToResidual(timeStep, R, dirichlets)
 
             K_ = self.assembleStiffnessCSR(K)
-            K_ = self.applyDirichletK(K_, dirichlets)
+            K_ = self.applyDirichletToStiffness(K_, dirichlets)  # zero rows, unit diagonal
 
             # solve for increment
             dU_[k] = self.linearSolve(K_, R)

--- a/edelweissfe/solvers/nonlinearimplicitstatic.py
+++ b/edelweissfe/solvers/nonlinearimplicitstatic.py
@@ -41,7 +41,7 @@ from edelweissfe.models.femodel import FEModel
 from edelweissfe.numerics.csrgeneratorv2 import CSRGenerator
 from edelweissfe.numerics.dofmanager import DofManager, DofVector, VIJSystemMatrix
 from edelweissfe.outputmanagers.base.outputmanagerbase import OutputManagerBase
-from edelweissfe.solvers.base.dirichlet import applyDirichletK
+from edelweissfe.solvers.base.dirichlet import applyDirichletToStiffness
 from edelweissfe.solvers.base.nonlinearsolverbase import NonlinearSolverBase
 from edelweissfe.stepactions.base.stepactionbase import StepActionBase
 from edelweissfe.stepactions.options import inputLanguage
@@ -375,6 +375,9 @@ class NIST(NonlinearSolverBase):
         distributedLoads = stepActions["distributedload"].values()
         bodyForces = stepActions["bodyforce"].values()
 
+        # Find which global DOFs the Dirichlet BCs constrain, once up front.
+        self.locateConstrainedDofs(dirichlets)
+
         self.applyStepActionsAtIncrementStart(model, timeStep, stepActions)
 
         dU, isExtrapolatedIncrement = self.extrapolateLastIncrement(
@@ -397,13 +400,25 @@ class NIST(NonlinearSolverBase):
             R[:] = -P
             R += PExt
 
+            # --- Impose the Dirichlet (prescribed-value) boundary conditions ---
+            # Row-replacement method: for each constrained DOF i we overwrite its
+            # row of the linearized system  K ddU = R  so that the linear solve
+            # returns a *known* value for the increment ddU[i]:
+            #     K: zero row i, set K[i, i] = 1   (see applyDirichletToStiffness)
+            #     R: set R[i] to the value ddU[i] must take
+            # Together these give  ddU[i] = R[i]  exactly.
             if iterationCounter == 0 and not isExtrapolatedIncrement and dirichlets:
-                # first iteration? apply dirichlet bcs and unconditionally solve
-                R = self.applyDirichlet(timeStep, R, dirichlets)
+                # First iteration: the constrained DOFs must still move by their
+                # prescribed increment for this step, so we ask the solve for it.
+                R = self.applyDirichletToResidual(timeStep, R, dirichlets)
             else:
-                # iteration cycle 1 or higher, time to check the convergence
+                # Later iterations: the constrained DOFs already sit at their
+                # prescribed value and must not move further, so we prescribe a
+                # zero increment. This also removes them from the convergence
+                # check below: there is no force equilibrium to satisfy at a DOF
+                # whose value we dictate.
                 for dirichlet in dirichlets:
-                    R[self.findDirichletIndices(dirichlet)] = 0.0
+                    R[dirichlet.constrainedDofIndices] = 0.0
 
                 converged, nodesWithLargestResidual = self.checkConvergence(
                     R, ddU, F, iterationCounter, incrementResidualHistory
@@ -421,7 +436,7 @@ class NIST(NonlinearSolverBase):
                     raise ReachedMaxIterations("Reached max. iterations in current increment, cutting back")
 
             K_ = self.assembleStiffnessCSR(K)
-            K_ = self.applyDirichletK(K_, dirichlets)
+            K_ = self.applyDirichletToStiffness(K_, dirichlets)  # zero rows, unit diagonal
 
             ddU = self.linearSolve(K_, R)
             dU += ddU
@@ -523,8 +538,8 @@ class NIST(NonlinearSolverBase):
         return PExt, K
 
     @performancetiming.timeit("dirichlet K on CSR")
-    def applyDirichletK(self, K: csr_matrix, dirichlets: list[StepActionBase]) -> csr_matrix:
-        return applyDirichletK(self, K, dirichlets)
+    def applyDirichletToStiffness(self, K: csr_matrix, dirichlets: list[StepActionBase]) -> csr_matrix:
+        return applyDirichletToStiffness(K, dirichlets)
 
     @performancetiming.timeit("elements")
     def computeElements(

--- a/edelweissfe/solvers/nonlinearimplicitstaticparallelarclength.py
+++ b/edelweissfe/solvers/nonlinearimplicitstaticparallelarclength.py
@@ -202,6 +202,9 @@ class NISTPArcLength(NISTParallel):
         distributedLoads = stepActions["distributedload"].values()
         bodyForces = stepActions["bodyforce"].values()
 
+        # Find which global DOFs the Dirichlet BCs constrain, once up front.
+        self.locateConstrainedDofs(dirichlets)
+
         for stepActionType in stepActions.values():
             for action in stepActionType.values():
                 action.applyAtIncrementStart(model, timeStep)
@@ -269,12 +272,12 @@ class NISTPArcLength(NISTParallel):
 
             # Dirichlets ..
             if isExtrapolatedIncrement and iterationCounter == 0:
-                R_0 = self.applyDirichlet(zeroTimeStep, R_0, dirichlets)
+                R_0 = self.applyDirichletToResidual(zeroTimeStep, R_0, dirichlets)
             else:
                 modifiedTimeStep = TimeStep(timeStep.number, dLambda, Lambda + dLambda, 0.0, 0.0, 0.0)
-                R_0 = self.applyDirichlet(modifiedTimeStep, R_0, dirichlets)
+                R_0 = self.applyDirichletToResidual(modifiedTimeStep, R_0, dirichlets)
 
-            R_f = self.applyDirichlet(referenceTimeStep, R_f, dirichlets)
+            R_f = self.applyDirichletToResidual(referenceTimeStep, R_f, dirichlets)
 
             if iterationCounter > 0 or isExtrapolatedIncrement:
                 converged, nodesWithLargestResidual = self.checkConvergence(
@@ -293,7 +296,7 @@ class NISTPArcLength(NISTParallel):
                     raise ReachedMaxIterations("Reached max. iterations in current increment, cutting back")
 
             K_ = self.assembleStiffnessCSR(K)
-            K_ = self.applyDirichletK(K_, dirichlets)
+            K_ = self.applyDirichletToStiffness(K_, dirichlets)  # zero rows, unit diagonal
 
             # solve 2 eq. systems at once:
             ddU_ = self.linearSolve(K_, R_)

--- a/edelweissfe/stepactions/base/dirichletbase.py
+++ b/edelweissfe/stepactions/base/dirichletbase.py
@@ -38,11 +38,39 @@ from edelweissfe.timesteppers.timestep import TimeStep
 
 
 class DirichletBase(StepActionBase):
+    """Base class for a Dirichlet (prescribed-value) boundary condition.
+
+    A Dirichlet BC prescribes selected ``components`` of a ``field`` (e.g. the
+    x- and z-component of the displacement) on every node of a node set
+    ``nSet``. The nonlinear solver imposes it with the row-replacement method,
+    for which it needs exactly two things from the BC:
+
+        * which global DOFs are constrained  -> ``constrainedDofIndices``
+        * by how much they must move this step -> ``getPrescribedIncrement()``
+    """
+
+    #: The field whose components are prescribed, e.g. "displacement".
+    field: str
+    #: The node set the boundary condition acts on.
+    nSet: object
+    #: Number of DOFs (components) the field has per node.
+    fieldSize: int
+    #: The global DOF indices constrained by this BC, in node-major order.
+    #: Populated once per step by the solver (see
+    #: :meth:`NonlinearSolverBase.locateConstrainedDofs`), because it depends on
+    #: the DofManager's layout, which the boundary condition does not know itself.
+    constrainedDofIndices: np.ndarray = None
+
     @property
     @abstractmethod
     def components(self) -> np.ndarray:
-        pass
+        """Column indices, within a node's field DOFs, that are prescribed."""
 
     @abstractmethod
-    def getDelta(self, timeStep: TimeStep) -> np.ndarray:
-        pass
+    def getPrescribedIncrement(self, timeStep: TimeStep) -> np.ndarray:
+        """The increment by which the prescribed DOFs must move in this time step.
+
+        The returned array has shape (number of nodes in ``nSet``, number of
+        prescribed ``components``), so that ``.flatten()`` yields the values in
+        the same node-major order as :attr:`constrainedDofIndices`.
+        """

--- a/edelweissfe/stepactions/dirichlet.py
+++ b/edelweissfe/stepactions/dirichlet.py
@@ -153,7 +153,7 @@ class StepAction(DirichletBase):
 
         self.amplitude = self._getAmplitude(action)
 
-    def getDelta(self, timeStep: TimeStep):
+    def getPrescribedIncrement(self, timeStep: TimeStep):
         if self.active:
             return self.delta * (
                 self.amplitude(timeStep.stepProgress)


### PR DESCRIPTION
Make Dirichlet BC application self-explaining

  Motivation

  EdelweissFE is also used to teach finite elements, so the solver code should make the method legible, not just correct. How Dirichlet (prescribed-value) BCs were imposed had grown hard to read: the core index mapping was a single opaque expression

  fieldIndices.reshape((len(nSet), -1))[:, components].flatten()

  recomputed twice per Newton iteration (once for the residual, once inside the Cython stiffness routine), and the method names (applyDirichlet, applyDirichletK, getDelta, findDirichletIndices) didn't convey the underlying row-replacement idea. A student reading solveIncrement couldn't see the textbook concept.

  What changed

  A student now reads this in the Newton loop:
```

  # --- Impose the Dirichlet (prescribed-value) boundary conditions ---
  # Row-replacement method: for each constrained DOF i we overwrite its
  # row of the linearized system  K ddU = R  so that the linear solve
  # returns a *known* value for the increment ddU[i]:
  #     K: zero row i, set K[i, i] = 1   (see applyDirichletToStiffness)
  #     R: set R[i] to the value ddU[i] must take
  # Together these give  ddU[i] = R[i]  exactly.
  if iterationCounter == 0 and not isExtrapolatedIncrement and dirichlets:
      # First iteration: constrained DOFs must move by their prescribed increment
      R = self.applyDirichletToResidual(timeStep, R, dirichlets)
  else:
      # Later iterations: they already sit at the prescribed value -> zero increment
      for dirichlet in dirichlets:
          R[dirichlet.constrainedDofIndices] = 0.0
      ...
  K_ = self.applyDirichletToStiffness(K_, dirichlets)  # zero rows, unit diagonal
```

  - Constrained DOFs computed once, cached on the BC. NonlinearSolverBase.locateConstrainedDofs(dirichlets) runs once when a step's BCs are established and stores the result on each BC as constrainedDofIndices. The hot loop just reads that attribute instead of recomputing the mapping every residual update and every stiffness modification. The mapping itself now lives in one documented place, _constrainedDofsOf, whose docstring draws the node-by-node DOF layout and explains the column-select.
- Names state their effect. applyDirichlet → applyDirichletToResidual, applyDirichletK → applyDirichletToStiffness, getDelta → getPrescribedIncrement; findDirichletIndices removed. Both apply-methods carry a docstring naming the row-replacement method.
- DirichletBase documents its contract (field, nSet, fieldSize, constrainedDofIndices) as real base-class attributes — no getattr, consistent with the repo convention.
- Teaching comments at the point of application explain the zero-row/unit-diagonal trick and why the residual is set to the prescribed increment on the first iteration and zeroed thereafter (constrained DOFs carry no equilibrium and drop out of the convergence check).

The Cython dirichlet.pyx no longer needs the solver handle — it reads the precomputed dirichlet.constrainedDofIndices directly (extension recompiled).

Design note

The EdelweissMeshfree side memoizes these indices with a (dirichlet, dofManager, nodeSet, components) dict key because MPM node sets change as particles move. In EdelweissFE the constrained DOFs are static within a step, so this uses the plainer compute-once-per-step approach rather than copying that machinery — clearer for teaching. Meshfree is left untouched.

Behavior

Behavior-preserving — no numerical results change. Verified against reference solutions across all four affected solvers:

- Implicit static (NIST) and explicit dynamic (NED/NEDParallel) — full testfiles/edelweiss-only/ suite passes.
- Explicit static (NEST) — Marmot NEST case passes.
- Arc-length (NISTPArcLength) — Marmot AT2PhaseField case passes.

(Remaining suite SKIPs are unrelated missing deps: num_dual, and Marmot materials GCDP/ModLeon.)

Scope

refactor(solvers), 8 files, +135/−43. No public input-file syntax changes.