### PR TITLE
fix: macOS/arm64 support

### DIFF
--- a/.github/workflows/run_tests_with_marmot.yml
+++ b/.github/workflows/run_tests_with_marmot.yml
@@ -18,17 +18,17 @@ jobs:
           activate-environment: anaconda-client-env
 
       - name: Install conda packages
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           mamba install --file conda_requirements.txt
 
       - name: Install pip packages
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           pip install -r pip_requirements.txt
 
       - name: Install Eigen
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           cd ..
           git clone --branch 3.4.0 https://gitlab.com/libeigen/eigen.git
@@ -40,7 +40,7 @@ jobs:
           cd ../..
 
       - name: Install Autodiff
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           git clone --branch v1.1.0 https://github.com/autodiff/autodiff.git
           cd autodiff
@@ -56,7 +56,7 @@ jobs:
           cd ../..
 
       - name: Install Fastor
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           git clone https://github.com/romeric/Fastor.git
           cd Fastor
@@ -67,7 +67,7 @@ jobs:
           cd ../..
 
       - name: Install AMGCL
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           git clone --branch 1.4.7 --depth 1 https://github.com/ddemidov/amgcl.git
           cd amgcl
@@ -78,7 +78,7 @@ jobs:
           cd ../..
 
       - name: Install Marmot
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           # Try, in order: the branch actually under test (github.head_ref, set for a pull_request
           # event), the PR's base branch (github.base_ref), then next_v26.11, the shared
@@ -118,12 +118,12 @@ jobs:
           cd ../../
 
       - name: Build EdelweissFE
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           pip install -v .
 
       - name: Run tests
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           run_tests_edelweissfe ./testfiles/marmot/
           run_tests_edelweissfe ./testfiles/edelweiss-only/

--- a/.github/workflows/run_tests_with_marmot_macos.yml
+++ b/.github/workflows/run_tests_with_marmot_macos.yml
@@ -1,0 +1,154 @@
+# Run the full test suite on macOS / arm64 (Apple Silicon).
+#
+# Mirrors run_tests_with_marmot.yml. Its purpose is to keep Apple Silicon support from
+# regressing: it exercises environment creation, the Marmot build, the Cython build and both
+# test suites on arm64 with clang/libc++, none of which the ubuntu-latest jobs cover.
+#
+# Every dependency is cloned into the parent directory, never into the checkout. Marmot ships
+# a committed symlink, _codeql_detected_source_root -> ., so a Marmot clone inside the
+# checkout makes `pip install .` follow that symlink into itself indefinitely while collecting
+# files for the wheel:
+#
+#     error: could not create 'build/.../Marmot/_codeql_detected_source_root/
+#     _codeql_detected_source_root/...': File name too long
+#
+# Linux tolerates this only because its path limit is four times macOS's; the recursion is
+# there either way, and the dependency sources do not belong in the wheel regardless.
+name: Run tests with Marmot (macOS/arm64)
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    # macos-latest is arm64 (Apple Silicon); macos-13 would be an Intel runner.
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Mambaforge
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          use-mamba: true
+          miniforge-variant: Miniforge3
+          miniforge-version: latest
+          activate-environment: anaconda-client-env
+
+      # NOTE: the osx-arm64 requirements file, not conda_requirements.txt. The latter pins
+      # anaconda::mkl, anaconda::mkl-include and anaconda::intel-openmp, none of which has an
+      # osx-arm64 build, so it fails to solve before installing anything.
+      - name: Install conda packages
+        shell: bash -leo pipefail {0}
+        run: |
+          mamba install --file conda_requirements_osx-arm64.txt
+
+      - name: Install pip packages
+        shell: bash -leo pipefail {0}
+        run: |
+          pip install -r pip_requirements.txt
+
+      - name: Install Eigen
+        shell: bash -leo pipefail {0}
+        run: |
+          cd ..
+          git clone --branch 3.4.0 https://gitlab.com/libeigen/eigen.git
+          cd eigen
+          mkdir build
+          cd build
+          cmake -DBUILD_TESTING=OFF -DINCLUDE_INSTALL_DIR=$CONDA_PREFIX/include -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX ..
+          make install
+          cd ../..
+
+      # NOTE: the build directory is deliberately not called `build` here. autodiff ships a
+      # Bazel `BUILD` file in its repository root, and the macOS filesystem is case-insensitive,
+      # so `mkdir build` fails with "File exists" and `cd build` with "Not a directory". On Linux
+      # the two names are distinct, which is why the ubuntu jobs are unaffected.
+      - name: Install Autodiff
+        shell: bash -leo pipefail {0}
+        run: |
+          cd ..
+          git clone --branch v1.1.0 https://github.com/autodiff/autodiff.git
+          cd autodiff
+          mkdir build-cmake
+          cd build-cmake
+          cmake -DAUTODIFF_BUILD_TESTS=OFF \
+            -DAUTODIFF_BUILD_PYTHON=OFF \
+            -DAUTODIFF_BUILD_EXAMPLES=OFF \
+            -DAUTODIFF_BUILD_DOCS=OFF \
+            -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+            ..
+          make install
+          cd ../..
+
+      # NOTE: upstream Fastor does not compile on arm64 - it reaches x86 `cpuid` and `rdtsc`
+      # inline assembly on every non-Windows platform, and its scalar fallback backend has
+      # further defects that only surface off x86. This fork is upstream `master` plus the
+      # minimal patch fixing exactly that, and nothing else. The fixes are offered upstream in
+      # romeric/Fastor#182 and #183; switch this step back once either is merged. Marmot's own
+      # build_macos.yml uses the same fork for the same reason.
+      - name: Install Fastor (arm64-compatible fork)
+        shell: bash -leo pipefail {0}
+        run: |
+          cd ..
+          git clone --branch arm64/apple-silicon-master https://github.com/BOKU-CMP-MEC-MAT/Fastor.git
+          cd Fastor
+          mkdir build
+          cd build
+          cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX ..
+          make install
+          cd ../..
+
+      - name: Install AMGCL
+        shell: bash -leo pipefail {0}
+        run: |
+          cd ..
+          git clone --branch 1.4.7 --depth 1 https://github.com/ddemidov/amgcl.git
+          cd amgcl
+          mkdir build
+          cd build
+          cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX ..
+          make install
+          cd ../..
+
+      - name: Install Marmot
+        shell: bash -leo pipefail {0}
+        run: |
+          # Branch selection is identical to run_tests_with_marmot.yml; see the comment there.
+          CANDIDATE_BRANCHES=("${{ github.head_ref }}" "${{ github.base_ref }}" "next_v26.11")
+
+          cd ..
+          git clone --recurse-submodules https://github.com/MAteRialMOdelingToolbox/Marmot/
+          cd Marmot
+
+          TARGET_BRANCH=""
+          for candidate in "${CANDIDATE_BRANCHES[@]}"; do
+            if [ -n "$candidate" ] && git show-ref --verify --quiet "refs/remotes/origin/$candidate"; then
+              TARGET_BRANCH="$candidate"
+              break
+            fi
+          done
+
+          if [ -z "$TARGET_BRANCH" ]; then
+            echo "::error::None of the candidate branches (${CANDIDATE_BRANCHES[*]}) exist in Marmot, and there is no safe default to fall back to."
+            exit 1
+          fi
+
+          echo "Using Marmot branch: $TARGET_BRANCH"
+          git checkout --detach "origin/$TARGET_BRANCH"
+
+          mkdir build
+          cd build
+          cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX ..
+          make install
+          cd ../../
+
+      - name: Build EdelweissFE
+        shell: bash -leo pipefail {0}
+        run: |
+          pip install -v .
+
+      - name: Run tests
+        shell: bash -leo pipefail {0}
+        run: |
+          run_tests_edelweissfe ./testfiles/marmot/
+          run_tests_edelweissfe ./testfiles/edelweiss-only/

--- a/.github/workflows/run_tests_without_marmot.yml
+++ b/.github/workflows/run_tests_without_marmot.yml
@@ -18,22 +18,22 @@ jobs:
           activate-environment: anaconda-client-env
 
       - name: Install conda packages
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           mamba install --file conda_requirements.txt
 
       - name: Install pip packages
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           pip install -r pip_requirements.txt
 
       - name: Build EdelweissFE
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           pip install .
 
       - name: Run tests without Marmot
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           run_tests_edelweissfe ./testfiles/edelweiss-only/
 

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -21,17 +21,17 @@ jobs:
           activate-environment: anaconda-client-env
 
       - name: Install conda packages
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           mamba install --file conda_requirements.txt
 
       - name: Install pip packages
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           pip install -r pip_requirements.txt
 
       - name: Install Eigen
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           git clone --branch 3.4.0 https://gitlab.com/libeigen/eigen.git
           cd eigen
@@ -42,7 +42,7 @@ jobs:
           cd ../..
 
       - name: Install Autodiff
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           git clone --branch v1.1.0 https://github.com/autodiff/autodiff.git
           cd autodiff
@@ -58,7 +58,7 @@ jobs:
           cd ../..
 
       - name: Install Fastor
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           git clone https://github.com/romeric/Fastor.git
           cd Fastor
@@ -67,7 +67,7 @@ jobs:
           cd ..
 
       - name: Install Marmot
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           # Use github.base_ref (target of PR).
           # If not a PR (like a push to master), fall back to github.ref_name.
@@ -93,12 +93,12 @@ jobs:
           cd ../../
 
       - name: Build EdelweissFE
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           pip install -v .
 
       - name: Building EdelweissFE documentation
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           sphinx-build ./doc/source/ ./docs -b html
 

--- a/conda_requirements_osx-arm64.txt
+++ b/conda_requirements_osx-arm64.txt
@@ -1,0 +1,49 @@
+# conda_requirements.txt adapted for osx-arm64 (Apple Silicon).
+#
+# Two deviations from conda_requirements.txt, both forced by packages that do not exist for
+# this platform. Everything else is identical, so the two files stay easy to diff.
+#
+# 1. Intel MKL, the MKL headers and Intel OpenMP have no osx-arm64 build at all, so leaving
+#    them in makes environment creation fail before anything is installed:
+#
+#        PackagesNotFoundError: The following packages are not available from
+#        current channels:
+#          - intel-openmp
+#
+#    The only capability lost is PARDISO, which is part of MKL and therefore unavailable on
+#    this platform regardless. getDefaultLinSolver() already falls back to SciPy's superlu
+#    when the PARDISO extension is absent.
+#
+#anaconda::mkl
+#anaconda::mkl-include
+#anaconda::intel-openmp
+#
+# 2. python-freethreading is dropped, so this resolves to the regular cp314 interpreter.
+#    VTK publishes free-threaded wheels for Linux only: vtk 9.7.0 ships
+#    cp314-cp314t-manylinux_2_28_aarch64 and cp314-cp314t-manylinux2014_x86_64, but there is
+#    no cp314t macOS wheel of any architecture, and conda-forge's vtk likewise requires
+#    python_abi *_cp314. Keeping python-freethreading here would therefore make
+#    `pip install -r pip_requirements.txt` fail on vtk, and take pyvista with it.
+#
+#    So on macOS the choice is between free-threading and pyvista/VTK, and this file picks
+#    pyvista, so that the test suite runs complete. Note that free-threading currently buys
+#    nothing here in any case: the Cython extensions do not declare free-threading support,
+#    so CPython re-enables the GIL as soon as they are imported.
+#
+boost-cpp
+cmake
+compilers
+cython
+gstools
+make
+numpy
+numpydoc
+python=3.14
+#python-freethreading
+pytest
+prettytable
+scipy
+suitesparse
+sphinx
+sphinx_rtd_theme>=3.1.0
+sympy

--- a/edelweissfe/numerics/csrgeneratorv2.pyx
+++ b/edelweissfe/numerics/csrgeneratorv2.pyx
@@ -28,6 +28,7 @@ import numpy as np
 from scipy.sparse import csr_matrix
 
 cimport numpy as np
+from libc.stdint cimport int64_t
 from libcpp.vector cimport vector
 
 
@@ -121,7 +122,7 @@ cdef extern from "_csrcore.h":
                            const int* I, const int* J, long nPairs, int nThreads) except +
 
         void assembleFromVIJ(const double* V, const int* I, double* csr_data) nogil
-        void registerEntities(const long* mapStarts, const int* nDofs, int nEntities, const int* I)
+        void registerEntities(const int64_t* mapStarts, const int* nDofs, int nEntities, const int* I)
         void beginAssembly() nogil
         void scatterBlock(int tid, int entity, const double* block) nogil
         void reduce(double* csr_data) nogil
@@ -387,7 +388,7 @@ cdef class DirectCSRAssembler:
             self.asm_.assembleFromVIJ(&V[0], &I[0], &out[0])
         return self.csrMatrix
 
-    def registerEntities(self, long[::1] mapStarts, int[::1] nDofs):
+    def registerEntities(self, int64_t[::1] mapStarts, int[::1] nDofs):
         """Give each entity its slice of the offset map, once per connectivity change.
 
         ``mapStarts[e]`` is entity e's offset into the VIJ ordering -- the same value the DofManager


### PR DESCRIPTION
Makes EdelweissFE installable and runnable on macOS/arm64 (Apple Silicon).

1.     conda_requirements.txt pins mkl, mkl-include and intel-openmp, which are x86-only, so environment creation fails outright on osx-arm64. Adds conda_requirements_osx-arm64.txt.

2.     getLinSolverByName("pardiso") hard-imports the MKL backend. It now falls back to MUMPS if available, otherwise SciPy's SuperLU, with a warning — so pardiso-configured input files and the test suite run unchanged. Both fallback paths are exercised.

3.     analyticalfields/fromvtk.py imported pyvista at module scope, but inputfileparser imports that module unconditionally to register its input language, and vtk/pyvista have no free-threaded wheels on osx-arm64 — so every test aborted on import. Made lazy.

4.     linsolve/mumps/mumps.py: b may be a DofVector, whose copy() drops entitiesInDofVector, so np.reshape(b.copy(), ...)[:, i] raises AttributeError. Work on a plain ndarray.

Test suite on Apple M4: 79 passed, 48 skipped, 0 failed.