### PR TITLE
fix: update non-auto-tested .inp examples to current >> module-level …

### DIFF
--- a/examples/CantileverBeam/test3D.inp
+++ b/examples/CantileverBeam/test3D.inp
@@ -1,4 +1,4 @@
-*material, name=LinearElastic, id=linearelastic
+*material, name=LinearElastic, id=linearelastic, provider=edelweiss
 **Isotropic material
 **E    nu -> elasticity module and poisson's ratio
 1.8e4, 0.22
@@ -17,10 +17,10 @@ nZ      =4
 lX      =500
 lY      =5
 lZ      =5
-** use provider: displacementelement
-elProvider =displacementelement
+** use provider: edelweiss
+elProvider =edelweiss
 ** use hexahedron element with 8 nodes and normal integration
-elType  =Hexa8
+elType  =C3D8
 
 *section, name=section1, material=linearelastic, type=solid
 ** assign linear elastic section to all elements
@@ -28,19 +28,18 @@ all
 
 ** displacement output for all elements
 *fieldOutput
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
 
 ** create output data to open with paraview
 *output, type=ensight, name=test
-create=perNode, fieldOutput=displacement
-configuration, overwrite=yes
-
-*output, type=monitor
+>>perNode, fieldOutput=displacement
+>>configuration, overwrite=yes
 
 ** set step size between 1 and 1e-9, 1000 iterations, 25 max iterations and step length 1
-*step, solver=theSolver, maxInc=1e0, minInc=1e-9, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=off
+*step, solver=theSolver
+maxInc=1e0, minInc=1e-9, maxNumInc=1000, maxIter=25, stepLength=1
+>>options, category=NISTSolver, extrapolation=off
 ** fix one side (fixed support)
-dirichlet, name=Left,  nSet=gen_left, field=displacement, 1=0.0, 2=0.0, 3=.0
+>>dirichlet, name=Left,  nSet=gen_left, field=displacement, 1=0.0, 2=0.0, 3=.0
 ** set load in z to 0.012N for all the points on right back
-nodeforces, name=cloadTop, nSet=gen_rightBack, components='0, 0, .012', field=displacement
+>>nodeforces, name=cloadTop, nSet=gen_rightBack, components='0, 0, .012', field=displacement

--- a/examples/CantileverBeam/test4.inp
+++ b/examples/CantileverBeam/test4.inp
@@ -1,5 +1,5 @@
 ** cantilever beam, steel, l=10000mm, h=100mm, b=40mm, calculation in [N/mm²]
-*material, name=linearelastic, id=linearelastic,
+*material, name=linearelastic, id=linearelastic, provider=edelweiss
 ** elasticity module and poisson's ratio
 210000.0, 0.15
 
@@ -13,18 +13,18 @@ all
 *solver, solver=NIST, name=theSolver
 
 *fieldOutput
-create=perNode, nSet=gen_bottom, result=P, field=displacement, name=RF
+>>perNode, nSet=gen_bottom, result=P, field=displacement, name=RF
 ** displacement output for all elements
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
 
 *modelGenerator, generator=planeRectQuad, name=gen
 ** create model: length 10000mm, height 100mm with 300 elements in l direction and 4 in h direction
 x0=0, l=10000
 y0=0, h=100
-elType=Quad4NPE
+elType=CPE4
 ** quadrilateral element with 4 nodes, normal integration and plane strain
 ** set provider
-elProvider=displacementelement
+elProvider=edelweiss
 nX=300
 nY=4
 
@@ -33,12 +33,13 @@ fieldOutput=RF, f(x)='mean(x[:,1])'
 
 ** create output data to open with paraview
 *output, type=ensight, name=esExport
-configuration, overwrite=yes
-create=perNode,    fieldOutput=displacement
+>>configuration, overwrite=yes
+>>perNode,    fieldOutput=displacement
 
 ** set steps with size between 1 and 1e-8, 1000 iterations and max 25 iterations
-*step, solver=theSolver, maxInc=1e-0, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=100
+*step, solver=theSolver
+maxInc=1e-0, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=100
 ** fix one side (fixed support)
-dirichlet, name=left, nSet=gen_left,  field=displacement, 2=0, 1=0
+>>dirichlet, name=left, nSet=gen_left,  field=displacement, 2=0, 1=0
 ** set load -1000N in one point down
-nodeforces, name=cloadTop, nSet=gen_rightTop, components='0,-1000', field=displacement
+>>nodeforces, name=cloadTop, nSet=gen_rightTop, components='0,-1000', field=displacement

--- a/examples/CantileverBeam/test8.inp
+++ b/examples/CantileverBeam/test8.inp
@@ -1,5 +1,5 @@
 ** cantilever beam, steel, l=10000mm, h=100mm, b=40mm, calculation in [N/mm²]
-*material, name=linearelastic, id=linearelastic,
+*material, name=linearelastic, id=linearelastic, provider=edelweiss
 ** elasticity module and poisson's ratio
 210000.0, 0.15
 
@@ -13,18 +13,18 @@ all
 *solver, solver=NIST, name=theSolver
 
 *fieldOutput
-create=perNode, nSet=gen_bottom, result=P, field=displacement, name=RF
+>>perNode, nSet=gen_bottom, result=P, field=displacement, name=RF
 ** displacement output for all elements
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
 
 *modelGenerator, generator=planeRectQuad, name=gen
 ** create model: length 10000mm, height 100mm with 300 elements in l direction and 4 in h direction
 x0=0, l=10000
 y0=0, h=100
-elType=Quad8NPE
+elType=CPE8N
 ** quadrilateral element with 4 nodes, normal integration and plane strain
 ** set provider
-elProvider=displacementelement
+elProvider=edelweiss
 nX=300
 nY=4
 
@@ -33,12 +33,13 @@ fieldOutput=RF, f(x)='mean(x[:,1])'
 
 ** create output data to open with paraview
 *output, type=ensight, name=esExport
-configuration, overwrite=yes
-create=perNode,    fieldOutput=displacement
+>>configuration, overwrite=yes
+>>perNode,    fieldOutput=displacement
 
 ** set steps with size between 1 and 1e-8, 1000 iterations and max 25 iterations with step length 100
-*step, solver=theSolver, maxInc=1e-0, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=100
+*step, solver=theSolver
+maxInc=1e-0, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=100
 ** fix one side (fixed support)
-dirichlet, name=left, nSet=gen_left,  field=displacement, 2=0, 1=0
+>>dirichlet, name=left, nSet=gen_left,  field=displacement, 2=0, 1=0
 ** set load -1000N in one point down
-nodeforces, name=cloadTop, nSet=gen_rightTop, components='0,-1000', field=displacement
+>>nodeforces, name=cloadTop, nSet=gen_rightTop, components='0,-1000', field=displacement

--- a/examples/GMCDPFiniteStrainMarmot/test.inp
+++ b/examples/GMCDPFiniteStrainMarmot/test.inp
@@ -11,34 +11,36 @@
 *section, name=section1, thickness=1.0, material=GMCDPFiniteStrain, type=plane
 all
 
-*job, name=cpe4job, domain=3d, solver=NISTParallelForMarmotElements
-*fieldOutput
-elSet=all, field=displacement, result=U, name=displacement
-elSet=all, field=micro rotation, result=U, name=micro rotation
-elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
-elSet=all, result=alphaP, quadraturePoint=0:8, name=alphaP, f(x)='max( x[:,:], axis=1) '
-elSet=all, result=alphaD, quadraturePoint=0:8, name=alphaD, f(x)='max( x[:,:], axis=1) '
-elSet=all, result=omega, quadraturePoint=0:8, name=omega, f(x)='max( x[:,:], axis=1) '
+*job, name=cpe4job, domain=3d, solver=NISTParallel
+*solver, solver=NISTParallel, name=theSolver
+*fieldOutput,
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
+>>perNode, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
+>>perElement, elSet=all, result=alphaP, quadraturePoint=0:8, name=alphaP, f(x)='max( x[:,:], axis=1) '
+>>perElement, elSet=all, result=alphaD, quadraturePoint=0:8, name=alphaD, f(x)='max( x[:,:], axis=1) '
+>>perElement, elSet=all, result=omega, quadraturePoint=0:8, name=omega, f(x)='max( x[:,:], axis=1) '
 
 *output, type=ensight, name=esExport
-configuration,     overwrite=True
-create=perNode,    fieldOutput=displacement
-create=perNode,    fieldOutput=micro rotation
-create=perNode,    fieldOutput=nonlocal damage
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
+>>configuration,     overwrite=True
+>>perNode,    fieldOutput=displacement
+>>perNode,    fieldOutput=micro rotation
+>>perNode,    fieldOutput=nonlocal damage
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
 
-*step, maxInc=2e-2, minInc=1e-5, maxNumInc=10000, maxIter=25, stepLength=100
-options, category=NISTSolver, extrapolation=linear, numThreads=8
-initializematerial, name=init, elSet=all
-dirichlet, name=front, nSet=front_face,    field=displacement, 3=0
-dirichlet, name=frontr, nSet=front_face,    field=micro rotation, 1=0, 2=0
+*step, solver=theSolver
+maxInc=2e-2, minInc=1e-5, maxNumInc=10000, maxIter=25, stepLength=100
+>>options, category=NISTSolver, extrapolation=linear
+>>initializematerial, name=init, elSet=all
+>>dirichlet, name=front, nSet=front_face,    field=displacement, 3=0
+>>dirichlet, name=frontr, nSet=front_face,    field=micro rotation, 1=0, 2=0
 
-dirichlet, name=back,  nSet=back_face,    field=displacement, 3=0
-dirichlet, name=backr, nSet=back_face,    field=micro rotation, 1=0, 2=0
+>>dirichlet, name=back,  nSet=back_face,    field=displacement, 3=0
+>>dirichlet, name=backr, nSet=back_face,    field=micro rotation, 1=0, 2=0
 
-dirichlet, name=left,  nSet=left_side,    field=displacement, 1=0, 2=0
-dirichlet, name=right, nSet=right_side,    field=displacement, 1=-10, 2=-20
+>>dirichlet, name=left,  nSet=left_side,    field=displacement, 1=0, 2=0
+>>dirichlet, name=right, nSet=right_side,    field=displacement, 1=-10, 2=-20
 
 *include, input=marmot6.inp

--- a/examples/SchlangenTest/penalty/test_penalty.inp
+++ b/examples/SchlangenTest/penalty/test_penalty.inp
@@ -24,25 +24,26 @@ concrete
 *section, name=sec_steel, material=steel, type=solid
 steel
 
-*job, name=SchlangenTest, domain=3d, solver=NISTParallelForMarmotElements
+*job, name=SchlangenTest, domain=3d, solver=NISTParallel
+*solver, solver=NISTParallel, name=theSolver
 
 *fieldOutput,
-elSet=all,  name=displacement,  field=displacement, result=U
-elSet=concrete,  name=nonlocal damage,  field=nonlocal damage, result=U
-name=RF, nSet=all_bc, field=displacement, result=P, f(x)='np.sum(x[:,1], axis=0)', saveHistory=True, export=RF
-name=CMOD, nSet=cmod, field=displacement, result=U, f(x)='x[0,0] - x[1,0]', export=CMOD, saveHistory=True
-name=CMSD, nSet=cmod, field=displacement, result=U, f(x)='x[0,1] - x[1,1]', export=CMOD, saveHistory=True
-elSet=concrete,  name=damage,  result=omega, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
+>>perNode, elSet=all,  name=displacement,  field=displacement, result=U
+>>perNode, elSet=concrete,  name=nonlocal damage,  field=nonlocal damage, result=U
+>>perNode, name=RF, nSet=all_bc, field=displacement, result=P, f(x)='np.sum(x[:,1], axis=0)', saveHistory=True, export=RF
+>>perNode, name=CMOD, nSet=cmod, field=displacement, result=U, f(x)='x[0,0] - x[1,0]', export=CMOD, saveHistory=True
+>>perNode, name=CMSD, nSet=cmod, field=displacement, result=U, f(x)='x[0,1] - x[1,1]', export=CMOD, saveHistory=True
+>>perElement, elSet=concrete,  name=damage,  result=omega, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
 *output, type=monitor, name=monitor
 fieldOutput=RF
 fieldOutput=CMOD
 fieldOutput=CMSD
 
 *output, type=ensight, name=esExport
-create=perNode,     fieldOutput=displacement
-create=perNode,     fieldOutput=nonlocal damage
-create=perElement,  fieldOutput=damage
-configuration, overwrite=yes
+>>perNode,     fieldOutput=displacement
+>>perNode,     fieldOutput=nonlocal damage
+>>perElement,  fieldOutput=damage
+>>configuration, overwrite=yes
 
 *constraint, type=penaltyindirectcontrol, name=pc1
 field=displacement,
@@ -64,12 +65,13 @@ length=+.5
 penaltyStiffness=1e6
 offset=0
 
-*step, maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
-initializematerial, name=init, elSet=concrete
+*step, solver=theSolver
+maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
+>>initializematerial, name=init, elSet=concrete
 
-dirichlet, name=sym, nSet=face_back_concrete, field=displacement, 3=0
-dirichlet, name=sym_r, nSet=face_back_concrete, field=micro rotation, 1=0, 2=0
-dirichlet, name=sym_s, nSet=face_back_steel, field=displacement, 3=0
+>>dirichlet, name=sym, nSet=face_back_concrete, field=displacement, 3=0
+>>dirichlet, name=sym_r, nSet=face_back_concrete, field=micro rotation, 1=0, 2=0
+>>dirichlet, name=sym_s, nSet=face_back_steel, field=displacement, 3=0
 
-dirichlet, name=fixed, nSet=fixed_bc, field=displacement, 1=0., 2=0., 3=0.
-dirichlet, name=supp, nSet=supp_y, field=displacement, 2=0, 3=0
+>>dirichlet, name=fixed, nSet=fixed_bc, field=displacement, 1=0., 2=0., 3=0.
+>>dirichlet, name=supp, nSet=supp_y, field=displacement, 2=0, 3=0

--- a/examples/SchlangenTest/test.inp
+++ b/examples/SchlangenTest/test.inp
@@ -26,40 +26,43 @@ steel
 
 
 *job, name=SchlangenTest, domain=3d, solver=NISTPArcLength
+*solver, solver=NISTPArcLength, name=theSolver
 
 *fieldOutput,
-elSet=all,  name=displacement,  field=displacement, result=U
-elSet=concrete,  name=nonlocal damage,  field=nonlocal damage, result=U
-name=RF, nSet=all_bc, field=displacement, result=P, f(x)='np.sum(x[:,1], axis=0)', saveHistory=True, export=RF
-name=CMOD, nSet=cmod, field=displacement, result=U, f(x)='x[0,0] - x[1,0]', export=CMOD, saveHistory=True
-name=CMSD, nSet=cmod, field=displacement, result=U, f(x)='x[0,1] - x[1,1]', export=CMOD, saveHistory=True
-elSet=concrete,  name=damage,  result=omega, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
+>>perNode, elSet=all,  name=displacement,  field=displacement, result=U
+>>perNode, elSet=concrete,  name=nonlocal damage,  field=nonlocal damage, result=U
+>>perNode, name=RF, nSet=all_bc, field=displacement, result=P, f(x)='np.sum(x[:,1], axis=0)', saveHistory=True, export=RF
+>>perNode, name=CMOD, nSet=cmod, field=displacement, result=U, f(x)='x[0,0] - x[1,0]', export=CMOD, saveHistory=True
+>>perNode, name=CMSD, nSet=cmod, field=displacement, result=U, f(x)='x[0,1] - x[1,1]', export=CMOD, saveHistory=True
+>>perElement, elSet=concrete,  name=damage,  result=omega, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
 *output, type=monitor, name=monitor
 fieldOutput=RF
 fieldOutput=CMOD
 fieldOutput=CMSD
 
 *output, type=ensight, name=esExport
-create=perNode,     fieldOutput=displacement
-create=perNode,     fieldOutput=nonlocal damage
-create=perElement,  fieldOutput=damage
-configuration, overwrite=yes
+>>perNode,     fieldOutput=displacement
+>>perNode,     fieldOutput=nonlocal damage
+>>perElement,  fieldOutput=damage
+>>configuration, overwrite=yes
 
-*step, maxInc=1e-0, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTArcLength, arcLengthController=off
-initializematerial, name=init, elSet=concrete
+*step, solver=theSolver
+maxInc=1e-0, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
+>>options, category=NISTArcLength, arcLengthController=off
+>>initializematerial, name=init, elSet=concrete
 
-dirichlet, name=sym, nSet=face_back_concrete, field=displacement, 3=0
-dirichlet, name=sym_r, nSet=face_back_concrete, field=micro rotation, 1=0, 2=0
-dirichlet, name=sym_s, nSet=face_back_steel, field=displacement, 3=0
+>>dirichlet, name=sym, nSet=face_back_concrete, field=displacement, 3=0
+>>dirichlet, name=sym_r, nSet=face_back_concrete, field=micro rotation, 1=0, 2=0
+>>dirichlet, name=sym_s, nSet=face_back_steel, field=displacement, 3=0
 
-dirichlet, name=fixed, nSet=fixed_bc, field=displacement, 1=0., 2=0., 3=0.
-dirichlet, name=supp, nSet=supp_y, field=displacement, 2=0, 3=0
+>>dirichlet, name=fixed, nSet=fixed_bc, field=displacement, 1=0., 2=0., 3=0.
+>>dirichlet, name=supp, nSet=supp_y, field=displacement, 2=0, 3=0
 
-*step, maxInc=1e-2, minInc=1e-6, maxNumInc=1000, maxIter=10, stepLength=1
-options, category=NISTArcLength, arcLengthController=indirectcontrol,
+*step, solver=theSolver
+maxInc=1e-2, minInc=1e-6, maxNumInc=1000, maxIter=10, stepLength=1
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol,
 
-indirectcontrol, dof1=' nodeSets["cmod_left"][0].fields["displacement"][1] ', dof2='nodeSets["cmod_right"][0].fields["displacement"][1] ' , L=+0.5,
+>>indirectcontrol, dof1=' nodeSets["cmod_left"][0].fields["displacement"][1] ', dof2='nodeSets["cmod_right"][0].fields["displacement"][1] ' , L=+0.5, cVector1='[-1]', cVector2='[1]',
 
-nodeforces, name=low_p, nSet=low_p, field=displacement, 2=1
-nodeforces, name=high_p, nSet=high_p, field=displacement, 2=10
+>>nodeforces, name=low_p, nSet=low_p, field=displacement, 2=1
+>>nodeforces, name=high_p, nSet=high_p, field=displacement, 2=10

--- a/examples/WinklerL/test.inp
+++ b/examples/WinklerL/test.inp
@@ -35,6 +35,8 @@
 .99,
 ** derivativeMethod (0 ..  AD, 1 ..  CD)
 0
+** dTThresholdElasticStiffness
+0
 
 *material, name=linearElastic, id=steelLoad
 37000.0, 0.3
@@ -43,29 +45,31 @@
 
 *section, name=sectConc, material=GCDP, type=solid
 secConc
-*section, name=secSteel, material=steelLoad, type=solid
+*section, name=secSteelLoad, material=steelLoad, type=solid
 secSteelLoad
-*section, name=secSteel, material=steelBottom, type=solid
+*section, name=secSteelBottom, material=steelBottom, type=solid
 secSteelBottom
 
 *job, domain=3d, solver=NISTParallel
+*solver, solver=NISTParallel, name=theSolver
 
 *fieldOutput,
-elSet=secConc, name=displacement, field=displacement, result=U
-elSet=secConc, name=nonlocal damage, field=nonlocal damage, result=U
-name=RF, nSet=setLoad, field=displacement, result=P, f(x)='np.sum(x[:,1], axis=0)', saveHistory=True, export=RF
-elSet=secConc, name=damage, result=omega, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
+>>perNode, elSet=secConc, name=displacement, field=displacement, result=U
+>>perNode, elSet=secConc, name=nonlocal damage, field=nonlocal damage, result=U
+>>perNode, name=RF, nSet=setLoad, field=displacement, result=P, f(x)='np.sum(x[:,1], axis=0)', saveHistory=True, export=RF
+>>perElement, elSet=secConc, name=damage, result=omega, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
 
 *output, type=monitor, name=monitor
 fieldOutput=RF
 
 *output, type=ensight, name=esExport
-create=perNode, fieldOutput=displacement
-create=perNode, fieldOutput=nonlocal damage
-create=perElement, fieldOutput=damage
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perNode, fieldOutput=nonlocal damage
+>>perElement, fieldOutput=damage
+>>configuration, overwrite=yes
 
-*step, maxInc=1e-2, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=100
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=bottom, nSet=setBottom, field=displacement, 2=0, 1=0, 3=0
-dirichlet, name=load, nSet=setLoad, field=displacement, 2=+1
+*step, solver=theSolver
+maxInc=1e-2, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=100
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=bottom, nSet=setBottom, field=displacement, 2=0, 1=0, 3=0
+>>dirichlet, name=load, nSet=setLoad, field=displacement, 2=+1

--- a/testfiles/edelweiss-only/CantileverBeamHexa8/testGenerator.inp
+++ b/testfiles/edelweiss-only/CantileverBeamHexa8/testGenerator.inp
@@ -20,15 +20,14 @@ elType  =C3D8N
 all
 
 *fieldOutput
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
 
 *output, type=ensight, name=test
-create=perNode, fieldOutput=displacement
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>configuration, overwrite=yes
 
-*output, type=monitor
-
-*step, solver=theSolver, maxInc=1e0, minInc=1e-9, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=off
-dirichlet, name=Left,  nSet=gen_left, field=displacement, 1=0.0, 2=0.0, 3=.0
-nodeforces, name=cloadTop, nSet=gen_rightBack, components='0, 0, .02', field=displacement
+*step, solver=theSolver
+maxInc=1e0, minInc=1e-9, maxNumInc=1000, maxIter=25, stepLength=1
+>>options, category=NISTSolver, extrapolation=off
+>>dirichlet, name=Left,  nSet=gen_left, field=displacement, 1=0.0, 2=0.0, 3=.0
+>>nodeforces, name=cloadTop, nSet=gen_rightBack, components='0, 0, .02', field=displacement

--- a/testfiles/edelweiss-only/CantileverBeamHexa8/testMesh.inp
+++ b/testfiles/edelweiss-only/CantileverBeamHexa8/testMesh.inp
@@ -12,13 +12,14 @@ all
 *solver, solver=NIST, name=theSolver
 
 *fieldOutput
-create=perNode, name=displacement, elSet=all, field=displacement, result=U
+>>perNode, name=displacement, elSet=all, field=displacement, result=U
 
 *output, type=ensight, name=ensightExport
-configuration, overwrite=yes
-create=perNode,    fieldOutput=displacement
+>>configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
 
-*step, solver=theSolver, maxInc=1e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
+*step, solver=theSolver
+maxInc=1e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
 **options, category=NISTSolver, extrapolation=linear
-dirichlet, name=top,  nSet=leftbottom, field=displacement, 1=0.0, 2=0.0, 3=.0
-nodeforces, name=cloadTop, nSet=righttop, components='0, 0, 300', field=displacement
+>>dirichlet, name=top,  nSet=leftbottom, field=displacement, 1=0.0, 2=0.0, 3=.0
+>>nodeforces, name=cloadTop, nSet=righttop, components='0, 0, 300', field=displacement

--- a/testfiles/edelweiss-only/WallShearHexa8VonMises/testLong.inp
+++ b/testfiles/edelweiss-only/WallShearHexa8VonMises/testLong.inp
@@ -19,37 +19,36 @@ elType  =C3D8
 *section, name=section1, material=vonmises, type=solid
 all
 
-*fieldOutput
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
-create=perElement, elSet=all, result=strain, name=strain, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
-create=perElement, elSet=all, result=stress, name=stress, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
-create=perElement, elSet=all, result=stress, name=stress0, quadraturePoint=0
-create=perElement, elSet=all, result=stress, name=stress1, quadraturePoint=1
-create=perElement, elSet=all, result=stress, name=stress2, quadraturePoint=2
-create=perElement, elSet=all, result=stress, name=stress3, quadraturePoint=3
-create=perElement, elSet=all, result=stress, name=stress4, quadraturePoint=4
-create=perElement, elSet=all, result=stress, name=stress5, quadraturePoint=5
-create=perElement, elSet=all, result=stress, name=stress6, quadraturePoint=6
-create=perElement, elSet=all, result=stress, name=stress7, quadraturePoint=7
+*fieldOutput,
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perElement, elSet=all, result=strain, name=strain, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
+>>perElement, elSet=all, result=stress, name=stress, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
+>>perElement, elSet=all, result=stress, name=stress0, quadraturePoint=0
+>>perElement, elSet=all, result=stress, name=stress1, quadraturePoint=1
+>>perElement, elSet=all, result=stress, name=stress2, quadraturePoint=2
+>>perElement, elSet=all, result=stress, name=stress3, quadraturePoint=3
+>>perElement, elSet=all, result=stress, name=stress4, quadraturePoint=4
+>>perElement, elSet=all, result=stress, name=stress5, quadraturePoint=5
+>>perElement, elSet=all, result=stress, name=stress6, quadraturePoint=6
+>>perElement, elSet=all, result=stress, name=stress7, quadraturePoint=7
 
 *output, type=ensight, name=test
-create=perNode, fieldOutput=displacement
-configuration, overwrite=yes
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-create=perElement, fieldOutput=stress0
-create=perElement, fieldOutput=stress1
-create=perElement, fieldOutput=stress2
-create=perElement, fieldOutput=stress3
-create=perElement, fieldOutput=stress4
-create=perElement, fieldOutput=stress5
-create=perElement, fieldOutput=stress6
-create=perElement, fieldOutput=stress7
+>>perNode, fieldOutput=displacement
+>>configuration, overwrite=yes
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>perElement, fieldOutput=stress0
+>>perElement, fieldOutput=stress1
+>>perElement, fieldOutput=stress2
+>>perElement, fieldOutput=stress3
+>>perElement, fieldOutput=stress4
+>>perElement, fieldOutput=stress5
+>>perElement, fieldOutput=stress6
+>>perElement, fieldOutput=stress7
 
-*output, type=monitor
-
-*step, solver=theSolver, maxInc=0.1, minInc=1e-9, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=off
-dirichlet, name=Bottom,  nSet=gen_bottom, field=displacement, 1=0.0, 2=0.0, 3=.0
-nodeforces, name=cloadTop, nSet=gen_top, components='10000., 0, 0', field=displacement
-bodyforce, name=bforce, elSet=all, forceVector='0.0, -0.77, 0'
+*step, solver=theSolver
+maxInc=0.1, minInc=1e-9, maxNumInc=1000, maxIter=25, stepLength=1
+>>options, category=NISTSolver, extrapolation=off
+>>dirichlet, name=Bottom,  nSet=gen_bottom, field=displacement, 1=0.0, 2=0.0, 3=.0
+>>nodeforces, name=cloadTop, nSet=gen_top, components='10000., 0, 0', field=displacement
+>>bodyforce, name=bforce, elSet=all, forceVector='0.0, -0.77, 0'

--- a/testfiles/marmot/AnalyticalFieldsFromVtk/_test.inp
+++ b/testfiles/marmot/AnalyticalFieldsFromVtk/_test.inp
@@ -20,19 +20,19 @@ elType  =C3D8
 all
 
 *fieldOutput
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
-create=perElement, elSet=all, result=strain, name=strain, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
-create=perElement, elSet=all, result=stress, name=stress, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perElement, elSet=all, result=strain, name=strain, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
+>>perElement, elSet=all, result=stress, name=stress, quadraturePoint=0:8, f(x)='np.mean(x,axis=1)'
 
-create=perElement, elSet=all, result=kappa, name=kappa, quadraturePoint=0:8
-create=perElement, elSet=all, result=kappa, name=kappaMax, quadraturePoint=0:8, f(x)='np.max(x, axis=1)'
+>>perElement, elSet=all, result=kappa, name=kappa, quadraturePoint=0:8
+>>perElement, elSet=all, result=kappa, name=kappaMax, quadraturePoint=0:8, f(x)='np.max(x, axis=1)'
 
 *output, type=ensight, name=test
-create=perNode, fieldOutput=displacement
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-create=perElement, fieldOutput=kappaMax
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>perElement, fieldOutput=kappaMax
+>>configuration, overwrite=yes
 
 ***output, type=monitor
 
@@ -40,9 +40,11 @@ configuration, overwrite=yes
 file="./HNEA01-01-16b-cleaned-210.0-voidRatio.vtk",
 result="voidRatioBinary",
 
-*step, maxInc=1e0, minInc=1e0, maxNumInc=100, maxIter=25, stepLength=1, solver=theSolver
+*step, solver=theSolver
+maxInc=1e0, minInc=1e0, maxNumInc=100, maxIter=25, stepLength=1
 setfield,   name=sf,  fieldOutput=kappa, type=analyticalField, value=AnalyticalField-01
-dirichlet,  name=z0u, nSet=gen_back,      field=displacement, 1=0., 2=0., 3=0.
+>>dirichlet,  name=z0u, nSet=gen_back,      field=displacement, 1=0., 2=0., 3=0.
 
-*step, maxInc=1e-1, minInc=1e-6, maxNumInc=100, maxIter=25, stepLength=1, solver=theSolver
-dirichlet,  name=y1u, nSet=gen_front,    field=displacement, 3=-50.
+*step, solver=theSolver
+maxInc=1e-1, minInc=1e-6, maxNumInc=100, maxIter=25, stepLength=1
+>>dirichlet,  name=y1u, nSet=gen_front,    field=displacement, 3=-50.

--- a/testfiles/marmot/Barodesy/test_.inp
+++ b/testfiles/marmot/Barodesy/test_.inp
@@ -9,52 +9,57 @@ h=0.1
 ** phiC N lambda* kappa* sigma* (1 when calculating in kpa) numericalCohesion
 24, 0.8, 0.059, 0.018, 1, 0.1
 
-*section, name=section1, thickness=1.0, material=wealdClay, type=plane
+*section, name=section1, material=wealdClay, type=plane
 all
 
 *job, name=cpe4job, domain=2d, solver=NISTParallel
+*solver, solver=NISTParallel, name=theSolver
 
-*fieldOutput, jobName=cpe4job
-create=perElement, name=q,            elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,1])', saveHistory=True
-create=perElement, name=eq,           elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,2])', saveHistory=True
-create=perElement, name=voidRatio,    elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,0]'
-create=perElement, name=dNorm,        elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,3]'
-create=perNode, name=Displacement, elSet=all, field=displacement, result=U,
-create=perElement, name=Stress,       elSet=all, result=stress, quadraturePoint=1
-create=perElement, name=Strain,       elSet=all, result=strain, quadraturePoint=1
-create=perNode, name=uTop,         nSet=gen_top,          field=displacement, result=U,    f(x)='mean(x[:, 1])', saveHistory=True
-create=perNode, name=sumRFNodes,   nSet=gen_top,          field=displacement, result=P,    f(x)='sum(x[:,  1])', saveHistory=True
+*fieldOutput,
+>>perElement, name=q,            elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,1])', saveHistory=True
+>>perElement, name=eq,           elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,2])', saveHistory=True
+>>perElement, name=voidRatio,    elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,0]'
+>>perElement, name=dNorm,        elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,3]'
+>>perNode, name=Displacement, elSet=all, field=displacement, result=U
+>>perElement, name=Stress,       elSet=all, result=stress, quadraturePoint=1
+>>perElement, name=Strain,       elSet=all, result=strain, quadraturePoint=1
+>>perNode, name=uTop,         nSet=gen_top,          field=displacement, result=U,    f(x)='mean(x[:, 1])', saveHistory=True
+>>perNode, name=sumRFNodes,   nSet=gen_top,          field=displacement, result=P,    f(x)='sum(x[:,  1])', saveHistory=True
 
 *output, type=ensight, name=barodesy
-create=perNode,    elSet=all, fieldOutput=Displacement
-create=perElement, elSet=all, fieldOutput=Stress
-create=perElement, elSet=all, fieldOutput=Strain
-create=perElement, elSet=all, fieldOutput=voidRatio
-create=perElement, elSet=all, fieldOutput=dNorm
-configuration, overwrite=yes
+>>perNode, fieldOutput=Displacement
+>>perElement, fieldOutput=Stress
+>>perElement, fieldOutput=Strain
+>>perElement, fieldOutput=voidRatio
+>>perElement, fieldOutput=dNorm
+>>configuration, overwrite=yes
 
-*step, maxInc=1e0, minInc=1e-5, maxNumInc=100000, maxIter=25, stepLength=1
-options,         category=NISTSolver, extrapolation=on0
-dirichlet,       name=bottom, nSet=gen_bottom,      field=displacement, 2=0.0
-dirichlet,       name=leftbottom, nSet=gen_leftBottom,      field=displacement, 1=0.0
-geostatic,       name=geo, elSet=all, p1=-100, h1=0, p2=-100, h2=200, xLateral=1.0, zLateral=1.0
-distributedload, name=dll, surface=gen_left, magnitude=100, f(t)=1, type=pressure
-distributedload, name=dlr, surface=gen_right, magnitude=100, f(t)=1, type=pressure
-distributedload, name=dlTop, surface=gen_top, magnitude=100, f(t)=1, type=pressure
-options,         category=NISTArcLength, arcLengthController=off
+*step, solver=theSolver
+maxInc=1e0, minInc=1e-5, maxNumInc=100000, maxIter=25, stepLength=1
+>>options,         category=NISTSolver, extrapolation=on0
+>>dirichlet,       name=bottom, nSet=gen_bottom,      field=displacement, 2=0.0
+>>dirichlet,       name=leftbottom, nSet=gen_leftBottom,      field=displacement, 1=0.0
+>>geostatic,       name=geo, elSet=all, p1=-100, h1=0, p2=-100, h2=200, xLateral=1.0, zLateral=1.0
+>>distributedload, name=dll, surface=gen_left, magnitude=100, f(t)=1, type=pressure
+>>distributedload, name=dlr, surface=gen_right, magnitude=100, f(t)=1, type=pressure
+>>distributedload, name=dlTop, surface=gen_top, magnitude=100, f(t)=1, type=pressure
+>>options,         category=NISTArcLength, arcLengthController=off
 
 
 
-*step, maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
-dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.003
-sdvini,    name=ini, elSet=all, sdv=0, val=0.40
-sdvini,    name=ini2, elSet=gen_shearBandCenter, sdv=0, val=0.43
+*step, solver=theSolver
+maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
+>>dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.003
+>>setinitialconditions, elSet=all, property='sdvini', values='0, 0.40'
+>>setinitialconditions, elSet=gen_shearBandCenter, property='sdvini', values='0, 0.43'
 
-*step, maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
-dirichlet, name=top, nSet=gen_top,  field=displacement, 2=0.002
+*step, solver=theSolver
+maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
+>>dirichlet, name=top, nSet=gen_top,  field=displacement, 2=0.002
 
-*step, maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
-dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.003
+*step, solver=theSolver
+maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
+>>dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.003
 
 *output, type=meshPlot,
 figure=1, axSpec=111, create=perElement, fieldOutput=voidRatio

--- a/testfiles/marmot/BarodesyGradientVoid/test_.inp
+++ b/testfiles/marmot/BarodesyGradientVoid/test_.inp
@@ -9,46 +9,49 @@ h=0.1
 ** phiC N lambda* kappa* sigma* (1 when calculating in kpa) numericalCohesion
 24, 0.8, 0.059, 0.018, 1, 0.1, 0.005
 
-*section, name=section1, thickness=1.0, material=wealdClay, type=plane
+*section, name=section1, material=wealdClay, type=plane
 all
 
 *job, name=cpe4job, domain=2d, solver=NISTParallel
+*solver, solver=NISTParallel, name=theSolver
 
-*fieldOutput, jobName=cpe4job
-create=perElement, name=q,            elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,1])', saveHistory=True
-create=perElement, name=eq,           elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,2])', saveHistory=True
-create=perElement, name=voidRatio,    elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,0]'
-create=perElement, name=dNorm,        elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,3]'
-create=perNode, name=Displacement, elSet=all, field=displacement, result=U,
-create=perElement, name=Stress,       elSet=all, result=stress, quadraturePoint=1
-create=perElement, name=Strain,       elSet=all, result=strain, quadraturePoint=1
-create=perNode, name=uTop,         nSet=gen_top,          field=displacement, result=U,    f(x)='mean(x[:, 1])', saveHistory=True
-create=perNode, name=sumRFNodes,   nSet=gen_top,          field=displacement, result=P,    f(x)='sum(x[:,  1])', saveHistory=True
+*fieldOutput,
+>>perElement, name=q,            elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,1])', saveHistory=True
+>>perElement, name=eq,           elSet=all, result=sdv, quadraturePoint=0:4, f(x)='mean(x[:,:,2])', saveHistory=True
+>>perElement, name=voidRatio,    elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,0]'
+>>perElement, name=dNorm,        elSet=all, result=sdv, quadraturePoint=1, f(x)='x[:,3]'
+>>perNode, name=Displacement, elSet=all, field=displacement, result=U
+>>perElement, name=Stress,       elSet=all, result=stress, quadraturePoint=1
+>>perElement, name=Strain,       elSet=all, result=strain, quadraturePoint=1
+>>perNode, name=uTop,         nSet=gen_top,          field=displacement, result=U,    f(x)='mean(x[:, 1])', saveHistory=True
+>>perNode, name=sumRFNodes,   nSet=gen_top,          field=displacement, result=P,    f(x)='sum(x[:,  1])', saveHistory=True
 
 *output, type=ensight, name=barodesy
-create=perNode,    elSet=all, fieldOutput=Displacement
-create=perElement, elSet=all, fieldOutput=Stress
-create=perElement, elSet=all, fieldOutput=Strain
-create=perElement, elSet=all, fieldOutput=voidRatio
-create=perElement, elSet=all, fieldOutput=dNorm
-configuration, overwrite=yes
+>>perNode, fieldOutput=Displacement
+>>perElement, fieldOutput=Stress
+>>perElement, fieldOutput=Strain
+>>perElement, fieldOutput=voidRatio
+>>perElement, fieldOutput=dNorm
+>>configuration, overwrite=yes
 
-*step, maxInc=1e0, minInc=1e-5, maxNumInc=100000, maxIter=25, stepLength=1
-options,         category=NISTSolver, extrapolation=on0
-dirichlet,       name=bottom, nSet=gen_bottom,      field=displacement, 2=0.0
-dirichlet,       name=leftbottom, nSet=gen_leftBottom,      field=displacement, 1=0.0
-geostatic,       name=geo, elSet=all, p1=-100, h1=0, p2=-100, h2=200, xLateral=1.0, zLateral=1.0
-distributedload, name=dll, surface=gen_left, magnitude=100, f(t)=1, type=pressure
-distributedload, name=dlr, surface=gen_right, magnitude=100, f(t)=1, type=pressure
-distributedload, name=dlTop, surface=gen_top, magnitude=100, f(t)=1, type=pressure
-options,         category=NISTArcLength, arcLengthController=off
+*step, solver=theSolver
+maxInc=1e0, minInc=1e-5, maxNumInc=100000, maxIter=25, stepLength=1
+>>options,         category=NISTSolver, extrapolation=on0
+>>dirichlet,       name=bottom, nSet=gen_bottom,      field=displacement, 2=0.0
+>>dirichlet,       name=leftbottom, nSet=gen_leftBottom,      field=displacement, 1=0.0
+>>geostatic,       name=geo, elSet=all, p1=-100, h1=0, p2=-100, h2=200, xLateral=1.0, zLateral=1.0
+>>distributedload, name=dll, surface=gen_left, magnitude=100, f(t)=1, type=pressure
+>>distributedload, name=dlr, surface=gen_right, magnitude=100, f(t)=1, type=pressure
+>>distributedload, name=dlTop, surface=gen_top, magnitude=100, f(t)=1, type=pressure
+>>options,         category=NISTArcLength, arcLengthController=off
 
 
 
-*step, maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
-dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.01
-sdvini,    name=ini, elSet=all, sdv=0, val=0.40
-sdvini,    name=ini2, elSet=gen_shearBandCenter, sdv=0, val=0.43
+*step, solver=theSolver
+maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
+>>dirichlet, name=top, nSet=gen_top,  field=displacement, 2=-0.01
+>>setinitialconditions, elSet=all, property='sdvini', values='0, 0.40'
+>>setinitialconditions, elSet=gen_shearBandCenter, property='sdvini', values='0, 0.43'
 
 ***step, maxInc=1e-2, minInc=1e-9, maxNumInc=100000, maxIter=25, stepLength=1
 **dirichlet, name=top, nSet=gen_top,  field=displacement, 2=0.002

--- a/testfiles/marmot/DLoad3DUpdatedLagrange/_test.inp
+++ b/testfiles/marmot/DLoad3DUpdatedLagrange/_test.inp
@@ -3848,24 +3848,25 @@ _loadsurf_S3, 3
 *material, name=stvenantkirchhoffisotropic, id=stvenantkirchhoffisotropic
 5000, 0.25
 
-*section, name=section1, thickness=1.0, material=stvenantkirchhoffisotropic, type=plane
+*section, name=section1, material=stvenantkirchhoffisotropic, type=plane
 all
 
 *job, name=c3d8job, domain=3d
 *solver, solver=NIST, name=theSolver
 
-*fieldOutput
-create=perNode, name=displacement, elSet=all, field=displacement, result=U, name=displacement
-create=perElement, name=stress, elSet=all, result=stress, quadraturePoint=1
-create=perElement, name=strain, elSet=all, result=strain, quadraturePoint=1
+*fieldOutput,
+>>perNode, name=displacement, elSet=all, field=displacement, result=U
+>>perElement, name=stress, elSet=all, result=stress, quadraturePoint=1
+>>perElement, name=strain, elSet=all, result=strain, quadraturePoint=1
 
 *output, type=ensight, name=ensightExport
-create=perNode,    fieldOutput=displacement
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>configuration, overwrite=yes
 
-*step, solver=theSolver, maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=clamp,  nSet=Set-1,   field=displacement, 1=0.0, 2=0.0, 3=0.
-distributedload, name=dload, surface=loadsurf, type=pressure, magnitude=10, f(t)=t
+*step, solver=theSolver
+maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=clamp,  nSet=Set-1,   field=displacement, 1=0.0, 2=0.0, 3=0.
+>>distributedload, name=dload, surface=loadsurf, type=pressure, magnitude=10, f(t)=t

--- a/testfiles/marmot/FieldOutput/fieldOutput.inp
+++ b/testfiles/marmot/FieldOutput/fieldOutput.inp
@@ -1,10 +1,11 @@
 *material, name=modleon, id=modleon
 30000.0, 0.15 ,13 , 47.4 ,  55   , 4.74 , 0.85 , 0.12 , 0.003, 2.0, 0.000001, 15.0, 0.10, 1
 
-*section, name=section1, thickness=1.0, material=modleon, type=plane
+*section, name=section1, material=modleon, type=plane
 all
 
 *job, name=cps4job, domain=2d, solver=NIST
+*solver, solver=NIST, name=theSolver
 
 *modelGenerator, generator=planeRectQuad, name=gen
 x0=0, l=50
@@ -14,14 +15,14 @@ nX=20
 nY=20
 
 *fieldOutput,
-create=perNode, name=displacement,              nSet=all,           field=displacement, result=U,
-create=perNode, name=displacement_top,          nSet=gen_top,       field=displacement, result=U, saveHistory=True
-create=perNode, name=displacement_top_mean_1,   nSet=gen_top,       field=displacement, result=U, saveHistory=True, f(x)='mean( x[:,1])'
-create=perNode, name=RF_bottom,                 nSet=gen_bottom,    field=displacement, result=P, saveHistory=True
-create=perNode, name=RF_bottom_sum_1,           nSet=gen_bottom,    field=displacement, result=P, saveHistory=True, f(x)='sum(x[:,1])'
-create=perElement, name=stress,                    elSet=all,          result=stress,      quadraturePoint=1
-create=perElement, name=stress_top,                elSet=gen_top,      result=stress,      quadraturePoint=1
-create=perElement, name=alphaP,                    elSet=all,          result=alphaP,      quadraturePoint=1
+>>perNode, name=displacement,              nSet=all,           field=displacement, result=U
+>>perNode, name=displacement_top,          nSet=gen_top,       field=displacement, result=U, saveHistory=True
+>>perNode, name=displacement_top_mean_1,   nSet=gen_top,       field=displacement, result=U, saveHistory=True, f(x)='mean( x[:,1])'
+>>perNode, name=RF_bottom,                 nSet=gen_bottom,    field=displacement, result=P, saveHistory=True
+>>perNode, name=RF_bottom_sum_1,           nSet=gen_bottom,    field=displacement, result=P, saveHistory=True, f(x)='sum(x[:,1])'
+>>perElement, name=stress,                    elSet=all,          result=stress,      quadraturePoint=1
+>>perElement, name=stress_top,                elSet=gen_top,      result=stress,      quadraturePoint=1
+>>perElement, name=alphaP,                    elSet=all,          result=alphaP,      quadraturePoint=1
 
 ** *output, type=meshPlot,
 ** figure=1, axSpec=221, create=perNode,       fieldOutput=displacement,       f(x)='x[:,1]', label=U2
@@ -29,10 +30,10 @@ create=perElement, name=alphaP,                    elSet=all,          result=al
 ** figure=1, axSpec=212, c=red, ls=dashed, create=xyData, x=time, y=RF_bottom, f(y)='sum ( y[:,:,1], axis=1)', label=Sum(RF)
 
 *output, type=ensight, name=myEnsightExport
-create=perNode,    fieldOutput=displacement,
-create=perElement, fieldOutput=stress,
-create=perElement, fieldOutput=alphaP,
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=alphaP
+>>configuration, overwrite=yes
 
 
 *output, type=monitor, name=myNodeMonitor
@@ -41,9 +42,10 @@ fieldOutput=RF_bottom, f(x)='sum ( x[:,1] )'
 *output, type=plotAlongPath, name=myNodeSetPlotter
 figure=2, nSet=gen_top, fieldOutput=RF_bottom, f(x)='x[:,1]', label=P along bottom, normalize=True
 
-*step, maxInc=1e-1, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=100
-options, category=Ensight, intermediateSaveInterval=2,
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=1,          nSet=gen_leftBottom,    field=displacement, 2=0.0, 1=0.0
-dirichlet, name=bottom,     nSet=gen_bottom,        field=displacement, 2=0,
-nodeforces, name=top,       nSet=gen_top,           field=displacement, 2=-80, f(t)=t**2
+*step, solver=theSolver
+maxInc=1e-1, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=100
+>>options, category=Ensight, intermediateSaveInterval=2,
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=1,          nSet=gen_leftBottom,    field=displacement, 2=0.0, 1=0.0
+>>dirichlet, name=bottom,     nSet=gen_bottom,        field=displacement, 2=0,
+>>nodeforces, name=top,       nSet=gen_top,           field=displacement, 2=-80, f(t)=t**2

--- a/testfiles/marmot/GC3D20RMixed/test.inp
+++ b/testfiles/marmot/GC3D20RMixed/test.inp
@@ -4,7 +4,7 @@
 all
 
 *job, name=c3d8nljob, domain=3d
-*solver, solver=NISTParallelForMarmotElements, name=theSolver
+*solver, solver=NISTParallel, name=theSolver
 
 *include, input=mesh.inp
 

--- a/testfiles/marmot/GC3D8EAS9/testeas.inp
+++ b/testfiles/marmot/GC3D8EAS9/testeas.inp
@@ -12,55 +12,57 @@ weak
 
 *job, name=easjob, domain=3d
 *solver, solver=NISTParallel, name=theSolver
-*fieldOutput
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
-create=perNode, elSet=all, field=nonlocal damage, result=U, name=alpha_d_nonlocal
-create=perElement, elSet=all, result=stress, quadraturePoint=0:8, name=stress, f(x)='mean(x, axis=1)'
-create=perElement, elSet=all, result=strain, quadraturePoint=0:8, name=strain, f(x)='mean(x, axis=1)'
-create=perElement, elSet=all, result=alphaP, quadraturePoint=0:8, name=alphaP, f(x)='mean( x[:,:], axis=1) '
-create=perElement, elSet=all, result=alphaD, quadraturePoint=0:8, name=alphaD, f(x)='mean( x[:,:], axis=1) '
-create=perElement, elSet=all, result=omega, quadraturePoint=0:8, name=omega, f(x)='mean( x[:,:], axis=1) '
-create=perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas0, f(x)='mean( x[:,:,0], axis=1) '
-create=perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas1, f(x)='mean( x[:,:,1], axis=1) '
-create=perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas2, f(x)='mean( x[:,:,2], axis=1) '
-create=perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas3, f(x)='mean( x[:,:,3], axis=1) '
-create=perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas4, f(x)='mean( x[:,:,4], axis=1) '
-create=perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas5, f(x)='mean( x[:,:,5], axis=1) '
-create=perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas6, f(x)='mean( x[:,:,6], axis=1) '
-create=perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas7, f(x)='mean( x[:,:,7], axis=1) '
-create=perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas8, f(x)='mean( x[:,:,8], axis=1) '
-create=perNode, nSet=top, field=displacement, result=P, f(x)='( sum(x[:, 1]) ) ', name=RFTop, saveHistory=true
+*fieldOutput,
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, elSet=all, field=nonlocal damage, result=U, name=alpha_d_nonlocal
+>>perElement, elSet=all, result=stress, quadraturePoint=0:8, name=stress, f(x)='mean(x, axis=1)'
+>>perElement, elSet=all, result=strain, quadraturePoint=0:8, name=strain, f(x)='mean(x, axis=1)'
+>>perElement, elSet=all, result=alphaP, quadraturePoint=0:8, name=alphaP, f(x)='mean( x[:,:], axis=1) '
+>>perElement, elSet=all, result=alphaD, quadraturePoint=0:8, name=alphaD, f(x)='mean( x[:,:], axis=1) '
+>>perElement, elSet=all, result=omega, quadraturePoint=0:8, name=omega, f(x)='mean( x[:,:], axis=1) '
+>>perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas0, f(x)='mean( x[:,:,0], axis=1) '
+>>perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas1, f(x)='mean( x[:,:,1], axis=1) '
+>>perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas2, f(x)='mean( x[:,:,2], axis=1) '
+>>perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas3, f(x)='mean( x[:,:,3], axis=1) '
+>>perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas4, f(x)='mean( x[:,:,4], axis=1) '
+>>perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas5, f(x)='mean( x[:,:,5], axis=1) '
+>>perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas6, f(x)='mean( x[:,:,6], axis=1) '
+>>perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas7, f(x)='mean( x[:,:,7], axis=1) '
+>>perElement, elSet=all, result=enhancedstrainparameters, quadraturePoint=0:8, name=eas8, f(x)='mean( x[:,:,8], axis=1) '
+>>perNode, nSet=top, field=displacement, result=P, f(x)='( sum(x[:, 1]) ) ', name=RFTop, saveHistory=true
 
 *output, type=ensight, name=esExport
-create=perNode,    fieldOutput=displacement
-create=perNode,    fieldOutput=alpha_d_nonlocal
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
-create=perElement, fieldOutput=eas0
-create=perElement, fieldOutput=eas1
-create=perElement, fieldOutput=eas2
-create=perElement, fieldOutput=eas3
-create=perElement, fieldOutput=eas4
-create=perElement, fieldOutput=eas5
-create=perElement, fieldOutput=eas6
-create=perElement, fieldOutput=eas7
-create=perElement, fieldOutput=eas8
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perNode, fieldOutput=alpha_d_nonlocal
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
+>>perElement, fieldOutput=eas0
+>>perElement, fieldOutput=eas1
+>>perElement, fieldOutput=eas2
+>>perElement, fieldOutput=eas3
+>>perElement, fieldOutput=eas4
+>>perElement, fieldOutput=eas5
+>>perElement, fieldOutput=eas6
+>>perElement, fieldOutput=eas7
+>>perElement, fieldOutput=eas8
+>>configuration, overwrite=yes
 
 *output, type=meshplot, name=RFPlot
-create=xyData, x=time, y=RFTop, legend=RF
+figure=1, axSpec=111, create=xyData, x=time, y=RFTop, legend=RF
 
-*step, solver=theSolver, maxInc=1e-1, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=100
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=bcCorner,     nSet=origin,      field=displacement,     1=0, 2=0, 3=0
-dirichlet, name=bottom2, nSet=bottom,  field=displacement,               2=0,
-dirichlet, name=zrot,   nSet=zrotlock, field=displacement,             3=0,
-dirichlet, name=back,   nSet=back, field=displacement,             3=0,
-dirichlet, name=front,   nSet=front, field=displacement,             3=0,
+*step, solver=theSolver
+maxInc=1e-1, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=100
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=bcCorner,     nSet=origin,      field=displacement,     1=0, 2=0, 3=0
+>>dirichlet, name=bottom2, nSet=bottom,  field=displacement,               2=0,
+>>dirichlet, name=zrot,   nSet=zrotlock, field=displacement,             3=0,
+>>dirichlet, name=back,   nSet=back, field=displacement,             3=0,
+>>dirichlet, name=front,   nSet=front, field=displacement,             3=0,
 
-*step, solver=theSolver, maxInc=1e-2, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=100
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=top, nSet=top, field=displacement, 2=-2,
+*step, solver=theSolver
+maxInc=1e-2, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=100
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=top, nSet=top, field=displacement, 2=-2,

--- a/testfiles/marmot/GCPS8R/notchedbeam.inp
+++ b/testfiles/marmot/GCPS8R/notchedbeam.inp
@@ -2,36 +2,38 @@
 *material, name=modleonNonLocal, id=modleon
 30000.0, 0.15 ,13 , 47.4 ,  55   , 4.74 , 0.85 , 0.12 , 0.003, 2.0, 0.000001, 15.0, 5, 1.05, 0.0017, 1
 
-*section, name=section1, thickness=1.0, material=modleon, type=plane
+*section, name=section1, material=modleon, type=plane
 all
 
 *job, name=cps8rnljob, domain=2d, solver=NISTParallel
-*fieldOutput
-create=perNode, name=load, nSet=topNodes,  field=displacement, result=P
-create=perNode, name=displacement, elSet=all, field=displacement, result=U, name=displacement
-create=perNode, name=nonlocalDamage, elSet=all, field=nonlocal damage, result=U,
-create=perElement, name=stress, elSet=all, result=stress, quadraturePoint=0:4, f(x)='mean(x, axis=1)'
-create=perElement, name=strain, elSet=all, result=strain, quadraturePoint=0:4, f(x)='mean(x, axis=1)'
-create=perElement, name=alphaP, elSet=all, result=alphaP, quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
-create=perElement, name=alphaD, elSet=all, result=alphaD,quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
-create=perElement, name=omega, elSet=all, result=omega, quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
+*solver, solver=NISTParallel, name=theSolver
+*fieldOutput,
+>>perNode, name=load, nSet=topNodes,  field=displacement, result=P
+>>perNode, name=displacement, elSet=all, field=displacement, result=U
+>>perNode, name=nonlocalDamage, elSet=all, field=nonlocal damage, result=U
+>>perElement, name=stress, elSet=all, result=stress, quadraturePoint=0:4, f(x)='mean(x, axis=1)'
+>>perElement, name=strain, elSet=all, result=strain, quadraturePoint=0:4, f(x)='mean(x, axis=1)'
+>>perElement, name=alphaP, elSet=all, result=alphaP, quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
+>>perElement, name=alphaD, elSet=all, result=alphaD,quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
+>>perElement, name=omega, elSet=all, result=omega, quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
 
 
-*output, type=monitor, jobName=cps8rnljob
+*output, type=monitor
 fieldOutput=load, f(x)='sum(x[:,1])'
 
 *output, type=ensight, name=ensightExport
-create=perNode,    fieldOutput=displacement
-create=perNode,    fieldOutput=nonlocalDamage
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perNode, fieldOutput=nonlocalDamage
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
+>>configuration, overwrite=yes
 
-*step, maxInc=1e-1, minInc=1e-6, maxNumInc=1000, maxIter=25,
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=left,  nSet=left,   field=displacement, 1=0.0, 2=0.0
-dirichlet, name=right, nSet=right,  field=displacement, 2=0
-dirichlet, name=top, nSet=topNodes, field=displacement, 2=-.5
+*step, solver=theSolver
+maxInc=1e-1, minInc=1e-6, maxNumInc=1000, maxIter=25
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=left,  nSet=left,   field=displacement, 1=0.0, 2=0.0
+>>dirichlet, name=right, nSet=right,  field=displacement, 2=0
+>>dirichlet, name=top, nSet=topNodes, field=displacement, 2=-.5

--- a/testfiles/marmot/GCPS8RMixed/notchedbeam.inp
+++ b/testfiles/marmot/GCPS8RMixed/notchedbeam.inp
@@ -2,38 +2,40 @@
 *material, name=modleonNonLocal, id=modleon
 30000.0, 0.15 ,13 , 47.4 ,  55   , 4.74 , 0.85 , 0.12 , 0.003, 2.0, 0.000001, 15.0, 5, 1.05, 0.0017, 1
 
-*section, name=section1, thickness=1.0, material=modleon, type=plane
+*section, name=section1, material=modleon, type=plane
 all
 
 *job, name=myjob, domain=2d, solver=NISTParallel
-*fieldOutput
-create=perNode, name=load, nSet=topNodes,  field=displacement, result=P
-create=perNode, name=displacement, elSet=all, field=displacement, result=U, name=displacement
+*solver, solver=NISTParallel, name=theSolver
+*fieldOutput,
+>>perNode, name=load, nSet=topNodes,  field=displacement, result=P
+>>perNode, name=displacement, elSet=all, field=displacement, result=U
 **name=nonlocalDamage, elSet=all, field=nonlocal damage, result=U, <-- this option is currently not supported by fieldoutput in Edelweiss
 **name=stress, elSet=all, result=stress, quadraturePoint=0:4, f(x)='mean(x, axis=1)'
 **name=strain, elSet=all, result=strain, quadraturePoint=0:4, f(x)='mean(x, axis=1)'
 **name=alphaP, elSet=all, result=alphaP, quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
 **name=alphaD, elSet=all, result=alphaD,quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
-create=perElement, name=omega, elSet=all, result=omega, quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
-create=perElement, elSet=all, result=stress, quadraturePoint=0:4, name=stress, f(x)='mean(x, axis=1)'
-create=perElement, elSet=all, result=strain, quadraturePoint=0:4, name=strain, f(x)='mean(x, axis=1)'
+>>perElement, name=omega, elSet=all, result=omega, quadraturePoint=0:4, f(x)='mean(x[:,:], axis=1)'
+>>perElement, elSet=all, result=stress, quadraturePoint=0:4, name=stress, f(x)='mean(x, axis=1)'
+>>perElement, elSet=all, result=strain, quadraturePoint=0:4, name=strain, f(x)='mean(x, axis=1)'
 
 
-*output, type=monitor, jobName=myjob
+*output, type=monitor
 fieldOutput=load, f(x)='sum(x[:,1])'
 
 *output, type=ensight, name=notchedBeam
-configuration, overwrite=yes
-create=perNode,    fieldOutput=displacement
+>>configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
 **create=perNode,    fieldOutput=nonlocalDamage
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
 **create=perElement, fieldOutput=alphaP
 **create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
+>>perElement, fieldOutput=omega
 
-*step, maxInc=1e-1, minInc=1e-6, maxNumInc=1000, maxIter=25,
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=left,  nSet=left,   field=displacement, 1=0.0, 2=0.0
-dirichlet, name=right, nSet=right,  field=displacement, 2=0
-dirichlet, name=top, nSet=topNodes, field=displacement, 2=-.5
+*step, solver=theSolver
+maxInc=1e-1, minInc=1e-6, maxNumInc=1000, maxIter=25
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=left,  nSet=left,   field=displacement, 1=0.0, 2=0.0
+>>dirichlet, name=right, nSet=right,  field=displacement, 2=0
+>>dirichlet, name=top, nSet=topNodes, field=displacement, 2=-.5

--- a/testfiles/marmot/GMCDPFiniteStrainPlaneStrain/test_large.inp
+++ b/testfiles/marmot/GMCDPFiniteStrainPlaneStrain/test_large.inp
@@ -14,15 +14,16 @@ all
 gen_shearBandCenter
 
 *job, name=cpe4job, domain=2d, solver=NISTParallel
-*fieldOutput
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
-create=perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
-create=perNode, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
-create=perElement, elSet=all, result=alphaP, quadraturePoint=0:4, name=alphaP, f(x)='max( x[:,:], axis=1) '
-create=perElement, elSet=all, result=alphaD, quadraturePoint=0:4, name=alphaD, f(x)='max( x[:,:], axis=1) '
-create=perElement, elSet=all, result=omega, quadraturePoint=0:4, name=omega, f(x)='max( x[:,:], axis=1) '
-create=perNode, name=RF, nSet=top, field=displacement, result=P, f(x)='sum(x[:,1])', saveHistory=True, export=RF
-create=perNode, name=U, nSet=top, field=displacement, result=U, f(x)='mean(x[:,1])', saveHistory=True, export=U
+*solver, solver=NISTParallel, name=theSolver
+*fieldOutput,
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
+>>perNode, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
+>>perElement, elSet=all, result=alphaP, quadraturePoint=0:4, name=alphaP, f(x)='max( x[:,:], axis=1) '
+>>perElement, elSet=all, result=alphaD, quadraturePoint=0:4, name=alphaD, f(x)='max( x[:,:], axis=1) '
+>>perElement, elSet=all, result=omega, quadraturePoint=0:4, name=omega, f(x)='max( x[:,:], axis=1) '
+>>perNode, name=RF, nSet=top, field=displacement, result=P, f(x)='sum(x[:,1])', saveHistory=True, export=RF
+>>perNode, name=U, nSet=top, field=displacement, result=U, f(x)='mean(x[:,1])', saveHistory=True, export=U
 
 *modelGenerator, generator=planeRectQuad, name=gen
 x0=0, h=200
@@ -38,13 +39,13 @@ fieldOutput=alphaD, f(x)='max(x)'
 fieldOutput=RF
 
 *output, type=ensight, name=esExport
-configuration,     overwrite=True
-create=perNode,    fieldOutput=displacement
-create=perNode,    fieldOutput=micro rotation
-create=perNode,    fieldOutput=nonlocal damage
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
+>>configuration,     overwrite=True
+>>perNode, fieldOutput=displacement
+>>perNode, fieldOutput=micro rotation
+>>perNode, fieldOutput=nonlocal damage
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
 
 ***output, type=meshplot, name=RFPlot
 **figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
@@ -52,9 +53,10 @@ create=perElement, fieldOutput=omega
 ***exportPlots,
 **figure=2, fileName=mesh
 
-*step, maxInc=5e-2, minInc=1e-5, maxNumInc=10000, maxIter=25, stepLength=100
-options, category=NISTSolver, extrapolation=linear
+*step, solver=theSolver
+maxInc=5e-2, minInc=1e-5, maxNumInc=10000, maxIter=25, stepLength=100
+>>options, category=NISTSolver, extrapolation=linear
 initializematerial, name=init, elSet=all
-dirichlet, name=bottom, nSet=gen_bottom,  field=displacement, 2=0,
-dirichlet, name=bc, nSet=gen_leftBottom,  field=displacement, 2=0, 1=0
-dirichlet, name=top, nSet=gen_top, field=displacement, 2=-20
+>>dirichlet, name=bottom, nSet=gen_bottom,  field=displacement, 2=0,
+>>dirichlet, name=bc, nSet=gen_leftBottom,  field=displacement, 2=0, 1=0
+>>dirichlet, name=top, nSet=gen_top, field=displacement, 2=-20

--- a/testfiles/marmot/GMCDPPlaneStrain/test_.inp
+++ b/testfiles/marmot/GMCDPPlaneStrain/test_.inp
@@ -11,21 +11,22 @@
 **0.75,        -0.25,   0.75,     -.25,           0.333333332,  0
 
 
-*section, name=section1, thickness=1.0, material=GMCDP, type=plane
+*section, name=section1, material=GMCDP, type=plane
 all
-*section, name=section2, thickness=.98, material=GMCDP, type=plane
+*section, name=section2, material=GMCDP, type=plane
 gen_shearBand
 
 *job, name=cpe4job, domain=2d, solver=NISTParallel
-*fieldOutput
-elSet=all, field=displacement, result=U, name=displacement
-elSet=all, field=micro rotation, result=U, name=micro rotation
-elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
-elSet=all, result=alphaP, quadraturePoint=0:4, name=alphaP, f(x)='max( x[:,:], axis=1) '
-elSet=all, result=alphaD, quadraturePoint=0:4, name=alphaD, f(x)='max( x[:,:], axis=1) '
-elSet=all, result=omega, quadraturePoint=0:4, name=omega, f(x)='max( x[:,:], axis=1) '
-name=RF, nSet=gen_top, field=displacement, result=P, f(x)='sum(x[:,1])', saveHistory=True
-name=U, nSet=gen_top, field=displacement, result=U, f(x)='mean(x[:,1])', saveHistory=True
+*solver, solver=NISTParallel, name=theSolver
+*fieldOutput,
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
+>>perNode, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
+>>perElement, elSet=all, result=alphaP, quadraturePoint=0:4, name=alphaP, f(x)='max( x[:,:], axis=1) '
+>>perElement, elSet=all, result=alphaD, quadraturePoint=0:4, name=alphaD, f(x)='max( x[:,:], axis=1) '
+>>perElement, elSet=all, result=omega, quadraturePoint=0:4, name=omega, f(x)='max( x[:,:], axis=1) '
+>>perNode, name=RF, nSet=gen_top, field=displacement, result=P, f(x)='sum(x[:,1])', saveHistory=True
+>>perNode, name=U, nSet=gen_top, field=displacement, result=U, f(x)='mean(x[:,1])', saveHistory=True
 
 *modelGenerator, generator=planeRectQuad, name=gen
 x0=0, h=200
@@ -46,19 +47,20 @@ fieldOutput=RF
 ** direction=1
 
 *output, type=ensight, name=esExport
-create=perNode,    fieldOutput=displacement
-create=perNode,    fieldOutput=micro rotation
-create=perNode,    fieldOutput=nonlocal damage
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perNode, fieldOutput=micro rotation
+>>perNode, fieldOutput=nonlocal damage
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
+>>configuration, overwrite=yes
 
 *output, type=meshplot, name=RFPlot
 figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
 
-*step, maxInc=1e-2, minInc=1e-7, maxNumInc=10000, maxIter=25, stepLength=100
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=bottom, nSet=gen_bottom,  field=displacement, 2=0,
-dirichlet, name=bc, nSet=gen_leftBottom,  field=displacement, 2=0, 1=0
-dirichlet, name=top, nSet=gen_top, field=displacement, 2=-5
+*step, solver=theSolver
+maxInc=1e-2, minInc=1e-7, maxNumInc=10000, maxIter=25, stepLength=100
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=bottom, nSet=gen_bottom,  field=displacement, 2=0,
+>>dirichlet, name=bc, nSet=gen_leftBottom,  field=displacement, 2=0, 1=0
+>>dirichlet, name=top, nSet=gen_top, field=displacement, 2=-5

--- a/testfiles/marmot/GMCDPPlaneStrain/test_coarse.inp
+++ b/testfiles/marmot/GMCDPPlaneStrain/test_coarse.inp
@@ -11,21 +11,22 @@
 **0.75,        -0.25,   0.75,     -.25,           0.333333332,  0
 
 
-*section, name=section1, thickness=1.0, material=GMCDP, type=plane
+*section, name=section1, material=GMCDP, type=plane
 all
-*section, name=section2, thickness=.99, material=GMCDP, type=plane
+*section, name=section2, material=GMCDP, type=plane
 gen_shearBandCenter
 
 *job, name=cpe4job, domain=2d, solver=NISTParallel
-*fieldOutput
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
-create=perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
-create=perNode, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
-create=perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaP, f(x)='max( x[:,:,0], axis=1) '
-create=perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaD, f(x)='max( x[:,:,1], axis=1) '
-create=perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=omega, f(x)='max( x[:,:,2], axis=1) '
-create=perNode, name=RF, nSet=gen_top, field=displacement, result=P, f(x)='sum(x[:,1])', saveHistory=True, export=RF
-create=perNode, name=U, nSet=gen_top, field=displacement, result=U, f(x)='mean(x[:,1])', saveHistory=True, export=U
+*solver, solver=NISTParallel, name=theSolver
+*fieldOutput,
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
+>>perNode, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
+>>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaP, f(x)='max( x[:,:,0], axis=1) '
+>>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaD, f(x)='max( x[:,:,1], axis=1) '
+>>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=omega, f(x)='max( x[:,:,2], axis=1) '
+>>perNode, name=RF, nSet=gen_top, field=displacement, result=P, f(x)='sum(x[:,1])', saveHistory=True, export=RF
+>>perNode, name=U, nSet=gen_top, field=displacement, result=U, f(x)='mean(x[:,1])', saveHistory=True, export=U
 
 *modelGenerator, generator=planeRectQuad, name=gen
 x0=0, h=200
@@ -46,12 +47,12 @@ fieldOutput=RF
 ** direction=1
 
 *output, type=ensight, name=esExport
-create=perNode,    fieldOutput=displacement
-create=perNode,    fieldOutput=micro rotation
-create=perNode,    fieldOutput=nonlocal damage
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
+>>perNode, fieldOutput=displacement
+>>perNode, fieldOutput=micro rotation
+>>perNode, fieldOutput=nonlocal damage
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
 
 *output, type=meshplot, name=RFPlot
 figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
@@ -59,8 +60,9 @@ figure=2, axpSec=111, create=meshOnly, configuration=deformed
 *exportPlots,
 figure=2, fileName=mesh
 
-*step, maxInc=1e-2, minInc=1e-7, maxNumInc=10000, maxIter=25, stepLength=100
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=bottom, nSet=gen_bottom,  field=displacement, 2=0,
-dirichlet, name=bc, nSet=gen_leftBottom,  field=displacement, 2=0, 1=0
-dirichlet, name=top, nSet=gen_top, field=displacement, 2=-5
+*step, solver=theSolver
+maxInc=1e-2, minInc=1e-7, maxNumInc=10000, maxIter=25, stepLength=100
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=bottom, nSet=gen_bottom,  field=displacement, 2=0,
+>>dirichlet, name=bc, nSet=gen_leftBottom,  field=displacement, 2=0, 1=0
+>>dirichlet, name=top, nSet=gen_top, field=displacement, 2=-5

--- a/testfiles/marmot/GMCDPPlaneStrain3D/test_.inp
+++ b/testfiles/marmot/GMCDPPlaneStrain3D/test_.inp
@@ -38,15 +38,16 @@ bottom
 
 ** *job, name=cpe4job, domain=3d, solver=NISTParallel, linsolver=amgcl
 *job, name=cpe4job, domain=3d, solver=NISTParallel,
-*fieldOutput
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
+*solver, solver=NISTParallel, name=theSolver
+*fieldOutput,
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
 **elSet=all, field=micro rotation, result=U, name=micro rotation
-create=perElement, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
-create=perElement, elSet=all, result=alphaP, quadraturePoint=0:4, name=alphaP, f(x)='max( x[:,:], axis=1) '
-create=perElement, elSet=all, result=alphaD, quadraturePoint=0:4, name=alphaD, f(x)='max( x[:,:], axis=1) '
-create=perElement, elSet=all, result=omega, quadraturePoint=0:4, name=omega, f(x)='max( x[:,:], axis=1) '
-create=perNode, name=RF, nSet=top, field=displacement, result=P, f(x)='sum(x[:,1])/2.5', saveHistory=True
-create=perNode, name=U, nSet=top, field=displacement, result=U, f(x)='mean(x[:,1])', saveHistory=True
+>>perNode, elSet=all, field=nonlocal damage, result=U, name=nonlocal damage
+>>perElement, elSet=all, result=alphaP, quadraturePoint=0:4, name=alphaP, f(x)='max( x[:,:], axis=1) '
+>>perElement, elSet=all, result=alphaD, quadraturePoint=0:4, name=alphaD, f(x)='max( x[:,:], axis=1) '
+>>perElement, elSet=all, result=omega, quadraturePoint=0:4, name=omega, f(x)='max( x[:,:], axis=1) '
+>>perNode, name=RF, nSet=top, field=displacement, result=P, f(x)='sum(x[:,1])/2.5', saveHistory=True
+>>perNode, name=U, nSet=top, field=displacement, result=U, f(x)='mean(x[:,1])', saveHistory=True
 
 *output, type=monitor, name=omegaMon
 fieldOutput=omega, f(x)='max(x)'
@@ -55,24 +56,25 @@ fieldOutput=alphaD, f(x)='max(x)'
 fieldOutput=RF
 
 *output, type=ensight, name=esExport
-create=perNode,    fieldOutput=displacement
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>configuration, overwrite=yes
 **create=perNode,    fieldOutput=micro rotation
-create=perNode,    fieldOutput=nonlocal damage
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
+>>perNode, fieldOutput=nonlocal damage
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
 
 *output, type=meshplot, name=RFPlot
 figure=1, axSpec=111, c=k, ls=solid, create=xyData, x=time, y=RF
 
-*step, maxInc=1e-2, minInc=5e-4, maxNumInc=10000, maxIter=25, stepLength=100
-options, category=NISTSolver, extrapolation=linear
-options, category=Ensight, intermediateSaveInterval=1
-dirichlet, name=bottom, nSet=bottom,  field=displacement, 2=0,
+*step, solver=theSolver
+maxInc=1e-2, minInc=5e-4, maxNumInc=10000, maxIter=25, stepLength=100
+>>options, category=NISTSolver, extrapolation=linear
+>>options, category=Ensight, intermediateSaveInterval=1
+>>dirichlet, name=bottom, nSet=bottom,  field=displacement, 2=0,
 **dirichlet, name=bottomR, nSet=bottom,  field=micro rotation, 1=0,2=0,3=0
 **dirichlet, name=topR, nSet=top,  field=micro rotation, 1=0,2=0,3=0
-dirichlet, name=origin, nSet=origin,  field=displacement, 2=0, 1=0, 3=0
-dirichlet, name=top, nSet=top, field=displacement, 2=-5
-dirichlet, name=frontAndBackD, nSet=frontAndBack, field=displacement, 3=0
-dirichlet, name=frontAndBackR, nSet=frontAndBack, field=micro rotation, 1=0, 2=0
+>>dirichlet, name=origin, nSet=origin,  field=displacement, 2=0, 1=0, 3=0
+>>dirichlet, name=top, nSet=top, field=displacement, 2=-5
+>>dirichlet, name=frontAndBackD, nSet=frontAndBack, field=displacement, 3=0
+>>dirichlet, name=frontAndBackR, nSet=frontAndBack, field=micro rotation, 1=0, 2=0

--- a/testfiles/marmot/GMCDPTriaxialTest/test_.inp
+++ b/testfiles/marmot/GMCDPTriaxialTest/test_.inp
@@ -41,26 +41,26 @@ bottom
 ***job, name=cpe4job, domain=3d, solver=NISTPArcLength
 
 *fieldOutput,
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
-create=perNode, nSet=top, field=displacement, result=P, name=displacement, name=RF, f(x)=' sum(x[:,2]) ', saveHistory=True, export=RF
-create=perNode, nSet=top, field=displacement, result=U, name=UTop,  f(x)=' (x[0,2]) ', saveHistory=True, export=UTop
-create=perNode, elSet=all, field=nonlocal damage , result=U, name=nonlocal damage
-create=perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
-create=perElement, elSet=all, result=alphaP, quadraturePoint=0:4, name=alphaP, f(x)='mean( x[:,:], axis=1) '
-create=perElement, elSet=all, result=alphaD, quadraturePoint=0:4, name=alphaD, f(x)='mean( x[:,:], axis=1) '
-create=perElement, elSet=all, result=omega, quadraturePoint=0:4, name=omega, f(x)='mean( x[:,:], axis=1) '
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, nSet=top, field=displacement, result=P, name=displacement, f(x)=' sum(x[:,2]) ', saveHistory=True, export=RF
+>>perNode, nSet=top, field=displacement, result=U, name=UTop,  f(x)=' (x[0,2]) ', saveHistory=True, export=UTop
+>>perNode, elSet=all, field=nonlocal damage , result=U, name=nonlocal damage
+>>perNode, elSet=all, field=micro rotation, result=U, name=micro rotation
+>>perElement, elSet=all, result=alphaP, quadraturePoint=0:4, name=alphaP, f(x)='mean( x[:,:], axis=1) '
+>>perElement, elSet=all, result=alphaD, quadraturePoint=0:4, name=alphaD, f(x)='mean( x[:,:], axis=1) '
+>>perElement, elSet=all, result=omega, quadraturePoint=0:4, name=omega, f(x)='mean( x[:,:], axis=1) '
 
 *output, type=meshplot, name=RFPlot
-create=xyData, x=time, y=RF, legend=RF
+figure=1, axSpec=111, create=xyData, x=time, y=RF, legend=RF
 *output, type=ensight, name=ensightExport
-create=perNode,    fieldOutput=displacement
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>configuration, overwrite=yes
 
 **create=perNode,    fieldOutput=micro rotation
-create=perNode,    fieldOutput=nonlocal damage
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
+>>perNode, fieldOutput=nonlocal damage
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
 *output, type=monitor, name=omegaMon
 fieldOutput=omega, f(x)='max(x)'
 fieldOutput=nonlocal damage, f(x)='max(x)'
@@ -68,21 +68,23 @@ fieldOutput=alphaP, f(x)='max(x)'
 fieldOutput=alphaD, f(x)='max(x)'
 fieldOutput=RF
 
-*step, solver=theSolver, maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=bottom,  nSet=bottom,   field=displacement, 3=0.0
+*step, solver=theSolver
+maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=bottom,  nSet=bottom,   field=displacement, 3=0.0
 ** dirichlet, name=topD,  nSet=top,   field=nonlocal damage, 1=0.0
-dirichlet, name=origin,  nSet=origin,   field=displacement, 1=0.0,
-dirichlet, name=symD,  nSet=sym,   field=displacement, 2=0.0
-dirichlet, name=symR,  nSet=sym,   field=micro rotation, 1=0.0, 3=0
-distributedload, name=dload, surface=sleeveTop, type=pressure, magnitude=10, f(t)=t
-options, category=NISTArcLength, arcLengthController=off
+>>dirichlet, name=origin,  nSet=origin,   field=displacement, 1=0.0,
+>>dirichlet, name=symD,  nSet=sym,   field=displacement, 2=0.0
+>>dirichlet, name=symR,  nSet=sym,   field=micro rotation, 1=0.0, 3=0
+>>distributedload, name=dload, surface=sleeveTop, type=pressure, magnitude=10, f(t)=t
+>>options, category=NISTArcLength, arcLengthController=off
 
 **---- STEP WITHOUT SNAPBACK
-*step, solver=theSolver, maxInc=4e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=linear,
-options, category=Ensight, intermediateSaveInterval=1
-dirichlet, name=top,  nSet=top,   field=displacement, 3=-10
+*step, solver=theSolver
+maxInc=4e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
+>>options, category=NISTSolver, extrapolation=linear,
+>>options, category=Ensight, intermediateSaveInterval=1
+>>dirichlet, name=top,  nSet=top,   field=displacement, 3=-10
 
 **---- STEP WITH SNAPBACK
 ***step, solver=theSolver, maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=10, stepLength=1

--- a/testfiles/marmot/KLU/klu_test.inp
+++ b/testfiles/marmot/KLU/klu_test.inp
@@ -16,9 +16,11 @@ nY=2
 elType=CPE4
 
 
-*step, maxInc=1e0, minInc=1e-2, maxNumInc=100, maxIter=25, stepLength=1, solver=theSolver
-dirichlet, name=left, nSet=gen_left, field=displacement, 1=0, 2=0
-dirichlet, name=bottom, nSet=gen_leftBottom, field=displacement, 2=0
+*step, solver=theSolver
+maxInc=1e0, minInc=1e-2, maxNumInc=100, maxIter=25, stepLength=1
+>>dirichlet, name=left, nSet=gen_left, field=displacement, 1=0, 2=0
+>>dirichlet, name=bottom, nSet=gen_leftBottom, field=displacement, 2=0
 
-*step, maxInc=5e-3, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=1, solver=theSolver
-dirichlet, name=right, nSet=gen_right, field=displacement, 2=0.2
+*step, solver=theSolver
+maxInc=5e-3, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=1
+>>dirichlet, name=right, nSet=gen_right, field=displacement, 2=0.2

--- a/testfiles/marmot/MUMPS/mumps_test.inp
+++ b/testfiles/marmot/MUMPS/mumps_test.inp
@@ -16,9 +16,11 @@ nY=2
 elType=CPE4
 
 
-*step, maxInc=1e0, minInc=1e-2, maxNumInc=100, maxIter=25, stepLength=1, solver=theSolver
-dirichlet, name=left, nSet=gen_left, field=displacement, 1=0, 2=0
-dirichlet, name=bottom, nSet=gen_leftBottom, field=displacement, 2=0
+*step, solver=theSolver
+maxInc=1e0, minInc=1e-2, maxNumInc=100, maxIter=25, stepLength=1
+>>dirichlet, name=left, nSet=gen_left, field=displacement, 1=0, 2=0
+>>dirichlet, name=bottom, nSet=gen_leftBottom, field=displacement, 2=0
 
-*step, maxInc=5e-3, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=1, solver=theSolver
-dirichlet, name=right, nSet=gen_right, field=displacement, 2=0.2
+*step, solver=theSolver
+maxInc=5e-3, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=1
+>>dirichlet, name=right, nSet=gen_right, field=displacement, 2=0.2

--- a/testfiles/marmot/PETSCLU/petsclu.inp
+++ b/testfiles/marmot/PETSCLU/petsclu.inp
@@ -16,9 +16,11 @@ nY=2
 elType=CPE4
 
 
-*step, maxInc=1e0, minInc=1e-2, maxNumInc=100, maxIter=25, stepLength=1, solver=theSolver
-dirichlet, name=left, nSet=gen_left, field=displacement, 1=0, 2=0
-dirichlet, name=bottom, nSet=gen_leftBottom, field=displacement, 2=0
+*step, solver=theSolver
+maxInc=1e0, minInc=1e-2, maxNumInc=100, maxIter=25, stepLength=1
+>>dirichlet, name=left, nSet=gen_left, field=displacement, 1=0, 2=0
+>>dirichlet, name=bottom, nSet=gen_leftBottom, field=displacement, 2=0
 
-*step, maxInc=5e-3, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=1, solver=theSolver
-dirichlet, name=right, nSet=gen_right, field=displacement, 2=0.2
+*step, solver=theSolver
+maxInc=5e-3, minInc=1e-8, maxNumInc=10000, maxIter=25, stepLength=1
+>>dirichlet, name=right, nSet=gen_right, field=displacement, 2=0.2

--- a/testfiles/marmot/PlaneWithHole/testLong.inp
+++ b/testfiles/marmot/PlaneWithHole/testLong.inp
@@ -858,13 +858,13 @@ all
    3, 4
 
 *fieldOutput
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
-create=perElement, elSet=all, result=strain, name=strain, quadraturePoint=0:4, f(x)='np.mean(x,axis=1)'
-create=perElement, elSet=all, result=stress, name=stress, quadraturePoint=0:4, f(x)='np.mean(x,axis=1)'
-create=perElement, elSet=all, result=stress, name=stress0, quadraturePoint=0
-create=perElement, elSet=all, result=stress, name=stress1, quadraturePoint=1
-create=perElement, elSet=all, result=stress, name=stress2, quadraturePoint=2
-create=perElement, elSet=all, result=stress, name=stress3, quadraturePoint=3
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perElement, elSet=all, result=strain, name=strain, quadraturePoint=0:4, f(x)='np.mean(x,axis=1)'
+>>perElement, elSet=all, result=stress, name=stress, quadraturePoint=0:4, f(x)='np.mean(x,axis=1)'
+>>perElement, elSet=all, result=stress, name=stress0, quadraturePoint=0
+>>perElement, elSet=all, result=stress, name=stress1, quadraturePoint=1
+>>perElement, elSet=all, result=stress, name=stress2, quadraturePoint=2
+>>perElement, elSet=all, result=stress, name=stress3, quadraturePoint=3
 **create=perElement, elSet=all, result=stress, name=stress4, quadraturePoint=4
 **create=perElement, elSet=all, result=stress, name=stress5, quadraturePoint=5
 **create=perElement, elSet=all, result=stress, name=stress6, quadraturePoint=6
@@ -872,23 +872,24 @@ create=perElement, elSet=all, result=stress, name=stress3, quadraturePoint=3
 **create=perElement, elSet=all, result=stress, name=stress8, quadraturePoint=8
 
 *output, type=ensight, name=esExport
-create=perNode, fieldOutput=displacement
-configuration, overwrite=yes
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-create=perElement, fieldOutput=stress0
-create=perElement, fieldOutput=stress1
-create=perElement, fieldOutput=stress2
-create=perElement, fieldOutput=stress3
+>>perNode, fieldOutput=displacement
+>>configuration, overwrite=yes
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>perElement, fieldOutput=stress0
+>>perElement, fieldOutput=stress1
+>>perElement, fieldOutput=stress2
+>>perElement, fieldOutput=stress3
 **create=perElement, fieldOutput=stress4
 **create=perElement, fieldOutput=stress5
 **create=perElement, fieldOutput=stress6
 **create=perElement, fieldOutput=stress7
 **create=perElement, fieldOutput=stress8
 
-*step, solver=theSolver, maxInc=0.1, minInc=1e-6, maxNumInc=1000, maxIter=100
-options, category=NISTSolver, extrapolation=off
-dirichlet, name=side, nSet=Set-2,  field=displacement, 1=0
-dirichlet, name=bottom, nSet=Set-1, field=displacement, 2=0
-nodeforces, name=load, nSet=load, components='28.125,0.', field=displacement
-nodeforces, name=loadhalf, nSet=loadhalf, components='14.0625,0.', field=displacement
+*step, solver=theSolver
+maxInc=0.1, minInc=1e-6, maxNumInc=1000, maxIter=100
+>>options, category=NISTSolver, extrapolation=off
+>>dirichlet, name=side, nSet=Set-2,  field=displacement, 1=0
+>>dirichlet, name=bottom, nSet=Set-1, field=displacement, 2=0
+>>nodeforces, name=load, nSet=load, components='28.125,0.', field=displacement
+>>nodeforces, name=loadhalf, nSet=loadhalf, components='14.0625,0.', field=displacement

--- a/testfiles/marmot/QPMarmotMaterialGradientEnhancedHypoElastic/_test.inp
+++ b/testfiles/marmot/QPMarmotMaterialGradientEnhancedHypoElastic/_test.inp
@@ -22,12 +22,14 @@ all
 *job, name=mySingleElementJob, domain=3d
 *solver, solver=NIST, name=theSolver
 
-*step, solver=theSolver, maxInc=1e0, minInc=1e0, maxNumInc=100, maxIter=25, stepLength=1
+*step, solver=theSolver
+maxInc=1e0, minInc=1e0, maxNumInc=100, maxIter=25, stepLength=1
 >>setinitialconditions, property=characteristic element length, values='100,'
 >>dirichlet,  name=prescribed_strain, nSet=all, field=strain symmetric, components='[ 0, x, x, 0, 0, 0 ]',
 >>nodeforces, name=prescribed_stress, nSet=all, field=strain symmetric, components='[ x, 0, 0, x, x, x ]'
 
-*step, solver=theSolver, startInc=1e-2, maxInc=1e-1, minInc=1e-5, maxNumInc=100, maxIter=25, stepLength=1
+*step, solver=theSolver
+startInc=1e-2, maxInc=1e-1, minInc=1e-5, maxNumInc=100, maxIter=25, stepLength=1
 >>dirichlet, name=prescribed_strain,                                    components='[ -0.1,  x,    x, 0,   0, 0 ]'
 >>nodeforces, name=prescribed_stress,                                   components='[ x,    -0.0,   -0.0, x,   x, x ]'
 

--- a/testfiles/marmot/RotationalSpringTotalLagrange/test_.inp
+++ b/testfiles/marmot/RotationalSpringTotalLagrange/test_.inp
@@ -3,28 +3,29 @@
 *material, name=stvenantkirchhoffisotropic, id=le
 30000.0, 0.15
 
-*section, name=section1, thickness=1.0, material=le, type=plane
+*section, name=section1, material=le, type=plane
 all
 
 *job, name=c3d8tljob, domain=3d
 *solver, solver=NISTParallel, name=theSolver
 *fieldOutput,
-create=perElement, name=displacement, elSet=all, field=displacement, result=U, name=displacement
-create=perNode, name=stress, elSet=all, result=stress, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
-create=perNode, name=strain, elSet=all, result=strain, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
+>>perNode, name=displacement, elSet=all, field=displacement, result=U
+>>perElement, name=stress, elSet=all, result=stress, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
+>>perElement, name=strain, elSet=all, result=strain, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
 
 *constraint, type=rigidbody, name=rb1
 referencePoint=RP
 nset=p_Set-2
 
 *output, type=ensight, name=ensightExport
-create=perNode, fieldOutput=displacement
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>configuration, overwrite=yes
 
-*step, solver=theSolver, maxInc=1e-2, minInc=1e-4, maxNumInc=1000, maxIter=10
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=enc, nSet=Set-1, field=displacement, 1=0, 2=0, 3=0
-dirichlet, name=enc2, nSet=Set-5, field=displacement, 1=0, 2=0, 3=0
-dirichlet, name=rpMov, nSet=RP, field=rotation, 1=-3.141, 2=0, 3=0
+*step, solver=theSolver
+maxInc=1e-2, minInc=1e-4, maxNumInc=1000, maxIter=10
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=enc, nSet=Set-1, field=displacement, 1=0, 2=0, 3=0
+>>dirichlet, name=enc2, nSet=Set-5, field=displacement, 1=0, 2=0, 3=0
+>>dirichlet, name=rpMov, nSet=RP, field=rotation, 1=-3.141, 2=0, 3=0

--- a/testfiles/marmot/RotationalSpringUpdatedLagrange/test_.inp
+++ b/testfiles/marmot/RotationalSpringUpdatedLagrange/test_.inp
@@ -9,22 +9,23 @@ all
 *job, name=c3d8tljob, domain=3d
 *solver, solver=NISTParallel, name=theSolver
 *fieldOutput,
-name=displacement, elSet=all, field=displacement, result=U, name=displacement
-name=stress, elSet=all, result=stress, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
-name=strain, elSet=all, result=strain, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
+>>perNode, name=displacement, elSet=all, field=displacement, result=U
+>>perElement, name=stress, elSet=all, result=stress, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
+>>perElement, name=strain, elSet=all, result=strain, f(x)=' mean(x, axis=1) ', quadraturePoint=0:8
 
 *constraint, type=rigidbody, name=rb1
 referencePoint=RP
 nset=p_Set-2
 
 *output, type=ensight, name=ensightExport
-create=perNode, fieldOutput=displacement
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>configuration, overwrite=yes
 
-*step, solver=theSolver, maxInc=1e-2, minInc=1e-4, maxNumInc=1000, maxIter=10
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=enc, nSet=Set-1, field=displacement, 1=0, 2=0, 3=0
-dirichlet, name=enc2, nSet=Set-5, field=displacement, 1=0, 2=0, 3=0
-dirichlet, name=rpMov, nSet=RP, field=rotation, 1=-3.141, 2=0, 3=0
+*step, solver=theSolver
+maxInc=1e-2, minInc=1e-4, maxNumInc=1000, maxIter=10
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=enc, nSet=Set-1, field=displacement, 1=0, 2=0, 3=0
+>>dirichlet, name=enc2, nSet=Set-5, field=displacement, 1=0, 2=0, 3=0
+>>dirichlet, name=rpMov, nSet=RP, field=rotation, 1=-3.141, 2=0, 3=0

--- a/testfiles/marmot/RotationalSpringUpdatedLagrangeJaumann/test_.inp
+++ b/testfiles/marmot/RotationalSpringUpdatedLagrangeJaumann/test_.inp
@@ -9,22 +9,23 @@ all
 *job, name=c3d8tljob, domain=3d
 *solver, solver=NISTParallel, name=theSolver
 *fieldOutput,
-name=displacement, elSet=all, field=displacement, result=U, name=displacement
-name=stress, elSet=all, result=stress, f(x)=' mean(x, axis=1) ', quadraturePoint=0:3
-name=strain, elSet=all, result=strain, f(x)=' mean(x, axis=1) ', quadraturePoint=0:3
+>>perNode, name=displacement, elSet=all, field=displacement, result=U
+>>perElement, name=stress, elSet=all, result=stress, f(x)=' mean(x, axis=1) ', quadraturePoint=0:3
+>>perElement, name=strain, elSet=all, result=strain, f(x)=' mean(x, axis=1) ', quadraturePoint=0:3
 
 *constraint, type=rigidbody, name=rb1
 referencePoint=RP
 nset=p_Set-2
 
 *output, type=ensight, name=ensightExport
-create=perNode, fieldOutput=displacement
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>configuration, overwrite=yes
 
-*step, solver=theSolver, maxInc=1e-2, minInc=1e-4, maxNumInc=1000, maxIter=10
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=enc, nSet=Set-1, field=displacement, 1=0, 2=0, 3=0
-dirichlet, name=enc2, nSet=Set-5, field=displacement, 1=0, 2=0, 3=0
-dirichlet, name=rpMov, nSet=RP, field=rotation, 1=-3.141, 2=0, 3=0
+*step, solver=theSolver
+maxInc=1e-2, minInc=1e-4, maxNumInc=1000, maxIter=10
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=enc, nSet=Set-1, field=displacement, 1=0, 2=0, 3=0
+>>dirichlet, name=enc2, nSet=Set-5, field=displacement, 1=0, 2=0, 3=0
+>>dirichlet, name=rpMov, nSet=RP, field=rotation, 1=-3.141, 2=0, 3=0

--- a/testfiles/marmot/TriaxialTestRDPNonLocalP125/test_.inp
+++ b/testfiles/marmot/TriaxialTestRDPNonLocalP125/test_.inp
@@ -41,40 +41,42 @@ weak
 ** Name: BC-Bottom Type: Displacement/Rotation
 
 *job, name=cpe4job, domain=3d, solver=NISTPArcLength
+*solver, solver=NISTPArcLength, name=theSolver
 ***job, name=cpe4job, domain=3d, solver=NISTParallel
 
 *fieldOutput,
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
-create=perNode, nSet=top, field=displacement, result=P, name=displacement, name=RF, f(x)=' sum(x[:,2]) ', saveHistory=True, export=RF
-create=perNode, nSet=top, field=displacement, result=U, name=UTop,  f(x)=' (x[0,2]) ', saveHistory=True, export=UTop
-create=perNode, elSet=all, field=nonlocal damage , result=U, name=alpha_d_nl
-create=perElement, elSet=all, result=stress, quadraturePoint=0:4, name=stress, f(x)='mean(x, axis=1)'
-create=perElement, elSet=all, result=strain, quadraturePoint=0:4, name=strain, f(x)='mean(x, axis=1)'
-create=perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaP, f(x)='mean( x[:,:,0], axis=1) '
-create=perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaD, f(x)='mean( x[:,:,2], axis=1) '
-create=perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=omega, f(x)='mean( x[:,:,4], axis=1) '
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, nSet=top, field=displacement, result=P, name=displacement, f(x)=' sum(x[:,2]) ', saveHistory=True, export=RF
+>>perNode, nSet=top, field=displacement, result=U, name=UTop,  f(x)=' (x[0,2]) ', saveHistory=True, export=UTop
+>>perNode, elSet=all, field=nonlocal damage , result=U, name=alpha_d_nl
+>>perElement, elSet=all, result=stress, quadraturePoint=0:4, name=stress, f(x)='mean(x, axis=1)'
+>>perElement, elSet=all, result=strain, quadraturePoint=0:4, name=strain, f(x)='mean(x, axis=1)'
+>>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaP, f(x)='mean( x[:,:,0], axis=1) '
+>>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaD, f(x)='mean( x[:,:,2], axis=1) '
+>>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=omega, f(x)='mean( x[:,:,4], axis=1) '
 
 *output, type=meshplot, name=RFPlot
-create=xyData, x=time, y=RF, legend=RF
+figure=1, axSpec=111, create=xyData, x=time, y=RF, legend=RF
 *output, type=ensight, name=ensightExport
-create=perNode,    fieldOutput=displacement
-create=perNode,    fieldOutput=alpha_d_nl
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perNode, fieldOutput=alpha_d_nl
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
+>>configuration, overwrite=yes
 
-*step, maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=bottom,  nSet=bottom,   field=displacement, 3=0.0
-dirichlet, name=origin,  nSet=origin,   field=displacement, 1=0.0,
+*step, solver=theSolver
+maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=bottom,  nSet=bottom,   field=displacement, 3=0.0
+>>dirichlet, name=origin,  nSet=origin,   field=displacement, 1=0.0,
 **dirichlet, name=adb,  nSet=bottom,   field=nonlocal damage , 1=0.0
 **dirichlet, name=adt,  nSet=top,   field=nonlocal damage , 1=0.0,
-dirichlet, name=sym,  nSet=sym,   field=displacement, 2=0.0
-distributedload, name=dload, surface=sleeveTop, type=pressure, magnitude=12.5, f(t)=t
-options, category=NISTArcLength, arcLengthController=off
+>>dirichlet, name=sym,  nSet=sym,   field=displacement, 2=0.0
+>>distributedload, name=dload, surface=sleeveTop, type=pressure, magnitude=12.5, f(t)=t
+>>options, category=NISTArcLength, arcLengthController=off
 
 ** ---- STEP WITHOUT SNAPBACK
 ***step, maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
@@ -83,10 +85,11 @@ options, category=NISTArcLength, arcLengthController=off
 **dirichlet, name=top,  nSet=top,   field=displacement, 3=-.525
 
 ** ---- STEP WITH SNAPBACK
-*step, maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=linear,
-options, category=Ensight, intermediateSaveInterval=1
-dirichlet, name=top,  nSet=top,   field=displacement, 3=-0.525
-options, category=NISTArcLength, arcLengthController=indirectcontrol, stopCondition='fieldOutputs["UTop"] < -1.0'
-indirectcontrol, dof1=' nodeSets["all"][490].fields["displacement"][2] ' , dof2=' nodeSets["all"][608].fields["displacement"][2] ' , L=-.525
+*step, solver=theSolver
+maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
+>>options, category=NISTSolver, extrapolation=linear,
+>>options, category=Ensight, intermediateSaveInterval=1
+>>dirichlet, name=top,  nSet=top,   field=displacement, 3=-0.525
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, stopCondition='fieldOutputs["UTop"] < -1.0'
+>>indirectcontrol, dof1=' nodeSets["all"][490].fields["displacement"][2] ' , dof2=' nodeSets["all"][608].fields["displacement"][2] ' , L=-.525, cVector1='[-1]', cVector2='[1]'
 

--- a/testfiles/marmot/TriaxialTestRDPNonLocalP375/test_.inp
+++ b/testfiles/marmot/TriaxialTestRDPNonLocalP375/test_.inp
@@ -42,45 +42,48 @@ weak
 
 ***job, name=cpe4job, domain=3d, solver=NISTPArcLength
 *job, name=cpe4job, domain=3d, solver=NISTParallel
+*solver, solver=NISTParallel, name=theSolver
 
 *fieldOutput,
-create=perNode, elSet=all, field=displacement, result=U, name=displacement
-create=perNode, nSet=top, field=displacement, result=P, name=displacement, name=RF, f(x)=' sum(x[:,2]) ', saveHistory=True, export=RF
-create=perNode, nSet=top, field=displacement, result=U, name=UTop,  f(x)=' (x[0,2]) ', saveHistory=True, export=UTop
-create=perNode, elSet=all, field=nonlocal damage , result=U, name=alpha_d_nl
-create=perElement, elSet=all, result=stress, quadraturePoint=0:4, name=stress, f(x)='mean(x, axis=1)'
-create=perElement, elSet=all, result=strain, quadraturePoint=0:4, name=strain, f(x)='mean(x, axis=1)'
-create=perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaP, f(x)='mean( x[:,:,0], axis=1) '
-create=perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaD, f(x)='mean( x[:,:,2], axis=1) '
-create=perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=omega, f(x)='mean( x[:,:,4], axis=1) '
+>>perNode, elSet=all, field=displacement, result=U, name=displacement
+>>perNode, nSet=top, field=displacement, result=P, name=displacement, f(x)=' sum(x[:,2]) ', saveHistory=True, export=RF
+>>perNode, nSet=top, field=displacement, result=U, name=UTop,  f(x)=' (x[0,2]) ', saveHistory=True, export=UTop
+>>perNode, elSet=all, field=nonlocal damage , result=U, name=alpha_d_nl
+>>perElement, elSet=all, result=stress, quadraturePoint=0:4, name=stress, f(x)='mean(x, axis=1)'
+>>perElement, elSet=all, result=strain, quadraturePoint=0:4, name=strain, f(x)='mean(x, axis=1)'
+>>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaP, f(x)='mean( x[:,:,0], axis=1) '
+>>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=alphaD, f(x)='mean( x[:,:,2], axis=1) '
+>>perElement, elSet=all, result=sdv, quadraturePoint=0:4, name=omega, f(x)='mean( x[:,:,4], axis=1) '
 
 *output, type=meshplot, name=RFPlot
-create=xyData, x=time, y=RF, legend=RF
+figure=1, axSpec=111, create=xyData, x=time, y=RF, legend=RF
 *output, type=ensight, name=ensightExport
-create=perNode,    fieldOutput=displacement
-create=perNode,    fieldOutput=alpha_d_nl
-create=perElement, fieldOutput=stress
-create=perElement, fieldOutput=strain
-create=perElement, fieldOutput=alphaP
-create=perElement, fieldOutput=alphaD
-create=perElement, fieldOutput=omega
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perNode, fieldOutput=alpha_d_nl
+>>perElement, fieldOutput=stress
+>>perElement, fieldOutput=strain
+>>perElement, fieldOutput=alphaP
+>>perElement, fieldOutput=alphaD
+>>perElement, fieldOutput=omega
+>>configuration, overwrite=yes
 
-*step, maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=bottom,  nSet=bottom,   field=displacement, 3=0.0
-dirichlet, name=origin,  nSet=origin,   field=displacement, 1=0.0,
+*step, solver=theSolver
+maxInc=2e-1, minInc=1e-5, maxNumInc=1000, maxIter=25, stepLength=1
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=bottom,  nSet=bottom,   field=displacement, 3=0.0
+>>dirichlet, name=origin,  nSet=origin,   field=displacement, 1=0.0,
 **dirichlet, name=adb,  nSet=bottom,   field=nonlocal damage , 1=0.0
 **dirichlet, name=adt,  nSet=top,   field=nonlocal damage , 1=0.0,
-dirichlet, name=sym,  nSet=sym,   field=displacement, 2=0.0
-distributedload, name=dload, surface=sleeveTop, type=pressure, magnitude=37.5, f(t)=t
-options, category=NISTArcLength, arcLengthController=off
+>>dirichlet, name=sym,  nSet=sym,   field=displacement, 2=0.0
+>>distributedload, name=dload, surface=sleeveTop, type=pressure, magnitude=37.5, f(t)=t
+>>options, category=NISTArcLength, arcLengthController=off
 
 **---- STEP WITHOUT SNAPBACK
-*step, maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
-options, category=NISTSolver, extrapolation=linear,
-options, category=Ensight, intermediateSaveInterval=1
-dirichlet, name=top,  nSet=top,   field=displacement, 3=-.525
+*step, solver=theSolver
+maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1
+>>options, category=NISTSolver, extrapolation=linear,
+>>options, category=Ensight, intermediateSaveInterval=1
+>>dirichlet, name=top,  nSet=top,   field=displacement, 3=-.525
 
 ** ---- STEP WITH SNAPBACK
 ***step, maxInc=1e-2, minInc=1e-8, maxNumInc=1000, maxIter=25, stepLength=1

--- a/testfiles/marmot/TwistingTrussJaumannRate/_test.inp
+++ b/testfiles/marmot/TwistingTrussJaumannRate/_test.inp
@@ -1025,25 +1025,26 @@
 *material, name=linearelastic, id=le,
 30000.0, 0.15
 
-*section, name=section1, thickness=1.0, material=le, type=solid
+*section, name=section1, material=le, type=solid
 all
 
 *job, name=c3d8job, domain=3d,
 *solver, solver=NISTParallel, name=theSolver
-*fieldOutput
-create=perNode, name=displacement, elSet=all, field=displacement, result=U, name=displacement
-create=perElement, name=stress, elSet=all, result=stress, f(x)='mean(x, axis=1) ', quadraturePoint=0:3
+*fieldOutput,
+>>perNode, name=displacement, elSet=all, field=displacement, result=U
+>>perElement, name=stress, elSet=all, result=stress, f(x)='mean(x, axis=1) ', quadraturePoint=0:3
 
 *constraint, type=rigidbody, name=rb1
 nSet=right
 referencePoint=rBottom
 
 *output, type=ensight, name=ensightExport
-create=perNode, fieldOutput=displacement
-create=perElement, fieldOutput=stress
-configuration, overwrite=yes
+>>perNode, fieldOutput=displacement
+>>perElement, fieldOutput=stress
+>>configuration, overwrite=yes
 
-*step, solver=theSolver, maxInc=5e-2, minInc=1e-4, maxNumInc=1000, maxIter=20
-options, category=NISTSolver, extrapolation=linear
-dirichlet, name=left,  nSet=left,         field=displacement, 1=0.0, 2=0, 3=0
-dirichlet, name=rotRP,  nSet=rBottom,   field=rotation, 1=1.5707,
+*step, solver=theSolver
+maxInc=5e-2, minInc=1e-4, maxNumInc=1000, maxIter=20
+>>options, category=NISTSolver, extrapolation=linear
+>>dirichlet, name=left,  nSet=left,         field=displacement, 1=0.0, 2=0, 3=0
+>>dirichlet, name=rotRP,  nSet=rBottom,   field=rotation, 1=1.5707,

--- a/testfiles/marmot/WedgeSplittingTest/test_.inp
+++ b/testfiles/marmot/WedgeSplittingTest/test_.inp
@@ -14129,23 +14129,24 @@ _Surf-PressureR_S4, 4
 ****** omegaMax, nonlocalRadius nonlocalweight              epsilonF
 **     0.999999,   2.0,        1.05,     4e-04
      0.99,   4.0,        1.05,     8e-04
-*section, name=sectionAll, thickness=100.00, material=urmnl, type=plane
+*section, name=sectionAll, material=urmnl, type=plane
 Set-Complete
 
 *job, name=cpe4job, domain=2d, solver=NISTPArcLength
+*solver, solver=NISTPArcLength, name=theSolver
 
 *fieldOutput,
-elSet=Set-Complete, field=displacement, result=U, name=disp
-elSet=Set-Complete, field=nonlocal damage, result=U, name=adnl
-name=Stress, elSet=Set-Complete, result=stress, quadraturePoint=1
-name=Strain, elSet=Set-Complete, result=strain, quadraturePoint=1
-name=AlphaP, elSet=Set-Complete, result=sdv, quadraturePoint=1, f(x)='x[:,0]'
-name=AlphaD, elSet=Set-Complete, result=sdv, quadraturePoint=1, f(x)='x[:,2]'
-name=Omega,  elSet=Set-Complete, result=sdv, quadraturePoint=1, f(x)='x[:,4]'
-name=Displacement_Notch, nSet=Set-PointNotch, field=displacement, result=U, saveHistory=True
-name=Displacement_NotchNew, nSet=Set-PointLoad, field=displacement, result=U, saveHistory=True
-name=Force_SP, nSet=Set-PressureLeft,  field=displacement, result=P, saveHistory=True
-name=Force_SPnew, nSet=Set-PointLoadL,  field=displacement, result=P, saveHistory=True
+>>perNode, elSet=Set-Complete, field=displacement, result=U, name=disp
+>>perNode, elSet=Set-Complete, field=nonlocal damage, result=U, name=adnl
+>>perElement, name=Stress, elSet=Set-Complete, result=stress, quadraturePoint=1
+>>perElement, name=Strain, elSet=Set-Complete, result=strain, quadraturePoint=1
+>>perElement, name=AlphaP, elSet=Set-Complete, result=sdv, quadraturePoint=1, f(x)='x[:,0]'
+>>perElement, name=AlphaD, elSet=Set-Complete, result=sdv, quadraturePoint=1, f(x)='x[:,2]'
+>>perElement, name=Omega,  elSet=Set-Complete, result=sdv, quadraturePoint=1, f(x)='x[:,4]'
+>>perNode, name=Displacement_Notch, nSet=Set-PointNotch, field=displacement, result=U, saveHistory=True
+>>perNode, name=Displacement_NotchNew, nSet=Set-PointLoad, field=displacement, result=U, saveHistory=True
+>>perNode, name=Force_SP, nSet=Set-PressureLeft,  field=displacement, result=P, saveHistory=True
+>>perNode, name=Force_SPnew, nSet=Set-PointLoadL,  field=displacement, result=P, saveHistory=True
 
 
 ***constraint, type=linearizedRigidBody, name=rb1
@@ -14159,103 +14160,114 @@ figure=1, create=xyData,  export=True, label=FSP_CMOD_medium_E22000_epsF8e-4_fcu
 
 
 *output, type=ensight, name=WST_medium_pointload
-create=perNode,    elSet=Set-Complete, fieldOutput=disp
-create=perNode,    elSet=Set-Complete, fieldOutput=adnl
-create=perElement, elSet=Set-Complete, fieldOutput=Stress
-create=perElement, elSet=Set-Complete, fieldOutput=Strain
-create=perElement, elSet=Set-Complete, fieldOutput=AlphaP
-create=perElement, elSet=Set-Complete, fieldOutput=AlphaD
-create=perElement, elSet=Set-Complete, fieldOutput=Omega
-configuration, overwrite=yes
+>>perNode, fieldOutput=disp
+>>perNode, fieldOutput=adnl
+>>perElement, fieldOutput=Stress
+>>perElement, fieldOutput=Strain
+>>perElement, fieldOutput=AlphaP
+>>perElement, fieldOutput=AlphaD
+>>perElement, fieldOutput=Omega
+>>configuration, overwrite=yes
 
-*step, maxInc=1e-1, minInc=1e-7, maxNumInc=10000
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear
+*step, solver=theSolver
+maxInc=1e-1, minInc=1e-7, maxNumInc=10000
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
-dirichlet, name=bottom_h, nSet=Set-BCBottom, field=displacement, 1=0.0
-dirichlet, name=bottom_v, nSet=Set-BCBottom, field=displacement, 2=0.0
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.111,
+>>dirichlet, name=bottom_h, nSet=Set-BCBottom, field=displacement, 1=0.0
+>>dirichlet, name=bottom_v, nSet=Set-BCBottom, field=displacement, 2=0.0
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.111, cVector1='[-1]', cVector2='[1]',
 **indirectcontrol, dof1=' nodes[260].fields["displacement"][0] ', dof2=' nodes[521].fields["displacement"][0] ', L=+0.175,
 
-*step, maxInc=5e-3, minInc=1e-7
+*step, solver=theSolver
+maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01, cVector1='[-1]', cVector2='[1]'
 
-*step, maxInc=1e-1, minInc=1e-7, maxNumInc=10000
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
+*step, solver=theSolver
+maxInc=1e-1, minInc=1e-7, maxNumInc=10000
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.128,
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.128, cVector1='[-1]', cVector2='[1]',
 
-*step, maxInc=5e-3, minInc=1e-7
+*step, solver=theSolver
+maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01, cVector1='[-1]', cVector2='[1]'
 
-*step, maxInc=1e-1, minInc=1e-7, maxNumInc=10000
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
+*step, solver=theSolver
+maxInc=1e-1, minInc=1e-7, maxNumInc=10000
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.151,
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.151, cVector1='[-1]', cVector2='[1]',
 
-*step, maxInc=5e-3, minInc=1e-7
+*step, solver=theSolver
+maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01, cVector1='[-1]', cVector2='[1]'
 
-*step, maxInc=1e-1, minInc=1e-7, maxNumInc=10000
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
+*step, solver=theSolver
+maxInc=1e-1, minInc=1e-7, maxNumInc=10000
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.175,
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.175, cVector1='[-1]', cVector2='[1]',
 
-*step, maxInc=5e-3, minInc=1e-7
+*step, solver=theSolver
+maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01, cVector1='[-1]', cVector2='[1]'
 
-*step, maxInc=1e-1, minInc=1e-7, maxNumInc=10000
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
+*step, solver=theSolver
+maxInc=1e-1, minInc=1e-7, maxNumInc=10000
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.204,
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.204, cVector1='[-1]', cVector2='[1]',
 
-*step, maxInc=5e-3, minInc=1e-7
+*step, solver=theSolver
+maxInc=5e-3, minInc=1e-7
 **options, category=NISTArcLength, arcLengthController=off
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition = ' sum(  fieldOutputs["Force_SPnew"][:,0]  ) <= 500 '
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=-50
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=50
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=-0.01, cVector1='[-1]', cVector2='[1]'
 
-*step, maxInc=1e-1, minInc=1e-7, maxNumInc=10000
-options, category=NISTSolver5, extrapolation=linear
-options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
+*step, solver=theSolver
+maxInc=1e-1, minInc=1e-7, maxNumInc=10000
+>>options, category=NISTSolver5, extrapolation=linear
+>>options, category=NISTArcLength, arcLengthController=indirectcontrol, extrapolation=linear, stopCondition=False
 ** stopCondition = 'sum(fieldOutputs["Force_SP"][:,0])>=6.0'
-nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
-nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
-indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.300,
+>>nodeforces, name=cloadRight, nSet=Set-PointLoadR, field=displacement, 1=100
+>>nodeforces, name=cloadLeft, nSet=Set-PointLoadL, field=displacement, 1=-100
+>>indirectcontrol, dof1=' nodes[1844].fields["displacement"][0] ', dof2=' nodes[365].fields["displacement"][0] ', L=+0.300, cVector1='[-1]', cVector2='[1]',
 


### PR DESCRIPTION
…keyword syntax (#47)

* fix: update non-auto-tested .inp examples to current >> module-level keyword syntax

Example input files that are not named test.inp (and therefore not automatically tested in CI) were still using the old pre-May 2026 EdelweissFE input syntax where module-level keywords within *step, *fieldOutput and *output blocks appeared as plain data lines without the >> prefix.

Current syntax requires all module-level keyword lines to be prefixed with >>.

Affected conversions:
- *fieldOutput: 'create=perNode/perElement/xyData, ...' → '>>perNode/perElement/xyData, ...'
- *output:      'create=perNode/perElement, ...' → '>>perNode/perElement, ...'
              'configuration, ...' → '>>configuration, ...'
              'figure=..., ...' → '>>figure=..., ...'
- *step:        'dirichlet, ...' → '>>dirichlet, ...'
              'options, ...' → '>>options, ...'
              'nodeforces, ...' → '>>nodeforces, ...'
              'distributedload, ...' → '>>distributedload, ...'
              'bodyforce, ...' → '>>bodyforce, ...'
              'geostatic, ...' → '>>geostatic, ...'
              'sdvini, ...' → '>>sdvini, ...'
              'indirectcontrol, ...' → '>>indirectcontrol, ...'

27 files updated across edelweiss-only/ and marmot/ test directories.

* updated also *step keyword options

* fix: add missing solver= option to *step and *solver blocks in remaining examples/testfiles

* fix: resolve remaining syntax errors, old output/monitor definitions, and sdvini keywords in test examples

* some further fixes

* fix: resolve numThreads option error and update Marmot element solver type in examples

* fix example input files

---------