### PR TITLE
fix(elements): unify Hexa8/Hexa20 node ordering with Marmot's Abaqus-standard convention

### DIFF
--- a/doc/source/documentation/elements.rst
+++ b/doc/source/documentation/elements.rst
@@ -46,7 +46,7 @@ One of the following element types needs to be included in the definition (``typ
 
 .. note::
     ``C3D8``/``C3D20`` (and their ``TL`` counterparts) use the standard Abaqus node ordering
-    (corner ring 0-3 at :math:`\zeta=-1`, ring 4-7 at :math:`\zeta=+1`), matching the ``marmot``
+    (corner ring 1-4 at :math:`\zeta=-1`, ring 5-8 at :math:`\zeta=+1`), matching the ``marmot``
     provider's elements -- there is only one node-ordering convention across the framework.
 
 **additional Parameters**

--- a/doc/source/documentation/elements.rst
+++ b/doc/source/documentation/elements.rst
@@ -44,6 +44,11 @@ One of the following element types needs to be included in the definition (``typ
 - **C3D8**    - hexahedron 3D element with 8 nodes.
 - **C3D20**    - hexahedron 3D element with 20 nodes.
 
+.. note::
+    ``C3D8``/``C3D20`` (and their ``TL`` counterparts) use the standard Abaqus node ordering
+    (corner ring 0-3 at :math:`\zeta=-1`, ring 4-7 at :math:`\zeta=+1`), matching the ``marmot``
+    provider's elements -- there is only one node-ordering convention across the framework.
+
 **additional Parameters**
 
 The following optional Parameters are also included in the element type definition:

--- a/edelweissfe/elements/_hexa3dnodeordering.py
+++ b/edelweissfe/elements/_hexa3dnodeordering.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#  ---------------------------------------------------------------------
+#
+#  _____    _      _              _         _____ _____
+# | ____|__| | ___| |_      _____(_)___ ___|  ___| ____|
+# |  _| / _` |/ _ \ \ \ /\ / / _ \ / __/ __| |_  |  _|
+# | |__| (_| |  __/ |\ V  V /  __/ \__ \__ \  _| | |___
+# |_____\__,_|\___|_| \_/\_/ \___|_|___/___/_|   |_____|
+#
+#
+#  Unit of Strength of Materials and Structural Analysis
+#  University of Innsbruck,
+#  2017 - today
+#
+#  Matthias Neuner matthias.neuner@uibk.ac.at
+#
+#  This file is part of EdelweissFE.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2.1 of the License, or (at your option) any later version.
+#
+#  The full text of the license can be found in the file LICENSE.md at
+#  the top level directory of EdelweissFE.
+#  ---------------------------------------------------------------------
+
+"""
+Hexa8/Hexa20 shape functions and their local derivatives, in the standard Abaqus C3D8/C3D20 node
+ordering (corner ring 0-3 at zeta=-1, ring 4-7 at zeta=+1) -- matching Marmot's element
+formulation, so this is the only node-ordering convention across the framework. The single source
+of truth for both the small-strain (:mod:`edelweissfe.elements.displacementelement`) and
+total-Lagrangian (:mod:`edelweissfe.elements.displacementtlelement`) element formulations, so the
+ordering only needs to be correct in one place.
+"""
+
+import numpy as np
+
+
+def hexa8N(xi, eta, z):
+    """The Hexa8 shape functions at ``(xi, eta, z)``.
+
+    Parameters
+    ----------
+    xi, eta, z
+        Local coordinates, either scalars or arrays of the same shape.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(8, ...)``: the 8 shape function values (leading dimension), broadcasting over
+        any additional shape of the inputs."""
+
+    return (
+        1
+        / 8
+        * np.array(
+            [
+                (1 - xi) * (1 - eta) * (1 - z),
+                (1 + xi) * (1 - eta) * (1 - z),
+                (1 + xi) * (1 + eta) * (1 - z),
+                (1 - xi) * (1 + eta) * (1 - z),
+                (1 - xi) * (1 - eta) * (1 + z),
+                (1 + xi) * (1 - eta) * (1 + z),
+                (1 + xi) * (1 + eta) * (1 + z),
+                (1 - xi) * (1 + eta) * (1 + z),
+            ]
+        )
+    )
+
+
+def hexa8DNdXi(xi, eta, z):
+    """dN/d(xi, eta, zeta) for Hexa8 at ``(xi, eta, z)``.
+
+    Parameters
+    ----------
+    xi, eta, z
+        Local coordinates, either scalars or arrays of the same shape.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(3, 8, ...)``: row 0/1/2 are d/dxi, d/deta, d/dzeta; the second dimension is the
+        node, broadcasting over any additional shape of the inputs."""
+
+    return (
+        1
+        / 8
+        * np.array(
+            [
+                [
+                    -(1 - eta) * (1 - z),
+                    (1 - eta) * (1 - z),
+                    (1 + eta) * (1 - z),
+                    -(1 + eta) * (1 - z),
+                    -(1 - eta) * (1 + z),
+                    (1 - eta) * (1 + z),
+                    (1 + eta) * (1 + z),
+                    -(1 + eta) * (1 + z),
+                ],
+                [
+                    -(1 - xi) * (1 - z),
+                    -(1 + xi) * (1 - z),
+                    (1 + xi) * (1 - z),
+                    (1 - xi) * (1 - z),
+                    -(1 - xi) * (1 + z),
+                    -(1 + xi) * (1 + z),
+                    (1 + xi) * (1 + z),
+                    (1 - xi) * (1 + z),
+                ],
+                [
+                    -(1 - xi) * (1 - eta),
+                    -(1 + xi) * (1 - eta),
+                    -(1 + xi) * (1 + eta),
+                    -(1 - xi) * (1 + eta),
+                    (1 - xi) * (1 - eta),
+                    (1 + xi) * (1 - eta),
+                    (1 + xi) * (1 + eta),
+                    (1 - xi) * (1 + eta),
+                ],
+            ]
+        )
+    )
+
+
+def hexa20N(xi, eta, z):
+    """The Hexa20 shape functions at ``(xi, eta, z)``.
+
+    Parameters
+    ----------
+    xi, eta, z
+        Local coordinates, either scalars or arrays of the same shape.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(20, ...)``: the 20 shape function values (leading dimension), broadcasting over
+        any additional shape of the inputs."""
+
+    return (
+        1
+        / 8
+        * np.array(
+            [
+                -(1 - xi) * (1 - eta) * (1 - z) * (2 + xi + eta + z),
+                -(1 + xi) * (1 - eta) * (1 - z) * (2 - xi + eta + z),
+                -(1 + xi) * (1 + eta) * (1 - z) * (2 - xi - eta + z),
+                -(1 - xi) * (1 + eta) * (1 - z) * (2 + xi - eta + z),
+                -(1 - xi) * (1 - eta) * (1 + z) * (2 + xi + eta - z),
+                -(1 + xi) * (1 - eta) * (1 + z) * (2 - xi + eta - z),
+                -(1 + xi) * (1 + eta) * (1 + z) * (2 - xi - eta - z),
+                -(1 - xi) * (1 + eta) * (1 + z) * (2 + xi - eta - z),
+                2 * (1 - xi**2) * (1 - eta) * (1 - z),
+                2 * (1 - eta**2) * (1 + xi) * (1 - z),
+                2 * (1 - xi**2) * (1 + eta) * (1 - z),
+                2 * (1 - eta**2) * (1 - xi) * (1 - z),
+                2 * (1 - xi**2) * (1 - eta) * (1 + z),
+                2 * (1 - eta**2) * (1 + xi) * (1 + z),
+                2 * (1 - xi**2) * (1 + eta) * (1 + z),
+                2 * (1 - eta**2) * (1 - xi) * (1 + z),
+                2 * (1 - xi) * (1 - eta) * (1 - z**2),
+                2 * (1 + xi) * (1 - eta) * (1 - z**2),
+                2 * (1 + xi) * (1 + eta) * (1 - z**2),
+                2 * (1 - xi) * (1 + eta) * (1 - z**2),
+            ]
+        )
+    )
+
+
+def hexa20DNdXi(xi, eta, z):
+    """dN/d(xi, eta, zeta) for Hexa20 at ``(xi, eta, z)``.
+
+    Parameters
+    ----------
+    xi, eta, z
+        Local coordinates, either scalars or arrays of the same shape.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(3, 20, ...)``: row 0/1/2 are d/dxi, d/deta, d/dzeta; the second dimension is the
+        node, broadcasting over any additional shape of the inputs."""
+
+    return np.array(
+        [
+            [
+                0.125 * (1 - eta) * (1 - z) * (1 + 2 * xi + eta + z),
+                -0.125 * (1 - eta) * (1 - z) * (1 - 2 * xi + eta + z),
+                -0.125 * (1 + eta) * (1 - z) * (1 - 2 * xi - eta + z),
+                0.125 * (1 + eta) * (1 - z) * (1 + 2 * xi - eta + z),
+                0.125 * (1 - eta) * (1 + z) * (1 + 2 * xi + eta - z),
+                -0.125 * (1 - eta) * (1 + z) * (1 - 2 * xi + eta - z),
+                -0.125 * (1 + eta) * (1 + z) * (1 - 2 * xi - eta - z),
+                0.125 * (1 + eta) * (1 + z) * (1 + 2 * xi - eta - z),
+                -0.5 * xi * (1 - eta) * (1 - z),
+                0.25 * (1 - eta * eta) * (1 - z),
+                -0.5 * xi * (1 + eta) * (1 - z),
+                -0.25 * (1 - eta * eta) * (1 - z),
+                -0.5 * xi * (1 - eta) * (1 + z),
+                0.25 * (1 - eta * eta) * (1 + z),
+                -0.5 * xi * (1 + eta) * (1 + z),
+                -0.25 * (1 - eta * eta) * (1 + z),
+                -0.25 * (1 - eta) * (1 - z * z),
+                0.25 * (1 - eta) * (1 - z * z),
+                0.25 * (1 + eta) * (1 - z * z),
+                -0.25 * (1 + eta) * (1 - z * z),
+            ],
+            [
+                0.125 * (1 - xi) * (1 - z) * (1 + xi + 2 * eta + z),
+                0.125 * (1 + xi) * (1 - z) * (1 - xi + 2 * eta + z),
+                -0.125 * (1 + xi) * (1 - z) * (1 - xi - 2 * eta + z),
+                -0.125 * (1 - xi) * (1 - z) * (1 + xi - 2 * eta + z),
+                0.125 * (1 - xi) * (1 + z) * (1 + xi + 2 * eta - z),
+                0.125 * (1 + xi) * (1 + z) * (1 - xi + 2 * eta - z),
+                -0.125 * (1 + xi) * (1 + z) * (1 - xi - 2 * eta - z),
+                -0.125 * (1 - xi) * (1 + z) * (1 + xi - 2 * eta - z),
+                -0.25 * (1 - xi * xi) * (1 - z),
+                -0.5 * eta * (1 + xi) * (1 - z),
+                0.25 * (1 - xi * xi) * (1 - z),
+                -0.5 * eta * (1 - xi) * (1 - z),
+                -0.25 * (1 - xi * xi) * (1 + z),
+                -0.5 * eta * (1 + xi) * (1 + z),
+                0.25 * (1 - xi * xi) * (1 + z),
+                -0.5 * eta * (1 - xi) * (1 + z),
+                -0.25 * (1 - xi) * (1 - z * z),
+                -0.25 * (1 + xi) * (1 - z * z),
+                0.25 * (1 + xi) * (1 - z * z),
+                0.25 * (1 - xi) * (1 - z * z),
+            ],
+            [
+                0.125 * (1 - xi) * (1 - eta) * (1 + xi + eta + 2 * z),
+                0.125 * (1 + xi) * (1 - eta) * (1 - xi + eta + 2 * z),
+                0.125 * (1 + xi) * (1 + eta) * (1 - xi - eta + 2 * z),
+                0.125 * (1 - xi) * (1 + eta) * (1 + xi - eta + 2 * z),
+                -0.125 * (1 - xi) * (1 - eta) * (1 + xi + eta - 2 * z),
+                -0.125 * (1 + xi) * (1 - eta) * (1 - xi + eta - 2 * z),
+                -0.125 * (1 + xi) * (1 + eta) * (1 - xi - eta - 2 * z),
+                -0.125 * (1 - xi) * (1 + eta) * (1 + xi - eta - 2 * z),
+                -0.25 * (1 - xi * xi) * (1 - eta),
+                -0.25 * (1 - eta * eta) * (1 + xi),
+                -0.25 * (1 - xi * xi) * (1 + eta),
+                -0.25 * (1 - eta * eta) * (1 - xi),
+                0.25 * (1 - xi * xi) * (1 - eta),
+                0.25 * (1 - eta * eta) * (1 + xi),
+                0.25 * (1 - xi * xi) * (1 + eta),
+                0.25 * (1 - eta * eta) * (1 - xi),
+                -0.5 * (1 - xi) * (1 - eta) * z,
+                -0.5 * (1 + xi) * (1 - eta) * z,
+                -0.5 * (1 + xi) * (1 + eta) * z,
+                -0.5 * (1 - xi) * (1 + eta) * z,
+            ],
+        ]
+    )

--- a/edelweissfe/elements/displacementelement/_elementcomputationmatrices.py
+++ b/edelweissfe/elements/displacementelement/_elementcomputationmatrices.py
@@ -652,7 +652,7 @@ def _B2D8(xi: np.ndarray, eta: np.ndarray, x: np.ndarray, nInt: int):
     return Bi
 
 
-def _B3DGeneric(dNdXi: np.ndarray, x: np.ndarray, J: np.ndarray, nInt: int, nNodes: int):
+def _B3DGeneric(dNdXi: np.ndarray, J: np.ndarray, nInt: int, nNodes: int):
     """Assemble the standard isoparametric strain-displacement (B) operator for a 3D solid
     element from its dN/dxi and Jacobian, given a node-major local DOF vector
     ``(ux1,uy1,uz1,ux2,uy2,uz2,...)``.
@@ -661,8 +661,6 @@ def _B3DGeneric(dNdXi: np.ndarray, x: np.ndarray, J: np.ndarray, nInt: int, nNod
     ----------
     dNdXi
         Shape ``(nInt, 3, nNodes)``, as returned by :func:`_dNdXi3D8`/:func:`_dNdXi3D20`.
-    x
-        Coordinates of the element points.
     J
         The Jacobian matrices, shape ``(nInt, 3, 3)``.
     nInt
@@ -678,7 +676,7 @@ def _B3DGeneric(dNdXi: np.ndarray, x: np.ndarray, J: np.ndarray, nInt: int, nNod
 
     Bi = np.zeros([nInt, 6, 3 * nNodes])
     for i in range(nInt):
-        dNdX = np.linalg.inv(J[i]) @ dNdXi[i]  # (3, nNodes): row b = dN/dX_b
+        dNdX = np.linalg.solve(J[i], dNdXi[i])  # (3, nNodes): row b = dN/dX_b
         for k in range(nNodes):
             dNkdX, dNkdY, dNkdZ = dNdX[:, k]
             Bi[i, :, 3 * k : 3 * k + 3] = np.array(
@@ -717,7 +715,7 @@ def _B3D8(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: i
 
     dNdXi = _dNdXi3D8(xi, eta, z, nInt)
     J = _J3D8(xi, eta, z, x, nInt)
-    return _B3DGeneric(dNdXi, x, J, nInt, 8)
+    return _B3DGeneric(dNdXi, J, nInt, 8)
 
 
 def _B3D20(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: int):
@@ -743,4 +741,4 @@ def _B3D20(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: 
 
     dNdXi = _dNdXi3D20(xi, eta, z, nInt)
     J = _J3D20(xi, eta, z, x, nInt)
-    return _B3DGeneric(dNdXi, x, J, nInt, 20)
+    return _B3DGeneric(dNdXi, J, nInt, 20)

--- a/edelweissfe/elements/displacementelement/_elementcomputationmatrices.py
+++ b/edelweissfe/elements/displacementelement/_elementcomputationmatrices.py
@@ -28,6 +28,13 @@
 
 import numpy as np
 
+from edelweissfe.elements._hexa3dnodeordering import (
+    hexa8DNdXi,
+    hexa8N,
+    hexa20DNdXi,
+    hexa20N,
+)
+
 
 def computeJacobian(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: int, nNodes: int, dim: int):
     """Get the Jacobi matrix for the element calculation.
@@ -161,58 +168,17 @@ def computeNOperator(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, nInt: int, 
                     )
                 )
     elif dim == 3:
-        # Hexa8/Hexa20 node ordering follows the standard Abaqus C3D8/C3D20 convention (corner
-        # ring 0-3 at zeta=-1, ring 4-7 at zeta=+1), matching Marmot's element formulation --
-        # see edelweissfe.generators.surfaceelementgenerator's module docstring for why this
-        # matters for contact-facet generation.
+        # Hexa8/Hexa20 node ordering (see edelweissfe.elements._hexa3dnodeordering) follows the
+        # standard Abaqus C3D8/C3D20 convention (corner ring 0-3 at zeta=-1, ring 4-7 at zeta=+1),
+        # matching Marmot's element formulation -- this is also the local node ordering assumed by
+        # any face-numbering convention (e.g. a contact-facet generator) built on top of this
+        # element.
         if nNodes == 8:  # Hexa8
             for i in range(nInt):
-                N[i] = (
-                    1
-                    / 8
-                    * np.array(
-                        [
-                            (1 - xi[i]) * (1 - eta[i]) * (1 - z[i]),
-                            (1 + xi[i]) * (1 - eta[i]) * (1 - z[i]),
-                            (1 + xi[i]) * (1 + eta[i]) * (1 - z[i]),
-                            (1 - xi[i]) * (1 + eta[i]) * (1 - z[i]),
-                            (1 - xi[i]) * (1 - eta[i]) * (1 + z[i]),
-                            (1 + xi[i]) * (1 - eta[i]) * (1 + z[i]),
-                            (1 + xi[i]) * (1 + eta[i]) * (1 + z[i]),
-                            (1 - xi[i]) * (1 + eta[i]) * (1 + z[i]),
-                        ]
-                    )
-                )
+                N[i] = hexa8N(xi[i], eta[i], z[i])
         elif nNodes == 20:  # Hexa20
             for i in range(nInt):
-                N[i] = (
-                    1
-                    / 8
-                    * np.array(
-                        [
-                            -(1 - xi[i]) * (1 - eta[i]) * (1 - z[i]) * (2 + xi[i] + eta[i] + z[i]),
-                            -(1 + xi[i]) * (1 - eta[i]) * (1 - z[i]) * (2 - xi[i] + eta[i] + z[i]),
-                            -(1 + xi[i]) * (1 + eta[i]) * (1 - z[i]) * (2 - xi[i] - eta[i] + z[i]),
-                            -(1 - xi[i]) * (1 + eta[i]) * (1 - z[i]) * (2 + xi[i] - eta[i] + z[i]),
-                            -(1 - xi[i]) * (1 - eta[i]) * (1 + z[i]) * (2 + xi[i] + eta[i] - z[i]),
-                            -(1 + xi[i]) * (1 - eta[i]) * (1 + z[i]) * (2 - xi[i] + eta[i] - z[i]),
-                            -(1 + xi[i]) * (1 + eta[i]) * (1 + z[i]) * (2 - xi[i] - eta[i] - z[i]),
-                            -(1 - xi[i]) * (1 + eta[i]) * (1 + z[i]) * (2 + xi[i] - eta[i] - z[i]),
-                            2 * (1 - xi[i] ** 2) * (1 - eta[i]) * (1 - z[i]),
-                            2 * (1 - eta[i] ** 2) * (1 + xi[i]) * (1 - z[i]),
-                            2 * (1 - xi[i] ** 2) * (1 + eta[i]) * (1 - z[i]),
-                            2 * (1 - eta[i] ** 2) * (1 - xi[i]) * (1 - z[i]),
-                            2 * (1 - xi[i] ** 2) * (1 - eta[i]) * (1 + z[i]),
-                            2 * (1 - eta[i] ** 2) * (1 + xi[i]) * (1 + z[i]),
-                            2 * (1 - xi[i] ** 2) * (1 + eta[i]) * (1 + z[i]),
-                            2 * (1 - eta[i] ** 2) * (1 - xi[i]) * (1 + z[i]),
-                            2 * (1 - xi[i]) * (1 - eta[i]) * (1 - z[i] ** 2),
-                            2 * (1 + xi[i]) * (1 - eta[i]) * (1 - z[i] ** 2),
-                            2 * (1 + xi[i]) * (1 + eta[i]) * (1 - z[i] ** 2),
-                            2 * (1 - xi[i]) * (1 + eta[i]) * (1 - z[i] ** 2),
-                        ]
-                    )
-                )
+                N[i] = hexa20N(xi[i], eta[i], z[i])
     return N
 
 
@@ -328,45 +294,31 @@ def _dNdXi3D8(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, nInt: int):
 
     dNdXi = np.zeros([nInt, 3, 8])
     for i in range(nInt):
-        dNdXi[i] = (
-            1
-            / 8
-            * np.array(
-                [
-                    [
-                        -(1 - eta[i]) * (1 - z[i]),
-                        (1 - eta[i]) * (1 - z[i]),
-                        (1 + eta[i]) * (1 - z[i]),
-                        -(1 + eta[i]) * (1 - z[i]),
-                        -(1 - eta[i]) * (1 + z[i]),
-                        (1 - eta[i]) * (1 + z[i]),
-                        (1 + eta[i]) * (1 + z[i]),
-                        -(1 + eta[i]) * (1 + z[i]),
-                    ],
-                    [
-                        -(1 - xi[i]) * (1 - z[i]),
-                        -(1 + xi[i]) * (1 - z[i]),
-                        (1 + xi[i]) * (1 - z[i]),
-                        (1 - xi[i]) * (1 - z[i]),
-                        -(1 - xi[i]) * (1 + z[i]),
-                        -(1 + xi[i]) * (1 + z[i]),
-                        (1 + xi[i]) * (1 + z[i]),
-                        (1 - xi[i]) * (1 + z[i]),
-                    ],
-                    [
-                        -(1 - xi[i]) * (1 - eta[i]),
-                        -(1 + xi[i]) * (1 - eta[i]),
-                        -(1 + xi[i]) * (1 + eta[i]),
-                        -(1 - xi[i]) * (1 + eta[i]),
-                        (1 - xi[i]) * (1 - eta[i]),
-                        (1 + xi[i]) * (1 - eta[i]),
-                        (1 + xi[i]) * (1 + eta[i]),
-                        (1 - xi[i]) * (1 + eta[i]),
-                    ],
-                ]
-            )
-        )
+        dNdXi[i] = hexa8DNdXi(xi[i], eta[i], z[i])
     return dNdXi
+
+
+def _JFromDNdXi(dNdXi: np.ndarray, x: np.ndarray, nInt: int):
+    """Get the Jacobi matrix for a 3D solid element from its (already computed) dN/dxi.
+
+    Parameters
+    ----------
+    dNdXi
+        Shape ``(nInt, 3, nNodes)``, as returned by :func:`_dNdXi3D8`/:func:`_dNdXi3D20`.
+    x
+        Coordinates of the element points.
+    nInt
+        Number of quadrature points the element has.
+
+    Returns
+    -------
+    np.ndarray
+        The requested Jacobian matrix."""
+
+    J = np.zeros([nInt, 3, 3])
+    for i in range(nInt):
+        J[i] = dNdXi[i] @ x.T
+    return J
 
 
 def _J3D8(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: int):
@@ -390,11 +342,7 @@ def _J3D8(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: i
     np.ndarray
         The requested Jacobian matrix."""
 
-    dNdXi = _dNdXi3D8(xi, eta, z, nInt)
-    J = np.zeros([nInt, 3, 3])
-    for i in range(nInt):
-        J[i] = dNdXi[i] @ x.T
-    return J
+    return _JFromDNdXi(_dNdXi3D8(xi, eta, z, nInt), x, nInt)
 
 
 def _dNdXi3D20(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, nInt: int):
@@ -418,73 +366,7 @@ def _dNdXi3D20(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, nInt: int):
 
     dNdXi = np.zeros([nInt, 3, 20])
     for i in range(nInt):
-        xi_, eta_, z_ = xi[i], eta[i], z[i]
-        dNdXi[i, 0, :] = [
-            0.125 * (1 - eta_) * (1 - z_) * (1 + 2 * xi_ + eta_ + z_),
-            -0.125 * (1 - eta_) * (1 - z_) * (1 - 2 * xi_ + eta_ + z_),
-            -0.125 * (1 + eta_) * (1 - z_) * (1 - 2 * xi_ - eta_ + z_),
-            0.125 * (1 + eta_) * (1 - z_) * (1 + 2 * xi_ - eta_ + z_),
-            0.125 * (1 - eta_) * (1 + z_) * (1 + 2 * xi_ + eta_ - z_),
-            -0.125 * (1 - eta_) * (1 + z_) * (1 - 2 * xi_ + eta_ - z_),
-            -0.125 * (1 + eta_) * (1 + z_) * (1 - 2 * xi_ - eta_ - z_),
-            0.125 * (1 + eta_) * (1 + z_) * (1 + 2 * xi_ - eta_ - z_),
-            -0.5 * xi_ * (1 - eta_) * (1 - z_),
-            0.25 * (1 - eta_ * eta_) * (1 - z_),
-            -0.5 * xi_ * (1 + eta_) * (1 - z_),
-            -0.25 * (1 - eta_ * eta_) * (1 - z_),
-            -0.5 * xi_ * (1 - eta_) * (1 + z_),
-            0.25 * (1 - eta_ * eta_) * (1 + z_),
-            -0.5 * xi_ * (1 + eta_) * (1 + z_),
-            -0.25 * (1 - eta_ * eta_) * (1 + z_),
-            -0.25 * (1 - eta_) * (1 - z_ * z_),
-            0.25 * (1 - eta_) * (1 - z_ * z_),
-            0.25 * (1 + eta_) * (1 - z_ * z_),
-            -0.25 * (1 + eta_) * (1 - z_ * z_),
-        ]
-        dNdXi[i, 1, :] = [
-            0.125 * (1 - xi_) * (1 - z_) * (1 + xi_ + 2 * eta_ + z_),
-            0.125 * (1 + xi_) * (1 - z_) * (1 - xi_ + 2 * eta_ + z_),
-            -0.125 * (1 + xi_) * (1 - z_) * (1 - xi_ - 2 * eta_ + z_),
-            -0.125 * (1 - xi_) * (1 - z_) * (1 + xi_ - 2 * eta_ + z_),
-            0.125 * (1 - xi_) * (1 + z_) * (1 + xi_ + 2 * eta_ - z_),
-            0.125 * (1 + xi_) * (1 + z_) * (1 - xi_ + 2 * eta_ - z_),
-            -0.125 * (1 + xi_) * (1 + z_) * (1 - xi_ - 2 * eta_ - z_),
-            -0.125 * (1 - xi_) * (1 + z_) * (1 + xi_ - 2 * eta_ - z_),
-            -0.25 * (1 - xi_ * xi_) * (1 - z_),
-            -0.5 * eta_ * (1 + xi_) * (1 - z_),
-            0.25 * (1 - xi_ * xi_) * (1 - z_),
-            -0.5 * eta_ * (1 - xi_) * (1 - z_),
-            -0.25 * (1 - xi_ * xi_) * (1 + z_),
-            -0.5 * eta_ * (1 + xi_) * (1 + z_),
-            0.25 * (1 - xi_ * xi_) * (1 + z_),
-            -0.5 * eta_ * (1 - xi_) * (1 + z_),
-            -0.25 * (1 - xi_) * (1 - z_ * z_),
-            -0.25 * (1 + xi_) * (1 - z_ * z_),
-            0.25 * (1 + xi_) * (1 - z_ * z_),
-            0.25 * (1 - xi_) * (1 - z_ * z_),
-        ]
-        dNdXi[i, 2, :] = [
-            0.125 * (1 - xi_) * (1 - eta_) * (1 + xi_ + eta_ + 2 * z_),
-            0.125 * (1 + xi_) * (1 - eta_) * (1 - xi_ + eta_ + 2 * z_),
-            0.125 * (1 + xi_) * (1 + eta_) * (1 - xi_ - eta_ + 2 * z_),
-            0.125 * (1 - xi_) * (1 + eta_) * (1 + xi_ - eta_ + 2 * z_),
-            -0.125 * (1 - xi_) * (1 - eta_) * (1 + xi_ + eta_ - 2 * z_),
-            -0.125 * (1 + xi_) * (1 - eta_) * (1 - xi_ + eta_ - 2 * z_),
-            -0.125 * (1 + xi_) * (1 + eta_) * (1 - xi_ - eta_ - 2 * z_),
-            -0.125 * (1 - xi_) * (1 + eta_) * (1 + xi_ - eta_ - 2 * z_),
-            -0.25 * (1 - xi_ * xi_) * (1 - eta_),
-            -0.25 * (1 - eta_ * eta_) * (1 + xi_),
-            -0.25 * (1 - xi_ * xi_) * (1 + eta_),
-            -0.25 * (1 - eta_ * eta_) * (1 - xi_),
-            0.25 * (1 - xi_ * xi_) * (1 - eta_),
-            0.25 * (1 - eta_ * eta_) * (1 + xi_),
-            0.25 * (1 - xi_ * xi_) * (1 + eta_),
-            0.25 * (1 - eta_ * eta_) * (1 - xi_),
-            -0.5 * (1 - xi_) * (1 - eta_) * z_,
-            -0.5 * (1 + xi_) * (1 - eta_) * z_,
-            -0.5 * (1 + xi_) * (1 + eta_) * z_,
-            -0.5 * (1 - xi_) * (1 + eta_) * z_,
-        ]
+        dNdXi[i] = hexa20DNdXi(xi[i], eta[i], z[i])
     return dNdXi
 
 
@@ -509,11 +391,7 @@ def _J3D20(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: 
     np.ndarray
         The requested Jacobian matrix."""
 
-    dNdXi = _dNdXi3D20(xi, eta, z, nInt)
-    J = np.zeros([nInt, 3, 3])
-    for i in range(nInt):
-        J[i] = dNdXi[i] @ x.T
-    return J
+    return _JFromDNdXi(_dNdXi3D20(xi, eta, z, nInt), x, nInt)
 
 
 def _B2D4(xi: np.ndarray, eta: np.ndarray, x: np.ndarray, nInt: int):
@@ -714,7 +592,7 @@ def _B3D8(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: i
         The requested B operator."""
 
     dNdXi = _dNdXi3D8(xi, eta, z, nInt)
-    J = _J3D8(xi, eta, z, x, nInt)
+    J = _JFromDNdXi(dNdXi, x, nInt)
     return _B3DGeneric(dNdXi, J, nInt, 8)
 
 
@@ -740,5 +618,5 @@ def _B3D20(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: 
         The requested B operator."""
 
     dNdXi = _dNdXi3D20(xi, eta, z, nInt)
-    J = _J3D20(xi, eta, z, x, nInt)
+    J = _JFromDNdXi(dNdXi, x, nInt)
     return _B3DGeneric(dNdXi, J, nInt, 20)

--- a/edelweissfe/elements/displacementelement/_elementcomputationmatrices.py
+++ b/edelweissfe/elements/displacementelement/_elementcomputationmatrices.py
@@ -161,6 +161,10 @@ def computeNOperator(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, nInt: int, 
                     )
                 )
     elif dim == 3:
+        # Hexa8/Hexa20 node ordering follows the standard Abaqus C3D8/C3D20 convention (corner
+        # ring 0-3 at zeta=-1, ring 4-7 at zeta=+1), matching Marmot's element formulation --
+        # see edelweissfe.generators.surfaceelementgenerator's module docstring for why this
+        # matters for contact-facet generation.
         if nNodes == 8:  # Hexa8
             for i in range(nInt):
                 N[i] = (
@@ -169,13 +173,13 @@ def computeNOperator(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, nInt: int, 
                     * np.array(
                         [
                             (1 - xi[i]) * (1 - eta[i]) * (1 - z[i]),
+                            (1 + xi[i]) * (1 - eta[i]) * (1 - z[i]),
+                            (1 + xi[i]) * (1 + eta[i]) * (1 - z[i]),
+                            (1 - xi[i]) * (1 + eta[i]) * (1 - z[i]),
                             (1 - xi[i]) * (1 - eta[i]) * (1 + z[i]),
                             (1 + xi[i]) * (1 - eta[i]) * (1 + z[i]),
-                            (1 + xi[i]) * (1 - eta[i]) * (1 - z[i]),
-                            (1 - xi[i]) * (1 + eta[i]) * (1 - z[i]),
-                            (1 - xi[i]) * (1 + eta[i]) * (1 + z[i]),
                             (1 + xi[i]) * (1 + eta[i]) * (1 + z[i]),
-                            (1 + xi[i]) * (1 + eta[i]) * (1 - z[i]),
+                            (1 - xi[i]) * (1 + eta[i]) * (1 + z[i]),
                         ]
                     )
                 )
@@ -186,26 +190,26 @@ def computeNOperator(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, nInt: int, 
                     / 8
                     * np.array(
                         [
-                            (1 - xi[i]) * (1 - eta[i]) * (1 - z[i]) * (-xi[i] - eta[i] - z[i] - 2),
-                            (1 - xi[i]) * (1 - eta[i]) * (1 + z[i]) * (-xi[i] - eta[i] + z[i] - 2),
-                            (1 + xi[i]) * (1 - eta[i]) * (1 + z[i]) * (xi[i] - eta[i] + z[i] - 2),
-                            (1 + xi[i]) * (1 - eta[i]) * (1 - z[i]) * (xi[i] - eta[i] - z[i] - 2),
-                            (1 - xi[i]) * (1 + eta[i]) * (1 - z[i]) * (-xi[i] + eta[i] - z[i] - 2),
-                            (1 - xi[i]) * (1 + eta[i]) * (1 + z[i]) * (-xi[i] + eta[i] + z[i] - 2),
-                            (1 + xi[i]) * (1 + eta[i]) * (1 + z[i]) * (xi[i] + eta[i] + z[i] - 2),
-                            (1 + xi[i]) * (1 + eta[i]) * (1 - z[i]) * (xi[i] + eta[i] - z[i] - 2),
-                            2 * (1 - xi[i]) * (1 - eta[i]) * (1 - z[i] ** 2),
-                            2 * (1 - xi[i] ** 2) * (1 - eta[i]) * (1 + z[i]),
-                            2 * (1 + xi[i]) * (1 - eta[i]) * (1 - z[i] ** 2),
+                            -(1 - xi[i]) * (1 - eta[i]) * (1 - z[i]) * (2 + xi[i] + eta[i] + z[i]),
+                            -(1 + xi[i]) * (1 - eta[i]) * (1 - z[i]) * (2 - xi[i] + eta[i] + z[i]),
+                            -(1 + xi[i]) * (1 + eta[i]) * (1 - z[i]) * (2 - xi[i] - eta[i] + z[i]),
+                            -(1 - xi[i]) * (1 + eta[i]) * (1 - z[i]) * (2 + xi[i] - eta[i] + z[i]),
+                            -(1 - xi[i]) * (1 - eta[i]) * (1 + z[i]) * (2 + xi[i] + eta[i] - z[i]),
+                            -(1 + xi[i]) * (1 - eta[i]) * (1 + z[i]) * (2 - xi[i] + eta[i] - z[i]),
+                            -(1 + xi[i]) * (1 + eta[i]) * (1 + z[i]) * (2 - xi[i] - eta[i] - z[i]),
+                            -(1 - xi[i]) * (1 + eta[i]) * (1 + z[i]) * (2 + xi[i] - eta[i] - z[i]),
                             2 * (1 - xi[i] ** 2) * (1 - eta[i]) * (1 - z[i]),
-                            2 * (1 - xi[i]) * (1 + eta[i]) * (1 - z[i] ** 2),
-                            2 * (1 - xi[i] ** 2) * (1 + eta[i]) * (1 + z[i]),
-                            2 * (1 + xi[i]) * (1 + eta[i]) * (1 - z[i] ** 2),
+                            2 * (1 - eta[i] ** 2) * (1 + xi[i]) * (1 - z[i]),
                             2 * (1 - xi[i] ** 2) * (1 + eta[i]) * (1 - z[i]),
-                            2 * (1 - xi[i]) * (1 - eta[i] ** 2) * (1 - z[i]),
-                            2 * (1 - xi[i]) * (1 - eta[i] ** 2) * (1 + z[i]),
-                            2 * (1 + xi[i]) * (1 - eta[i] ** 2) * (1 + z[i]),
-                            2 * (1 + xi[i]) * (1 - eta[i] ** 2) * (1 - z[i]),
+                            2 * (1 - eta[i] ** 2) * (1 - xi[i]) * (1 - z[i]),
+                            2 * (1 - xi[i] ** 2) * (1 - eta[i]) * (1 + z[i]),
+                            2 * (1 - eta[i] ** 2) * (1 + xi[i]) * (1 + z[i]),
+                            2 * (1 - xi[i] ** 2) * (1 + eta[i]) * (1 + z[i]),
+                            2 * (1 - eta[i] ** 2) * (1 - xi[i]) * (1 + z[i]),
+                            2 * (1 - xi[i]) * (1 - eta[i]) * (1 - z[i] ** 2),
+                            2 * (1 + xi[i]) * (1 - eta[i]) * (1 - z[i] ** 2),
+                            2 * (1 + xi[i]) * (1 + eta[i]) * (1 - z[i] ** 2),
+                            2 * (1 - xi[i]) * (1 + eta[i]) * (1 - z[i] ** 2),
                         ]
                     )
                 )
@@ -303,6 +307,68 @@ def _J2D8(xi: np.ndarray, eta: np.ndarray, x: np.ndarray, nInt: int):
     return J
 
 
+def _dNdXi3D8(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, nInt: int):
+    """Get dN/dxi for a Hexa8 element (matching Marmot's node ordering, see computeNOperator).
+
+    Parameters
+    ----------
+    xi
+        Local coordinates xi for the integration points.
+    eta
+        Local coordinates eta for the integration points.
+    z
+        Local coordinates zeta for the integration points.
+    nInt
+        Number of quadrature points the element has.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(nInt, 3, 8)``: row 0/1/2 are d/dxi, d/deta, d/dzeta; columns are nodes."""
+
+    dNdXi = np.zeros([nInt, 3, 8])
+    for i in range(nInt):
+        dNdXi[i] = (
+            1
+            / 8
+            * np.array(
+                [
+                    [
+                        -(1 - eta[i]) * (1 - z[i]),
+                        (1 - eta[i]) * (1 - z[i]),
+                        (1 + eta[i]) * (1 - z[i]),
+                        -(1 + eta[i]) * (1 - z[i]),
+                        -(1 - eta[i]) * (1 + z[i]),
+                        (1 - eta[i]) * (1 + z[i]),
+                        (1 + eta[i]) * (1 + z[i]),
+                        -(1 + eta[i]) * (1 + z[i]),
+                    ],
+                    [
+                        -(1 - xi[i]) * (1 - z[i]),
+                        -(1 + xi[i]) * (1 - z[i]),
+                        (1 + xi[i]) * (1 - z[i]),
+                        (1 - xi[i]) * (1 - z[i]),
+                        -(1 - xi[i]) * (1 + z[i]),
+                        -(1 + xi[i]) * (1 + z[i]),
+                        (1 + xi[i]) * (1 + z[i]),
+                        (1 - xi[i]) * (1 + z[i]),
+                    ],
+                    [
+                        -(1 - xi[i]) * (1 - eta[i]),
+                        -(1 + xi[i]) * (1 - eta[i]),
+                        -(1 + xi[i]) * (1 + eta[i]),
+                        -(1 - xi[i]) * (1 + eta[i]),
+                        (1 - xi[i]) * (1 - eta[i]),
+                        (1 + xi[i]) * (1 - eta[i]),
+                        (1 + xi[i]) * (1 + eta[i]),
+                        (1 - xi[i]) * (1 + eta[i]),
+                    ],
+                ]
+            )
+        )
+    return dNdXi
+
+
 def _J3D8(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: int):
     """Get the Jacobi matrix for a Hexa8 element.
 
@@ -324,46 +390,102 @@ def _J3D8(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: i
     np.ndarray
         The requested Jacobian matrix."""
 
+    dNdXi = _dNdXi3D8(xi, eta, z, nInt)
     J = np.zeros([nInt, 3, 3])
-    # calc all parameters for the X and Y functions (H8)
-    A = np.array(
-        [
-            [1, -1, -1, -1, 1, 1, 1, -1],
-            [1, -1, -1, 1, 1, -1, -1, 1],
-            [1, 1, -1, 1, -1, -1, 1, -1],
-            [1, 1, -1, -1, -1, 1, -1, 1],
-            [1, -1, 1, -1, -1, -1, 1, 1],
-            [1, -1, 1, 1, -1, 1, -1, -1],
-            [1, 1, 1, 1, 1, 1, 1, 1],
-            [1, 1, 1, -1, 1, -1, -1, -1],
-        ]
-    )
-    invA = np.linalg.inv(A)
-    ax = invA @ np.transpose(x[0])
-    ay = invA @ np.transpose(x[1])
-    az = invA @ np.transpose(x[2])
-    for i in range(0, nInt):  # for all Gauss points (N in total)
-        # [J] Jacobi matrix (only H8)
-        J[i] = np.array(
-            [
-                [
-                    ax[1] + ax[4] * xi[i] + ax[6] * z[i] + ax[7] * xi[i] * z[i],
-                    ay[1] + ay[4] * xi[i] + ay[6] * z[i] + ay[7] * xi[i] * z[i],
-                    az[1] + az[4] * xi[i] + az[6] * z[i] + az[7] * xi[i] * z[i],
-                ],
-                [
-                    ax[2] + ax[4] * eta[i] + ax[5] * z[i] + ax[7] * eta[i] * z[i],
-                    ay[2] + ay[4] * eta[i] + ay[5] * z[i] + ay[7] * eta[i] * z[i],
-                    az[2] + az[4] * eta[i] + az[5] * z[i] + az[7] * eta[i] * z[i],
-                ],
-                [
-                    ax[3] + ax[5] * xi[i] + ax[6] * eta[i] + ax[7] * eta[i] * xi[i],
-                    ay[3] + ay[5] * xi[i] + ay[6] * eta[i] + ay[7] * eta[i] * xi[i],
-                    az[3] + az[5] * xi[i] + az[6] * eta[i] + az[7] * eta[i] * xi[i],
-                ],
-            ]
-        )
+    for i in range(nInt):
+        J[i] = dNdXi[i] @ x.T
     return J
+
+
+def _dNdXi3D20(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, nInt: int):
+    """Get dN/dxi for a Hexa20 element (matching Marmot's node ordering, see computeNOperator).
+
+    Parameters
+    ----------
+    xi
+        Local coordinates xi for the integration points.
+    eta
+        Local coordinates eta for the integration points.
+    z
+        Local coordinates zeta for the integration points.
+    nInt
+        Number of quadrature points the element has.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(nInt, 3, 20)``: row 0/1/2 are d/dxi, d/deta, d/dzeta; columns are nodes."""
+
+    dNdXi = np.zeros([nInt, 3, 20])
+    for i in range(nInt):
+        xi_, eta_, z_ = xi[i], eta[i], z[i]
+        dNdXi[i, 0, :] = [
+            0.125 * (1 - eta_) * (1 - z_) * (1 + 2 * xi_ + eta_ + z_),
+            -0.125 * (1 - eta_) * (1 - z_) * (1 - 2 * xi_ + eta_ + z_),
+            -0.125 * (1 + eta_) * (1 - z_) * (1 - 2 * xi_ - eta_ + z_),
+            0.125 * (1 + eta_) * (1 - z_) * (1 + 2 * xi_ - eta_ + z_),
+            0.125 * (1 - eta_) * (1 + z_) * (1 + 2 * xi_ + eta_ - z_),
+            -0.125 * (1 - eta_) * (1 + z_) * (1 - 2 * xi_ + eta_ - z_),
+            -0.125 * (1 + eta_) * (1 + z_) * (1 - 2 * xi_ - eta_ - z_),
+            0.125 * (1 + eta_) * (1 + z_) * (1 + 2 * xi_ - eta_ - z_),
+            -0.5 * xi_ * (1 - eta_) * (1 - z_),
+            0.25 * (1 - eta_ * eta_) * (1 - z_),
+            -0.5 * xi_ * (1 + eta_) * (1 - z_),
+            -0.25 * (1 - eta_ * eta_) * (1 - z_),
+            -0.5 * xi_ * (1 - eta_) * (1 + z_),
+            0.25 * (1 - eta_ * eta_) * (1 + z_),
+            -0.5 * xi_ * (1 + eta_) * (1 + z_),
+            -0.25 * (1 - eta_ * eta_) * (1 + z_),
+            -0.25 * (1 - eta_) * (1 - z_ * z_),
+            0.25 * (1 - eta_) * (1 - z_ * z_),
+            0.25 * (1 + eta_) * (1 - z_ * z_),
+            -0.25 * (1 + eta_) * (1 - z_ * z_),
+        ]
+        dNdXi[i, 1, :] = [
+            0.125 * (1 - xi_) * (1 - z_) * (1 + xi_ + 2 * eta_ + z_),
+            0.125 * (1 + xi_) * (1 - z_) * (1 - xi_ + 2 * eta_ + z_),
+            -0.125 * (1 + xi_) * (1 - z_) * (1 - xi_ - 2 * eta_ + z_),
+            -0.125 * (1 - xi_) * (1 - z_) * (1 + xi_ - 2 * eta_ + z_),
+            0.125 * (1 - xi_) * (1 + z_) * (1 + xi_ + 2 * eta_ - z_),
+            0.125 * (1 + xi_) * (1 + z_) * (1 - xi_ + 2 * eta_ - z_),
+            -0.125 * (1 + xi_) * (1 + z_) * (1 - xi_ - 2 * eta_ - z_),
+            -0.125 * (1 - xi_) * (1 + z_) * (1 + xi_ - 2 * eta_ - z_),
+            -0.25 * (1 - xi_ * xi_) * (1 - z_),
+            -0.5 * eta_ * (1 + xi_) * (1 - z_),
+            0.25 * (1 - xi_ * xi_) * (1 - z_),
+            -0.5 * eta_ * (1 - xi_) * (1 - z_),
+            -0.25 * (1 - xi_ * xi_) * (1 + z_),
+            -0.5 * eta_ * (1 + xi_) * (1 + z_),
+            0.25 * (1 - xi_ * xi_) * (1 + z_),
+            -0.5 * eta_ * (1 - xi_) * (1 + z_),
+            -0.25 * (1 - xi_) * (1 - z_ * z_),
+            -0.25 * (1 + xi_) * (1 - z_ * z_),
+            0.25 * (1 + xi_) * (1 - z_ * z_),
+            0.25 * (1 - xi_) * (1 - z_ * z_),
+        ]
+        dNdXi[i, 2, :] = [
+            0.125 * (1 - xi_) * (1 - eta_) * (1 + xi_ + eta_ + 2 * z_),
+            0.125 * (1 + xi_) * (1 - eta_) * (1 - xi_ + eta_ + 2 * z_),
+            0.125 * (1 + xi_) * (1 + eta_) * (1 - xi_ - eta_ + 2 * z_),
+            0.125 * (1 - xi_) * (1 + eta_) * (1 + xi_ - eta_ + 2 * z_),
+            -0.125 * (1 - xi_) * (1 - eta_) * (1 + xi_ + eta_ - 2 * z_),
+            -0.125 * (1 + xi_) * (1 - eta_) * (1 - xi_ + eta_ - 2 * z_),
+            -0.125 * (1 + xi_) * (1 + eta_) * (1 - xi_ - eta_ - 2 * z_),
+            -0.125 * (1 - xi_) * (1 + eta_) * (1 + xi_ - eta_ - 2 * z_),
+            -0.25 * (1 - xi_ * xi_) * (1 - eta_),
+            -0.25 * (1 - eta_ * eta_) * (1 + xi_),
+            -0.25 * (1 - xi_ * xi_) * (1 + eta_),
+            -0.25 * (1 - eta_ * eta_) * (1 - xi_),
+            0.25 * (1 - xi_ * xi_) * (1 - eta_),
+            0.25 * (1 - eta_ * eta_) * (1 + xi_),
+            0.25 * (1 - xi_ * xi_) * (1 + eta_),
+            0.25 * (1 - eta_ * eta_) * (1 - xi_),
+            -0.5 * (1 - xi_) * (1 - eta_) * z_,
+            -0.5 * (1 + xi_) * (1 - eta_) * z_,
+            -0.5 * (1 + xi_) * (1 + eta_) * z_,
+            -0.5 * (1 - xi_) * (1 + eta_) * z_,
+        ]
+    return dNdXi
 
 
 def _J3D20(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: int):
@@ -387,156 +509,10 @@ def _J3D20(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: 
     np.ndarray
         The requested Jacobian matrix."""
 
+    dNdXi = _dNdXi3D20(xi, eta, z, nInt)
     J = np.zeros([nInt, 3, 3])
-    # calc all parameters for the X and Y functions (H20)
-    A = np.array(
-        [
-            [1, -1, -1, -1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1, -1, -1, -1, 1, 1, 1],
-            [1, -1, -1, 1, 1, -1, -1, 1, 1, 1, -1, -1, 1, -1, -1, 1, 1, -1, -1, 1],
-            [1, 1, -1, 1, -1, -1, 1, 1, 1, 1, -1, 1, 1, -1, 1, 1, -1, -1, 1, -1],
-            [1, 1, -1, -1, -1, 1, -1, 1, 1, 1, -1, 1, -1, -1, 1, -1, 1, 1, -1, -1],
-            [1, -1, 1, -1, -1, -1, 1, 1, 1, 1, 1, -1, -1, 1, -1, -1, 1, -1, 1, -1],
-            [1, -1, 1, 1, -1, 1, -1, 1, 1, 1, 1, -1, 1, 1, -1, 1, -1, 1, -1, -1],
-            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-            [1, 1, 1, -1, 1, -1, -1, 1, 1, 1, 1, 1, -1, 1, 1, -1, -1, -1, -1, 1],
-            [1, -1, -1, 0, 1, 0, 0, 1, 1, 0, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0],
-            [1, 0, -1, 1, 0, -1, 0, 0, 1, 1, 0, 0, 1, -1, 0, 0, 0, 0, 0, 0],
-            [1, 1, -1, 0, -1, 0, 0, 1, 1, 0, -1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-            [1, 0, -1, -1, 0, 1, 0, 0, 1, 1, 0, 0, -1, -1, 0, 0, 0, 0, 0, 0],
-            [1, -1, 1, 0, -1, 0, 0, 1, 1, 0, 1, -1, 0, 0, 0, 0, 0, 0, 0, 0],
-            [1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0],
-            [1, 1, 1, 0, 1, 0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-            [1, 0, 1, -1, 0, -1, 0, 0, 1, 1, 0, 0, -1, 1, 0, 0, 0, 0, 0, 0],
-            [1, -1, 0, -1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, -1, -1, 0, 0, 0, 0],
-            [1, -1, 0, 1, 0, 0, -1, 1, 0, 1, 0, 0, 0, 0, -1, 1, 0, 0, 0, 0],
-            [1, 1, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0],
-            [1, 1, 0, -1, 0, 0, -1, 1, 0, 1, 0, 0, 0, 0, 1, -1, 0, 0, 0, 0],
-        ]
-    )
-    invA = np.linalg.inv(A)
-    ax = invA @ np.transpose(x[0])
-    ay = invA @ np.transpose(x[1])
-    az = invA @ np.transpose(x[2])
-    for i in range(0, nInt):  # for all Gauss points (N in total)
-        # [J] Jacobi matrix (only H8)
-        J[i] = np.array(
-            [
-                [
-                    ax[1]
-                    + ax[4] * xi[i]
-                    + ax[6] * z[i]
-                    + 2 * ax[7] * eta[i]
-                    + 2 * ax[10] * eta[i] * xi[i]
-                    + ax[11] * xi[i] ** 2
-                    + ax[14] * z[i] ** 2
-                    + 2 * ax[15] * z[i] * eta[i]
-                    + ax[16] * xi[i] * z[i]
-                    + 2 * ax[17] * eta[i] * xi[i] * z[i]
-                    + ax[18] * xi[i] ** 2 * z[i]
-                    + ax[19] * xi[i] * z[i] ** 2,
-                    ay[1]
-                    + ay[4] * xi[i]
-                    + ay[6] * z[i]
-                    + 2 * ay[7] * eta[i]
-                    + 2 * ay[10] * eta[i] * xi[i]
-                    + ay[11] * xi[i] ** 2
-                    + ay[14] * z[i] ** 2
-                    + 2 * ay[15] * z[i] * eta[i]
-                    + ay[16] * xi[i] * z[i]
-                    + 2 * ay[17] * eta[i] * xi[i] * z[i]
-                    + ay[18] * xi[i] ** 2 * z[i]
-                    + ay[19] * xi[i] * z[i] ** 2,
-                    az[1]
-                    + az[4] * xi[i]
-                    + az[6] * z[i]
-                    + 2 * az[7] * eta[i]
-                    + 2 * az[10] * eta[i] * xi[i]
-                    + az[11] * xi[i] ** 2
-                    + az[14] * z[i] ** 2
-                    + 2 * az[15] * z[i] * eta[i]
-                    + az[16] * xi[i] * z[i]
-                    + 2 * az[17] * eta[i] * xi[i] * z[i]
-                    + az[18] * xi[i] ** 2 * z[i]
-                    + az[19] * xi[i] * z[i] ** 2,
-                ],
-                [
-                    ax[2]
-                    + ax[4] * eta[i]
-                    + ax[5] * z[i]
-                    + 2 * ax[8] * xi[i]
-                    + ax[10] * eta[i] ** 2
-                    + 2 * ax[11] * eta[i] * xi[i]
-                    + 2 * ax[12] * xi[i] * z[i]
-                    + ax[13] * z[i] ** 2
-                    + ax[16] * eta[i] * z[i]
-                    + ax[17] * eta[i] ** 2 * z[i]
-                    + 2 * ax[18] * eta[i] * xi[i] * z[i]
-                    + ax[19] * eta[i] * z[i] ** 2,
-                    ay[2]
-                    + ay[4] * eta[i]
-                    + ay[5] * z[i]
-                    + 2 * ay[8] * xi[i]
-                    + ay[10] * eta[i] ** 2
-                    + 2 * ay[11] * eta[i] * xi[i]
-                    + 2 * ay[12] * xi[i] * z[i]
-                    + ay[13] * z[i] ** 2
-                    + ay[16] * eta[i] * z[i]
-                    + ay[17] * eta[i] ** 2 * z[i]
-                    + 2 * ay[18] * eta[i] * xi[i] * z[i]
-                    + ay[19] * eta[i] * z[i] ** 2,
-                    az[2]
-                    + az[4] * eta[i]
-                    + az[5] * z[i]
-                    + 2 * az[8] * xi[i]
-                    + az[10] * eta[i] ** 2
-                    + 2 * az[11] * eta[i] * xi[i]
-                    + 2 * az[12] * xi[i] * z[i]
-                    + az[13] * z[i] ** 2
-                    + az[16] * eta[i] * z[i]
-                    + az[17] * eta[i] ** 2 * z[i]
-                    + 2 * az[18] * eta[i] * xi[i] * z[i]
-                    + az[19] * eta[i] * z[i] ** 2,
-                ],
-                [
-                    ax[3]
-                    + ax[5] * z[i]
-                    + ax[6] * eta[i]
-                    + 2 * ax[9] * z[i]
-                    + ax[12] * xi[i] ** 2
-                    + 2 * ax[13] * xi[i] * z[i]
-                    + 2 * ax[14] * z[i] * eta[i]
-                    + ax[15] * eta[i] ** 2
-                    + ax[16] * eta[i] * xi[i]
-                    + ax[17] * eta[i] ** 2 * xi[i]
-                    + ax[18] * eta[i] * xi[i] ** 2
-                    + 2 * ax[19] * eta[i] * xi[i] * z[i],
-                    ay[3]
-                    + ay[5] * z[i]
-                    + ay[6] * eta[i]
-                    + 2 * ay[9] * z[i]
-                    + ay[12] * xi[i] ** 2
-                    + 2 * ay[13] * xi[i] * z[i]
-                    + 2 * ay[14] * z[i] * eta[i]
-                    + ay[15] * eta[i] ** 2
-                    + ay[16] * eta[i] * xi[i]
-                    + ay[17] * eta[i] ** 2 * xi[i]
-                    + ay[18] * eta[i] * xi[i] ** 2
-                    + 2 * ay[19] * eta[i] * xi[i] * z[i],
-                    az[3]
-                    + az[5] * z[i]
-                    + az[6] * eta[i]
-                    + 2 * az[9] * z[i]
-                    + az[12] * xi[i] ** 2
-                    + 2 * az[13] * xi[i] * z[i]
-                    + 2 * az[14] * z[i] * eta[i]
-                    + az[15] * eta[i] ** 2
-                    + az[16] * eta[i] * xi[i]
-                    + az[17] * eta[i] ** 2 * xi[i]
-                    + az[18] * eta[i] * xi[i] ** 2
-                    + 2 * az[19] * eta[i] * xi[i] * z[i],
-                ],
-            ]
-        )
+    for i in range(nInt):
+        J[i] = dNdXi[i] @ x.T
     return J
 
 
@@ -676,6 +652,48 @@ def _B2D8(xi: np.ndarray, eta: np.ndarray, x: np.ndarray, nInt: int):
     return Bi
 
 
+def _B3DGeneric(dNdXi: np.ndarray, x: np.ndarray, J: np.ndarray, nInt: int, nNodes: int):
+    """Assemble the standard isoparametric strain-displacement (B) operator for a 3D solid
+    element from its dN/dxi and Jacobian, given a node-major local DOF vector
+    ``(ux1,uy1,uz1,ux2,uy2,uz2,...)``.
+
+    Parameters
+    ----------
+    dNdXi
+        Shape ``(nInt, 3, nNodes)``, as returned by :func:`_dNdXi3D8`/:func:`_dNdXi3D20`.
+    x
+        Coordinates of the element points.
+    J
+        The Jacobian matrices, shape ``(nInt, 3, 3)``.
+    nInt
+        Number of quadrature points the element has.
+    nNodes
+        Number of nodes the element has.
+
+    Returns
+    -------
+    np.ndarray
+        The B operator, shape ``(nInt, 6, 3*nNodes)``, Voigt order
+        ``(exx, eyy, ezz, gxy, gxz, gyz)``."""
+
+    Bi = np.zeros([nInt, 6, 3 * nNodes])
+    for i in range(nInt):
+        dNdX = np.linalg.inv(J[i]) @ dNdXi[i]  # (3, nNodes): row b = dN/dX_b
+        for k in range(nNodes):
+            dNkdX, dNkdY, dNkdZ = dNdX[:, k]
+            Bi[i, :, 3 * k : 3 * k + 3] = np.array(
+                [
+                    [dNkdX, 0, 0],
+                    [0, dNkdY, 0],
+                    [0, 0, dNkdZ],
+                    [dNkdY, dNkdX, 0],
+                    [dNkdZ, 0, dNkdX],
+                    [0, dNkdZ, dNkdY],
+                ]
+            )
+    return Bi
+
+
 def _B3D8(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: int):
     """Get the B operator for a linear Hexa8 element.
 
@@ -697,128 +715,13 @@ def _B3D8(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: i
     np.ndarray
         The requested B operator."""
 
-    Bi = np.zeros([nInt, 6, 24])
-    # [a] matrix that connects strain and displacement derivatives
-    a = np.array(
-        [
-            [1, 0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 1, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0, 1],
-            [0, 1, 0, 1, 0, 0, 0, 0, 0],
-            [0, 0, 1, 0, 0, 0, 1, 0, 0],
-            [0, 0, 0, 0, 0, 1, 0, 1, 0],
-        ]
-    )
+    dNdXi = _dNdXi3D8(xi, eta, z, nInt)
     J = _J3D8(xi, eta, z, x, nInt)
-    for i in range(0, nInt):  # for all Gauss points (N in total)
-        # make inverse of Jacobi
-        invJ = np.linalg.inv(J[i])
-        # [b] connects displacement derivatives (Hex8)
-        bi = np.array(
-            [
-                [invJ, np.zeros([3, 3]), np.zeros([3, 3])],
-                [np.zeros([3, 3]), invJ, np.zeros([3, 3])],
-                [np.zeros([3, 3]), np.zeros([3, 3]), invJ],
-            ]
-        )
-        # make [b] what it should actually look like
-        b = bi.transpose(0, 2, 1, 3).reshape(9, 9)
-        # [h] as a temporary matrix
-        h = (
-            1
-            / 8
-            * np.array(
-                [
-                    [
-                        -(1 - xi[i]) * (1 - z[i]),
-                        0,
-                        0,
-                        -(1 - xi[i]) * (1 + z[i]),
-                        0,
-                        0,
-                        (1 - xi[i]) * (1 + z[i]),
-                        0,
-                        0,
-                        (1 - xi[i]) * (1 - z[i]),
-                        0,
-                        0,
-                        -(1 + xi[i]) * (1 - z[i]),
-                        0,
-                        0,
-                        -(1 + xi[i]) * (1 + z[i]),
-                        0,
-                        0,
-                        (1 + xi[i]) * (1 + z[i]),
-                        0,
-                        0,
-                        (1 + xi[i]) * (1 - z[i]),
-                    ],
-                    [
-                        -(1 - eta[i]) * (1 - z[i]),
-                        0,
-                        0,
-                        -(1 - eta[i]) * (1 + z[i]),
-                        0,
-                        0,
-                        -(1 + eta[i]) * (1 + z[i]),
-                        0,
-                        0,
-                        -(1 + eta[i]) * (1 - z[i]),
-                        0,
-                        0,
-                        (1 - eta[i]) * (1 - z[i]),
-                        0,
-                        0,
-                        (1 - eta[i]) * (1 + z[i]),
-                        0,
-                        0,
-                        (1 + eta[i]) * (1 + z[i]),
-                        0,
-                        0,
-                        (1 + eta[i]) * (1 - z[i]),
-                    ],
-                    [
-                        -(1 - eta[i]) * (1 - xi[i]),
-                        0,
-                        0,
-                        (1 - eta[i]) * (1 - xi[i]),
-                        0,
-                        0,
-                        (1 + eta[i]) * (1 - xi[i]),
-                        0,
-                        0,
-                        -(1 + eta[i]) * (1 - xi[i]),
-                        0,
-                        0,
-                        -(1 - eta[i]) * (1 + xi[i]),
-                        0,
-                        0,
-                        (1 - eta[i]) * (1 + xi[i]),
-                        0,
-                        0,
-                        (1 + eta[i]) * (1 + xi[i]),
-                        0,
-                        0,
-                        -(1 + eta[i]) * (1 + xi[i]),
-                    ],
-                ]
-            )
-        )
-        # assemble [c] differentiated shapefunctions (Hexa8)
-        c = np.vstack(
-            [
-                np.hstack([h, np.zeros([3, 2])]),
-                np.hstack([np.zeros([3, 1]), h, np.zeros([3, 1])]),
-                np.hstack([np.zeros([3, 2]), h]),
-            ]
-        )
-        # [B] for all different s and t
-        Bi[i] = a @ b @ c
-    return Bi
+    return _B3DGeneric(dNdXi, x, J, nInt, 8)
 
 
 def _B3D20(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: int):
-    """Get the B operator for a linear Hexa20 element.
+    """Get the B operator for a quadratic Hexa20 element.
 
     Parameters
     ----------
@@ -838,223 +741,6 @@ def _B3D20(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: 
     np.ndarray
         The requested B operator."""
 
-    Bi = np.zeros([nInt, 6, 60])
-    # [a] matrix that connects strain and displacement derivatives
-    a = np.array(
-        [
-            [1, 0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 1, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0, 1],
-            [0, 1, 0, 1, 0, 0, 0, 0, 0],
-            [0, 0, 1, 0, 0, 0, 1, 0, 0],
-            [0, 0, 0, 0, 0, 1, 0, 1, 0],
-        ]
-    )
+    dNdXi = _dNdXi3D20(xi, eta, z, nInt)
     J = _J3D20(xi, eta, z, x, nInt)
-    for i in range(0, nInt):  # for all Gauss points (N in total)
-        # make inverse of Jacobi
-        invJ = np.linalg.inv(J[i])
-        # make [b] - connects displacement derivatives (Hexa8)
-        b = np.bmat(
-            [
-                [invJ, np.zeros([3, 3]), np.zeros([3, 3])],
-                [np.zeros([3, 3]), invJ, np.zeros([3, 3])],
-                [np.zeros([3, 3]), np.zeros([3, 3]), invJ],
-            ]
-        )
-        # [h] as a temporary matrix
-        h = np.array(
-            [
-                [
-                    ((xi[i] - 1) * (z[i] - 1) * (2 * eta[i] + xi[i] + z[i] + 1)) / 8,
-                    0,
-                    0,
-                    -((xi[i] - 1) * (z[i] + 1) * (2 * eta[i] + xi[i] - z[i] + 1)) / 8,
-                    0,
-                    0,
-                    -((xi[i] - 1) * (z[i] + 1) * (2 * eta[i] - xi[i] + z[i] - 1)) / 8,
-                    0,
-                    0,
-                    -((xi[i] - 1) * (z[i] - 1) * (xi[i] - 2 * eta[i] + z[i] + 1)) / 8,
-                    0,
-                    0,
-                    -((xi[i] + 1) * (z[i] - 1) * (2 * eta[i] - xi[i] + z[i] + 1)) / 8,
-                    0,
-                    0,
-                    ((xi[i] + 1) * (z[i] + 1) * (2 * eta[i] - xi[i] - z[i] + 1)) / 8,
-                    0,
-                    0,
-                    ((xi[i] + 1) * (z[i] + 1) * (2 * eta[i] + xi[i] + z[i] - 1)) / 8,
-                    0,
-                    0,
-                    -((xi[i] + 1) * (z[i] - 1) * (2 * eta[i] + xi[i] - z[i] - 1)) / 8,
-                    0,
-                    0,
-                    -((z[i] ** 2 - 1) * (xi[i] - 1)) / 4,
-                    0,
-                    0,
-                    (eta[i] * (xi[i] - 1) * (z[i] + 1)) / 2,
-                    0,
-                    0,
-                    ((z[i] ** 2 - 1) * (xi[i] - 1)) / 4,
-                    0,
-                    0,
-                    -(eta[i] * (xi[i] - 1) * (z[i] - 1)) / 2,
-                    0,
-                    0,
-                    ((z[i] ** 2 - 1) * (xi[i] + 1)) / 4,
-                    0,
-                    0,
-                    -(eta[i] * (xi[i] + 1) * (z[i] + 1)) / 2,
-                    0,
-                    0,
-                    -((z[i] ** 2 - 1) * (xi[i] + 1)) / 4,
-                    0,
-                    0,
-                    (eta[i] * (xi[i] + 1) * (z[i] - 1)) / 2,
-                    0,
-                    0,
-                    -((xi[i] ** 2 - 1) * (z[i] - 1)) / 4,
-                    0,
-                    0,
-                    ((xi[i] ** 2 - 1) * (z[i] + 1)) / 4,
-                    0,
-                    0,
-                    -((xi[i] ** 2 - 1) * (z[i] + 1)) / 4,
-                    0,
-                    0,
-                    ((xi[i] ** 2 - 1) * (z[i] - 1)) / 4,
-                ],
-                [
-                    ((eta[i] - 1) * (z[i] - 1) * (eta[i] + 2 * xi[i] + z[i] + 1)) / 8,
-                    0,
-                    0,
-                    -((eta[i] - 1) * (z[i] + 1) * (eta[i] + 2 * xi[i] - z[i] + 1)) / 8,
-                    0,
-                    0,
-                    -((eta[i] + 1) * (z[i] + 1) * (eta[i] - 2 * xi[i] + z[i] - 1)) / 8,
-                    0,
-                    0,
-                    -((eta[i] + 1) * (z[i] - 1) * (2 * xi[i] - eta[i] + z[i] + 1)) / 8,
-                    0,
-                    0,
-                    -((eta[i] - 1) * (z[i] - 1) * (eta[i] - 2 * xi[i] + z[i] + 1)) / 8,
-                    0,
-                    0,
-                    ((eta[i] - 1) * (z[i] + 1) * (eta[i] - 2 * xi[i] - z[i] + 1)) / 8,
-                    0,
-                    0,
-                    ((eta[i] + 1) * (z[i] + 1) * (eta[i] + 2 * xi[i] + z[i] - 1)) / 8,
-                    0,
-                    0,
-                    -((eta[i] + 1) * (z[i] - 1) * (eta[i] + 2 * xi[i] - z[i] - 1)) / 8,
-                    0,
-                    0,
-                    -(eta[i] / 4 - 1 / 4) * (z[i] ** 2 - 1),
-                    0,
-                    0,
-                    (eta[i] ** 2 / 4 - 1 / 4) * (z[i] + 1),
-                    0,
-                    0,
-                    (eta[i] / 4 + 1 / 4) * (z[i] ** 2 - 1),
-                    0,
-                    0,
-                    -(eta[i] ** 2 / 4 - 1 / 4) * (z[i] - 1),
-                    0,
-                    0,
-                    (eta[i] / 4 - 1 / 4) * (z[i] ** 2 - 1),
-                    0,
-                    0,
-                    -(eta[i] ** 2 / 4 - 1 / 4) * (z[i] + 1),
-                    0,
-                    0,
-                    -(eta[i] / 4 + 1 / 4) * (z[i] ** 2 - 1),
-                    0,
-                    0,
-                    (eta[i] ** 2 / 4 - 1 / 4) * (z[i] - 1),
-                    0,
-                    0,
-                    -2 * xi[i] * (eta[i] / 4 - 1 / 4) * (z[i] - 1),
-                    0,
-                    0,
-                    2 * xi[i] * (eta[i] / 4 - 1 / 4) * (z[i] + 1),
-                    0,
-                    0,
-                    -2 * xi[i] * (eta[i] / 4 + 1 / 4) * (z[i] + 1),
-                    0,
-                    0,
-                    2 * xi[i] * (eta[i] / 4 + 1 / 4) * (z[i] - 1),
-                ],
-                [
-                    ((eta[i] - 1) * (xi[i] - 1) * (eta[i] + xi[i] + 2 * z[i] + 1)) / 8,
-                    0,
-                    0,
-                    -((eta[i] - 1) * (xi[i] - 1) * (eta[i] + xi[i] - 2 * z[i] + 1)) / 8,
-                    0,
-                    0,
-                    -((eta[i] + 1) * (xi[i] - 1) * (eta[i] - xi[i] + 2 * z[i] - 1)) / 8,
-                    0,
-                    0,
-                    -((eta[i] + 1) * (xi[i] - 1) * (xi[i] - eta[i] + 2 * z[i] + 1)) / 8,
-                    0,
-                    0,
-                    -((eta[i] - 1) * (xi[i] + 1) * (eta[i] - xi[i] + 2 * z[i] + 1)) / 8,
-                    0,
-                    0,
-                    ((eta[i] - 1) * (xi[i] + 1) * (eta[i] - xi[i] - 2 * z[i] + 1)) / 8,
-                    0,
-                    0,
-                    ((eta[i] + 1) * (xi[i] + 1) * (eta[i] + xi[i] + 2 * z[i] - 1)) / 8,
-                    0,
-                    0,
-                    -((eta[i] + 1) * (xi[i] + 1) * (eta[i] + xi[i] - 2 * z[i] - 1)) / 8,
-                    0,
-                    0,
-                    -2 * z[i] * (eta[i] / 4 - 1 / 4) * (xi[i] - 1),
-                    0,
-                    0,
-                    (eta[i] ** 2 / 4 - 1 / 4) * (xi[i] - 1),
-                    0,
-                    0,
-                    2 * z[i] * (eta[i] / 4 + 1 / 4) * (xi[i] - 1),
-                    0,
-                    0,
-                    -(eta[i] ** 2 / 4 - 1 / 4) * (xi[i] - 1),
-                    0,
-                    0,
-                    2 * z[i] * (eta[i] / 4 - 1 / 4) * (xi[i] + 1),
-                    0,
-                    0,
-                    -(eta[i] ** 2 / 4 - 1 / 4) * (xi[i] + 1),
-                    0,
-                    0,
-                    -2 * z[i] * (eta[i] / 4 + 1 / 4) * (xi[i] + 1),
-                    0,
-                    0,
-                    (eta[i] ** 2 / 4 - 1 / 4) * (xi[i] + 1),
-                    0,
-                    0,
-                    -(eta[i] / 4 - 1 / 4) * (xi[i] ** 2 - 1),
-                    0,
-                    0,
-                    (eta[i] / 4 - 1 / 4) * (xi[i] ** 2 - 1),
-                    0,
-                    0,
-                    -(eta[i] / 4 + 1 / 4) * (xi[i] ** 2 - 1),
-                    0,
-                    0,
-                    (eta[i] / 4 + 1 / 4) * (xi[i] ** 2 - 1),
-                ],
-            ]
-        )
-        # assemble [c] differentiated shapefunctions (Hexa20)
-        c = np.vstack(
-            [
-                np.hstack([h, np.zeros([3, 2])]),
-                np.hstack([np.zeros([3, 1]), h, np.zeros([3, 1])]),
-                np.hstack([np.zeros([3, 2]), h]),
-            ]
-        )
-        # [B] for all different s and t
-        Bi[i] = a @ b @ c
-    return Bi
+    return _B3DGeneric(dNdXi, x, J, nInt, 20)

--- a/edelweissfe/elements/displacementtlelement/_elementcomputationmatrices.py
+++ b/edelweissfe/elements/displacementtlelement/_elementcomputationmatrices.py
@@ -193,6 +193,10 @@ def computeNOperator(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, nInt: int, 
                     )
                 )
     elif dim == 3:
+        # Hexa8/Hexa20 node ordering follows the standard Abaqus C3D8/C3D20 convention (corner
+        # ring 0-3 at zeta=-1, ring 4-7 at zeta=+1), matching Marmot's element formulation and
+        # the small-strain displacementelement -- see edelweissfe.generators.surfaceelementgenerator's
+        # module docstring for why this matters for contact-facet generation.
         if nNodes == 8:  # Hexa8
             for i in range(nInt):
                 N[i] = (
@@ -201,13 +205,13 @@ def computeNOperator(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, nInt: int, 
                     * np.array(
                         [
                             (1 - xi[i]) * (1 - eta[i]) * (1 - z[i]),
+                            (1 + xi[i]) * (1 - eta[i]) * (1 - z[i]),
+                            (1 + xi[i]) * (1 + eta[i]) * (1 - z[i]),
+                            (1 - xi[i]) * (1 + eta[i]) * (1 - z[i]),
                             (1 - xi[i]) * (1 - eta[i]) * (1 + z[i]),
                             (1 + xi[i]) * (1 - eta[i]) * (1 + z[i]),
-                            (1 + xi[i]) * (1 - eta[i]) * (1 - z[i]),
-                            (1 - xi[i]) * (1 + eta[i]) * (1 - z[i]),
-                            (1 - xi[i]) * (1 + eta[i]) * (1 + z[i]),
                             (1 + xi[i]) * (1 + eta[i]) * (1 + z[i]),
-                            (1 + xi[i]) * (1 + eta[i]) * (1 - z[i]),
+                            (1 - xi[i]) * (1 + eta[i]) * (1 + z[i]),
                         ]
                     )
                 )
@@ -218,26 +222,26 @@ def computeNOperator(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, nInt: int, 
                     / 8
                     * np.array(
                         [
-                            (1 - xi[i]) * (1 - eta[i]) * (1 - z[i]) * (-xi[i] - eta[i] - z[i] - 2),
-                            (1 - xi[i]) * (1 - eta[i]) * (1 + z[i]) * (-xi[i] - eta[i] + z[i] - 2),
-                            (1 + xi[i]) * (1 - eta[i]) * (1 + z[i]) * (xi[i] - eta[i] + z[i] - 2),
-                            (1 + xi[i]) * (1 - eta[i]) * (1 - z[i]) * (xi[i] - eta[i] - z[i] - 2),
-                            (1 - xi[i]) * (1 + eta[i]) * (1 - z[i]) * (-xi[i] + eta[i] - z[i] - 2),
-                            (1 - xi[i]) * (1 + eta[i]) * (1 + z[i]) * (-xi[i] + eta[i] + z[i] - 2),
-                            (1 + xi[i]) * (1 + eta[i]) * (1 + z[i]) * (xi[i] + eta[i] + z[i] - 2),
-                            (1 + xi[i]) * (1 + eta[i]) * (1 - z[i]) * (xi[i] + eta[i] - z[i] - 2),
-                            2 * (1 - xi[i]) * (1 - eta[i]) * (1 - z[i] ** 2),
-                            2 * (1 - xi[i] ** 2) * (1 - eta[i]) * (1 + z[i]),
-                            2 * (1 + xi[i]) * (1 - eta[i]) * (1 - z[i] ** 2),
+                            -(1 - xi[i]) * (1 - eta[i]) * (1 - z[i]) * (2 + xi[i] + eta[i] + z[i]),
+                            -(1 + xi[i]) * (1 - eta[i]) * (1 - z[i]) * (2 - xi[i] + eta[i] + z[i]),
+                            -(1 + xi[i]) * (1 + eta[i]) * (1 - z[i]) * (2 - xi[i] - eta[i] + z[i]),
+                            -(1 - xi[i]) * (1 + eta[i]) * (1 - z[i]) * (2 + xi[i] - eta[i] + z[i]),
+                            -(1 - xi[i]) * (1 - eta[i]) * (1 + z[i]) * (2 + xi[i] + eta[i] - z[i]),
+                            -(1 + xi[i]) * (1 - eta[i]) * (1 + z[i]) * (2 - xi[i] + eta[i] - z[i]),
+                            -(1 + xi[i]) * (1 + eta[i]) * (1 + z[i]) * (2 - xi[i] - eta[i] - z[i]),
+                            -(1 - xi[i]) * (1 + eta[i]) * (1 + z[i]) * (2 + xi[i] - eta[i] - z[i]),
                             2 * (1 - xi[i] ** 2) * (1 - eta[i]) * (1 - z[i]),
-                            2 * (1 - xi[i]) * (1 + eta[i]) * (1 - z[i] ** 2),
-                            2 * (1 - xi[i] ** 2) * (1 + eta[i]) * (1 + z[i]),
-                            2 * (1 + xi[i]) * (1 + eta[i]) * (1 - z[i] ** 2),
+                            2 * (1 - eta[i] ** 2) * (1 + xi[i]) * (1 - z[i]),
                             2 * (1 - xi[i] ** 2) * (1 + eta[i]) * (1 - z[i]),
-                            2 * (1 - xi[i]) * (1 - eta[i] ** 2) * (1 - z[i]),
-                            2 * (1 - xi[i]) * (1 - eta[i] ** 2) * (1 + z[i]),
-                            2 * (1 + xi[i]) * (1 - eta[i] ** 2) * (1 + z[i]),
-                            2 * (1 + xi[i]) * (1 - eta[i] ** 2) * (1 - z[i]),
+                            2 * (1 - eta[i] ** 2) * (1 - xi[i]) * (1 - z[i]),
+                            2 * (1 - xi[i] ** 2) * (1 - eta[i]) * (1 + z[i]),
+                            2 * (1 - eta[i] ** 2) * (1 + xi[i]) * (1 + z[i]),
+                            2 * (1 - xi[i] ** 2) * (1 + eta[i]) * (1 + z[i]),
+                            2 * (1 - eta[i] ** 2) * (1 - xi[i]) * (1 + z[i]),
+                            2 * (1 - xi[i]) * (1 - eta[i]) * (1 - z[i] ** 2),
+                            2 * (1 + xi[i]) * (1 - eta[i]) * (1 - z[i] ** 2),
+                            2 * (1 + xi[i]) * (1 + eta[i]) * (1 - z[i] ** 2),
+                            2 * (1 - xi[i]) * (1 + eta[i]) * (1 - z[i] ** 2),
                         ]
                     )
                 )
@@ -386,6 +390,7 @@ def _Ndiff3D(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, nNodes: int):
     np.ndarray
         The derivative of the 3D shape functions w.r.t. the local coordinates."""
 
+    # Node ordering matches computeNOperator (Marmot's/standard Abaqus C3D8/C3D20 convention).
     if nNodes == 8:  # Hexa8
         return (
             1
@@ -393,34 +398,34 @@ def _Ndiff3D(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, nNodes: int):
             * np.array(
                 [
                     [
-                        -(1 - xi) * (1 - z),
-                        -(1 - xi) * (1 + z),
-                        (1 - xi) * (1 + z),
-                        (1 - xi) * (1 - z),
-                        -(1 + xi) * (1 - z),
-                        -(1 + xi) * (1 + z),
-                        (1 + xi) * (1 + z),
-                        (1 + xi) * (1 - z),
-                    ],
-                    [
                         -(1 - eta) * (1 - z),
-                        -(1 - eta) * (1 + z),
-                        -(1 + eta) * (1 + z),
-                        -(1 + eta) * (1 - z),
                         (1 - eta) * (1 - z),
+                        (1 + eta) * (1 - z),
+                        -(1 + eta) * (1 - z),
+                        -(1 - eta) * (1 + z),
                         (1 - eta) * (1 + z),
                         (1 + eta) * (1 + z),
-                        (1 + eta) * (1 - z),
+                        -(1 + eta) * (1 + z),
                     ],
                     [
-                        -(1 - eta) * (1 - xi),
-                        (1 - eta) * (1 - xi),
-                        (1 + eta) * (1 - xi),
-                        -(1 + eta) * (1 - xi),
-                        -(1 - eta) * (1 + xi),
-                        (1 - eta) * (1 + xi),
-                        (1 + eta) * (1 + xi),
-                        -(1 + eta) * (1 + xi),
+                        -(1 - xi) * (1 - z),
+                        -(1 + xi) * (1 - z),
+                        (1 + xi) * (1 - z),
+                        (1 - xi) * (1 - z),
+                        -(1 - xi) * (1 + z),
+                        -(1 + xi) * (1 + z),
+                        (1 + xi) * (1 + z),
+                        (1 - xi) * (1 + z),
+                    ],
+                    [
+                        -(1 - xi) * (1 - eta),
+                        -(1 + xi) * (1 - eta),
+                        -(1 + xi) * (1 + eta),
+                        -(1 - xi) * (1 + eta),
+                        (1 - xi) * (1 - eta),
+                        (1 + xi) * (1 - eta),
+                        (1 + xi) * (1 + eta),
+                        (1 - xi) * (1 + eta),
                     ],
                 ]
             )
@@ -429,70 +434,70 @@ def _Ndiff3D(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, nNodes: int):
         return np.array(
             [
                 [
-                    ((xi - 1) * (z - 1) * (2 * eta + xi + z + 1)) / 8,
-                    -((xi - 1) * (z + 1) * (2 * eta + xi - z + 1)) / 8,
-                    -((xi - 1) * (z + 1) * (2 * eta - xi + z - 1)) / 8,
-                    -((xi - 1) * (z - 1) * (xi - 2 * eta + z + 1)) / 8,
-                    -((xi + 1) * (z - 1) * (2 * eta - xi + z + 1)) / 8,
-                    ((xi + 1) * (z + 1) * (2 * eta - xi - z + 1)) / 8,
-                    ((xi + 1) * (z + 1) * (2 * eta + xi + z - 1)) / 8,
-                    -((xi + 1) * (z - 1) * (2 * eta + xi - z - 1)) / 8,
-                    -((z**2 - 1) * (xi - 1)) / 4,
-                    (eta * (xi - 1) * (z + 1)) / 2,
-                    ((z**2 - 1) * (xi - 1)) / 4,
-                    -(eta * (xi - 1) * (z - 1)) / 2,
-                    ((z**2 - 1) * (xi + 1)) / 4,
-                    -(eta * (xi + 1) * (z + 1)) / 2,
-                    -((z**2 - 1) * (xi + 1)) / 4,
-                    (eta * (xi + 1) * (z - 1)) / 2,
-                    -((xi**2 - 1) * (z - 1)) / 4,
-                    ((xi**2 - 1) * (z + 1)) / 4,
-                    -((xi**2 - 1) * (z + 1)) / 4,
-                    ((xi**2 - 1) * (z - 1)) / 4,
+                    0.125 * (1 - eta) * (1 - z) * (1 + 2 * xi + eta + z),
+                    -0.125 * (1 - eta) * (1 - z) * (1 - 2 * xi + eta + z),
+                    -0.125 * (1 + eta) * (1 - z) * (1 - 2 * xi - eta + z),
+                    0.125 * (1 + eta) * (1 - z) * (1 + 2 * xi - eta + z),
+                    0.125 * (1 - eta) * (1 + z) * (1 + 2 * xi + eta - z),
+                    -0.125 * (1 - eta) * (1 + z) * (1 - 2 * xi + eta - z),
+                    -0.125 * (1 + eta) * (1 + z) * (1 - 2 * xi - eta - z),
+                    0.125 * (1 + eta) * (1 + z) * (1 + 2 * xi - eta - z),
+                    -0.5 * xi * (1 - eta) * (1 - z),
+                    0.25 * (1 - eta * eta) * (1 - z),
+                    -0.5 * xi * (1 + eta) * (1 - z),
+                    -0.25 * (1 - eta * eta) * (1 - z),
+                    -0.5 * xi * (1 - eta) * (1 + z),
+                    0.25 * (1 - eta * eta) * (1 + z),
+                    -0.5 * xi * (1 + eta) * (1 + z),
+                    -0.25 * (1 - eta * eta) * (1 + z),
+                    -0.25 * (1 - eta) * (1 - z * z),
+                    0.25 * (1 - eta) * (1 - z * z),
+                    0.25 * (1 + eta) * (1 - z * z),
+                    -0.25 * (1 + eta) * (1 - z * z),
                 ],
                 [
-                    ((eta - 1) * (z - 1) * (eta + 2 * xi + z + 1)) / 8,
-                    -((eta - 1) * (z + 1) * (eta + 2 * xi - z + 1)) / 8,
-                    -((eta + 1) * (z + 1) * (eta - 2 * xi + z - 1)) / 8,
-                    -((eta + 1) * (z - 1) * (2 * xi - eta + z + 1)) / 8,
-                    -((eta - 1) * (z - 1) * (eta - 2 * xi + z + 1)) / 8,
-                    ((eta - 1) * (z + 1) * (eta - 2 * xi - z + 1)) / 8,
-                    ((eta + 1) * (z + 1) * (eta + 2 * xi + z - 1)) / 8,
-                    -((eta + 1) * (z - 1) * (eta + 2 * xi - z - 1)) / 8,
-                    -(eta / 4 - 1 / 4) * (z**2 - 1),
-                    (eta**2 / 4 - 1 / 4) * (z + 1),
-                    (eta / 4 + 1 / 4) * (z**2 - 1),
-                    -(eta**2 / 4 - 1 / 4) * (z - 1),
-                    (eta / 4 - 1 / 4) * (z**2 - 1),
-                    -(eta**2 / 4 - 1 / 4) * (z + 1),
-                    -(eta / 4 + 1 / 4) * (z**2 - 1),
-                    (eta**2 / 4 - 1 / 4) * (z - 1),
-                    -2 * xi * (eta / 4 - 1 / 4) * (z - 1),
-                    2 * xi * (eta / 4 - 1 / 4) * (z + 1),
-                    -2 * xi * (eta / 4 + 1 / 4) * (z + 1),
-                    2 * xi * (eta / 4 + 1 / 4) * (z - 1),
+                    0.125 * (1 - xi) * (1 - z) * (1 + xi + 2 * eta + z),
+                    0.125 * (1 + xi) * (1 - z) * (1 - xi + 2 * eta + z),
+                    -0.125 * (1 + xi) * (1 - z) * (1 - xi - 2 * eta + z),
+                    -0.125 * (1 - xi) * (1 - z) * (1 + xi - 2 * eta + z),
+                    0.125 * (1 - xi) * (1 + z) * (1 + xi + 2 * eta - z),
+                    0.125 * (1 + xi) * (1 + z) * (1 - xi + 2 * eta - z),
+                    -0.125 * (1 + xi) * (1 + z) * (1 - xi - 2 * eta - z),
+                    -0.125 * (1 - xi) * (1 + z) * (1 + xi - 2 * eta - z),
+                    -0.25 * (1 - xi * xi) * (1 - z),
+                    -0.5 * eta * (1 + xi) * (1 - z),
+                    0.25 * (1 - xi * xi) * (1 - z),
+                    -0.5 * eta * (1 - xi) * (1 - z),
+                    -0.25 * (1 - xi * xi) * (1 + z),
+                    -0.5 * eta * (1 + xi) * (1 + z),
+                    0.25 * (1 - xi * xi) * (1 + z),
+                    -0.5 * eta * (1 - xi) * (1 + z),
+                    -0.25 * (1 - xi) * (1 - z * z),
+                    -0.25 * (1 + xi) * (1 - z * z),
+                    0.25 * (1 + xi) * (1 - z * z),
+                    0.25 * (1 - xi) * (1 - z * z),
                 ],
                 [
-                    ((eta - 1) * (xi - 1) * (eta + xi + 2 * z + 1)) / 8,
-                    -((eta - 1) * (xi - 1) * (eta + xi - 2 * z + 1)) / 8,
-                    -((eta + 1) * (xi - 1) * (eta - xi + 2 * z - 1)) / 8,
-                    -((eta + 1) * (xi - 1) * (xi - eta + 2 * z + 1)) / 8,
-                    -((eta - 1) * (xi + 1) * (eta - xi + 2 * z + 1)) / 8,
-                    ((eta - 1) * (xi + 1) * (eta - xi - 2 * z + 1)) / 8,
-                    ((eta + 1) * (xi + 1) * (eta + xi + 2 * z - 1)) / 8,
-                    -((eta + 1) * (xi + 1) * (eta + xi - 2 * z - 1)) / 8,
-                    -2 * z * (eta / 4 - 1 / 4) * (xi - 1),
-                    (eta**2 / 4 - 1 / 4) * (xi - 1),
-                    2 * z * (eta / 4 + 1 / 4) * (xi - 1),
-                    -(eta**2 / 4 - 1 / 4) * (xi - 1),
-                    2 * z * (eta / 4 - 1 / 4) * (xi + 1),
-                    -(eta**2 / 4 - 1 / 4) * (xi + 1),
-                    -2 * z * (eta / 4 + 1 / 4) * (xi + 1),
-                    (eta**2 / 4 - 1 / 4) * (xi + 1),
-                    -(eta / 4 - 1 / 4) * (xi**2 - 1),
-                    (eta / 4 - 1 / 4) * (xi**2 - 1),
-                    -(eta / 4 + 1 / 4) * (xi**2 - 1),
-                    (eta / 4 + 1 / 4) * (xi**2 - 1),
+                    0.125 * (1 - xi) * (1 - eta) * (1 + xi + eta + 2 * z),
+                    0.125 * (1 + xi) * (1 - eta) * (1 - xi + eta + 2 * z),
+                    0.125 * (1 + xi) * (1 + eta) * (1 - xi - eta + 2 * z),
+                    0.125 * (1 - xi) * (1 + eta) * (1 + xi - eta + 2 * z),
+                    -0.125 * (1 - xi) * (1 - eta) * (1 + xi + eta - 2 * z),
+                    -0.125 * (1 + xi) * (1 - eta) * (1 - xi + eta - 2 * z),
+                    -0.125 * (1 + xi) * (1 + eta) * (1 - xi - eta - 2 * z),
+                    -0.125 * (1 - xi) * (1 + eta) * (1 + xi - eta - 2 * z),
+                    -0.25 * (1 - xi * xi) * (1 - eta),
+                    -0.25 * (1 - eta * eta) * (1 + xi),
+                    -0.25 * (1 - xi * xi) * (1 + eta),
+                    -0.25 * (1 - eta * eta) * (1 - xi),
+                    0.25 * (1 - xi * xi) * (1 - eta),
+                    0.25 * (1 - eta * eta) * (1 + xi),
+                    0.25 * (1 - xi * xi) * (1 + eta),
+                    0.25 * (1 - eta * eta) * (1 - xi),
+                    -0.5 * (1 - xi) * (1 - eta) * z,
+                    -0.5 * (1 + xi) * (1 - eta) * z,
+                    -0.5 * (1 + xi) * (1 + eta) * z,
+                    -0.5 * (1 - xi) * (1 + eta) * z,
                 ],
             ]
         )
@@ -611,44 +616,9 @@ def _J3D8(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: i
         The requested Jacobian matrix."""
 
     J = np.zeros([nInt, 3, 3])
-    # calc all parameters for the X and Y functions (H8)
-    A = np.array(
-        [
-            [1, -1, -1, -1, 1, 1, 1, -1],
-            [1, -1, -1, 1, 1, -1, -1, 1],
-            [1, 1, -1, 1, -1, -1, 1, -1],
-            [1, 1, -1, -1, -1, 1, -1, 1],
-            [1, -1, 1, -1, -1, -1, 1, 1],
-            [1, -1, 1, 1, -1, 1, -1, -1],
-            [1, 1, 1, 1, 1, 1, 1, 1],
-            [1, 1, 1, -1, 1, -1, -1, -1],
-        ]
-    )
-    invA = lin.solve(A, np.eye(8))
-    ax = invA @ np.transpose(x[0])
-    ay = invA @ np.transpose(x[1])
-    az = invA @ np.transpose(x[2])
-    for i in range(0, nInt):  # for all Gauss points (N in total)
-        # [J] Jacobi matrix (only H8)
-        J[i] = np.array(
-            [
-                [
-                    ax[1] + ax[4] * xi[i] + ax[6] * z[i] + ax[7] * xi[i] * z[i],
-                    ay[1] + ay[4] * xi[i] + ay[6] * z[i] + ay[7] * xi[i] * z[i],
-                    az[1] + az[4] * xi[i] + az[6] * z[i] + az[7] * xi[i] * z[i],
-                ],
-                [
-                    ax[2] + ax[4] * eta[i] + ax[5] * z[i] + ax[7] * eta[i] * z[i],
-                    ay[2] + ay[4] * eta[i] + ay[5] * z[i] + ay[7] * eta[i] * z[i],
-                    az[2] + az[4] * eta[i] + az[5] * z[i] + az[7] * eta[i] * z[i],
-                ],
-                [
-                    ax[3] + ax[5] * xi[i] + ax[6] * eta[i] + ax[7] * eta[i] * xi[i],
-                    ay[3] + ay[5] * xi[i] + ay[6] * eta[i] + ay[7] * eta[i] * xi[i],
-                    az[3] + az[5] * xi[i] + az[6] * eta[i] + az[7] * eta[i] * xi[i],
-                ],
-            ]
-        )
+    for i in range(nInt):
+        dN = _Ndiff3D(xi[i], eta[i], z[i], 8)
+        J[i] = dN @ x.T
     return J
 
 
@@ -674,155 +644,9 @@ def _J3D20(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: 
         The requested Jacobian matrix."""
 
     J = np.zeros([nInt, 3, 3])
-    # calc all parameters for the X and Y functions (H20)
-    A = np.array(
-        [
-            [1, -1, -1, -1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1, -1, -1, -1, 1, 1, 1],
-            [1, -1, -1, 1, 1, -1, -1, 1, 1, 1, -1, -1, 1, -1, -1, 1, 1, -1, -1, 1],
-            [1, 1, -1, 1, -1, -1, 1, 1, 1, 1, -1, 1, 1, -1, 1, 1, -1, -1, 1, -1],
-            [1, 1, -1, -1, -1, 1, -1, 1, 1, 1, -1, 1, -1, -1, 1, -1, 1, 1, -1, -1],
-            [1, -1, 1, -1, -1, -1, 1, 1, 1, 1, 1, -1, -1, 1, -1, -1, 1, -1, 1, -1],
-            [1, -1, 1, 1, -1, 1, -1, 1, 1, 1, 1, -1, 1, 1, -1, 1, -1, 1, -1, -1],
-            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-            [1, 1, 1, -1, 1, -1, -1, 1, 1, 1, 1, 1, -1, 1, 1, -1, -1, -1, -1, 1],
-            [1, -1, -1, 0, 1, 0, 0, 1, 1, 0, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0],
-            [1, 0, -1, 1, 0, -1, 0, 0, 1, 1, 0, 0, 1, -1, 0, 0, 0, 0, 0, 0],
-            [1, 1, -1, 0, -1, 0, 0, 1, 1, 0, -1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-            [1, 0, -1, -1, 0, 1, 0, 0, 1, 1, 0, 0, -1, -1, 0, 0, 0, 0, 0, 0],
-            [1, -1, 1, 0, -1, 0, 0, 1, 1, 0, 1, -1, 0, 0, 0, 0, 0, 0, 0, 0],
-            [1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0],
-            [1, 1, 1, 0, 1, 0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-            [1, 0, 1, -1, 0, -1, 0, 0, 1, 1, 0, 0, -1, 1, 0, 0, 0, 0, 0, 0],
-            [1, -1, 0, -1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, -1, -1, 0, 0, 0, 0],
-            [1, -1, 0, 1, 0, 0, -1, 1, 0, 1, 0, 0, 0, 0, -1, 1, 0, 0, 0, 0],
-            [1, 1, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0],
-            [1, 1, 0, -1, 0, 0, -1, 1, 0, 1, 0, 0, 0, 0, 1, -1, 0, 0, 0, 0],
-        ]
-    )
-    invA = lin.solve(A, np.eye(20))
-    ax = invA @ np.transpose(x[0])
-    ay = invA @ np.transpose(x[1])
-    az = invA @ np.transpose(x[2])
-    for i in range(0, nInt):  # for all Gauss points (N in total)
-        # [J] Jacobi matrix (only H8)
-        J[i] = np.array(
-            [
-                [
-                    ax[1]
-                    + ax[4] * xi[i]
-                    + ax[6] * z[i]
-                    + 2 * ax[7] * eta[i]
-                    + 2 * ax[10] * eta[i] * xi[i]
-                    + ax[11] * xi[i] ** 2
-                    + ax[14] * z[i] ** 2
-                    + 2 * ax[15] * z[i] * eta[i]
-                    + ax[16] * xi[i] * z[i]
-                    + 2 * ax[17] * eta[i] * xi[i] * z[i]
-                    + ax[18] * xi[i] ** 2 * z[i]
-                    + ax[19] * xi[i] * z[i] ** 2,
-                    ay[1]
-                    + ay[4] * xi[i]
-                    + ay[6] * z[i]
-                    + 2 * ay[7] * eta[i]
-                    + 2 * ay[10] * eta[i] * xi[i]
-                    + ay[11] * xi[i] ** 2
-                    + ay[14] * z[i] ** 2
-                    + 2 * ay[15] * z[i] * eta[i]
-                    + ay[16] * xi[i] * z[i]
-                    + 2 * ay[17] * eta[i] * xi[i] * z[i]
-                    + ay[18] * xi[i] ** 2 * z[i]
-                    + ay[19] * xi[i] * z[i] ** 2,
-                    az[1]
-                    + az[4] * xi[i]
-                    + az[6] * z[i]
-                    + 2 * az[7] * eta[i]
-                    + 2 * az[10] * eta[i] * xi[i]
-                    + az[11] * xi[i] ** 2
-                    + az[14] * z[i] ** 2
-                    + 2 * az[15] * z[i] * eta[i]
-                    + az[16] * xi[i] * z[i]
-                    + 2 * az[17] * eta[i] * xi[i] * z[i]
-                    + az[18] * xi[i] ** 2 * z[i]
-                    + az[19] * xi[i] * z[i] ** 2,
-                ],
-                [
-                    ax[2]
-                    + ax[4] * eta[i]
-                    + ax[5] * z[i]
-                    + 2 * ax[8] * xi[i]
-                    + ax[10] * eta[i] ** 2
-                    + 2 * ax[11] * eta[i] * xi[i]
-                    + 2 * ax[12] * xi[i] * z[i]
-                    + ax[13] * z[i] ** 2
-                    + ax[16] * eta[i] * z[i]
-                    + ax[17] * eta[i] ** 2 * z[i]
-                    + 2 * ax[18] * eta[i] * xi[i] * z[i]
-                    + ax[19] * eta[i] * z[i] ** 2,
-                    ay[2]
-                    + ay[4] * eta[i]
-                    + ay[5] * z[i]
-                    + 2 * ay[8] * xi[i]
-                    + ay[10] * eta[i] ** 2
-                    + 2 * ay[11] * eta[i] * xi[i]
-                    + 2 * ay[12] * xi[i] * z[i]
-                    + ay[13] * z[i] ** 2
-                    + ay[16] * eta[i] * z[i]
-                    + ay[17] * eta[i] ** 2 * z[i]
-                    + 2 * ay[18] * eta[i] * xi[i] * z[i]
-                    + ay[19] * eta[i] * z[i] ** 2,
-                    az[2]
-                    + az[4] * eta[i]
-                    + az[5] * z[i]
-                    + 2 * az[8] * xi[i]
-                    + az[10] * eta[i] ** 2
-                    + 2 * az[11] * eta[i] * xi[i]
-                    + 2 * az[12] * xi[i] * z[i]
-                    + az[13] * z[i] ** 2
-                    + az[16] * eta[i] * z[i]
-                    + az[17] * eta[i] ** 2 * z[i]
-                    + 2 * az[18] * eta[i] * xi[i] * z[i]
-                    + az[19] * eta[i] * z[i] ** 2,
-                ],
-                [
-                    ax[3]
-                    + ax[5] * z[i]
-                    + ax[6] * eta[i]
-                    + 2 * ax[9] * z[i]
-                    + ax[12] * xi[i] ** 2
-                    + 2 * ax[13] * xi[i] * z[i]
-                    + 2 * ax[14] * z[i] * eta[i]
-                    + ax[15] * eta[i] ** 2
-                    + ax[16] * eta[i] * xi[i]
-                    + ax[17] * eta[i] ** 2 * xi[i]
-                    + ax[18] * eta[i] * xi[i] ** 2
-                    + 2 * ax[19] * eta[i] * xi[i] * z[i],
-                    ay[3]
-                    + ay[5] * z[i]
-                    + ay[6] * eta[i]
-                    + 2 * ay[9] * z[i]
-                    + ay[12] * xi[i] ** 2
-                    + 2 * ay[13] * xi[i] * z[i]
-                    + 2 * ay[14] * z[i] * eta[i]
-                    + ay[15] * eta[i] ** 2
-                    + ay[16] * eta[i] * xi[i]
-                    + ay[17] * eta[i] ** 2 * xi[i]
-                    + ay[18] * eta[i] * xi[i] ** 2
-                    + 2 * ay[19] * eta[i] * xi[i] * z[i],
-                    az[3]
-                    + az[5] * z[i]
-                    + az[6] * eta[i]
-                    + 2 * az[9] * z[i]
-                    + az[12] * xi[i] ** 2
-                    + 2 * az[13] * xi[i] * z[i]
-                    + 2 * az[14] * z[i] * eta[i]
-                    + az[15] * eta[i] ** 2
-                    + az[16] * eta[i] * xi[i]
-                    + az[17] * eta[i] ** 2 * xi[i]
-                    + az[18] * eta[i] * xi[i] ** 2
-                    + 2 * az[19] * eta[i] * xi[i] * z[i],
-                ],
-            ]
-        )
+    for i in range(nInt):
+        dN = _Ndiff3D(xi[i], eta[i], z[i], 20)
+        J[i] = dN @ x.T
     return J
 
 

--- a/edelweissfe/elements/displacementtlelement/_elementcomputationmatrices.py
+++ b/edelweissfe/elements/displacementtlelement/_elementcomputationmatrices.py
@@ -29,6 +29,13 @@
 import numpy as np
 import numpy.linalg as lin
 
+from edelweissfe.elements._hexa3dnodeordering import (
+    hexa8DNdXi,
+    hexa8N,
+    hexa20DNdXi,
+    hexa20N,
+)
+
 
 def computeJacobian(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, x: np.ndarray, nInt: int, nNodes: int, dim: int):
     """Get the Jacobi matrix for the element calculation.
@@ -193,58 +200,17 @@ def computeNOperator(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, nInt: int, 
                     )
                 )
     elif dim == 3:
-        # Hexa8/Hexa20 node ordering follows the standard Abaqus C3D8/C3D20 convention (corner
-        # ring 0-3 at zeta=-1, ring 4-7 at zeta=+1), matching Marmot's element formulation and
-        # the small-strain displacementelement -- see edelweissfe.generators.surfaceelementgenerator's
-        # module docstring for why this matters for contact-facet generation.
+        # Hexa8/Hexa20 node ordering (see edelweissfe.elements._hexa3dnodeordering) follows the
+        # standard Abaqus C3D8/C3D20 convention (corner ring 0-3 at zeta=-1, ring 4-7 at zeta=+1),
+        # matching Marmot's element formulation and the small-strain displacementelement -- this
+        # is also the local node ordering assumed by any face-numbering convention (e.g. a
+        # contact-facet generator) built on top of this element.
         if nNodes == 8:  # Hexa8
             for i in range(nInt):
-                N[i] = (
-                    1
-                    / 8
-                    * np.array(
-                        [
-                            (1 - xi[i]) * (1 - eta[i]) * (1 - z[i]),
-                            (1 + xi[i]) * (1 - eta[i]) * (1 - z[i]),
-                            (1 + xi[i]) * (1 + eta[i]) * (1 - z[i]),
-                            (1 - xi[i]) * (1 + eta[i]) * (1 - z[i]),
-                            (1 - xi[i]) * (1 - eta[i]) * (1 + z[i]),
-                            (1 + xi[i]) * (1 - eta[i]) * (1 + z[i]),
-                            (1 + xi[i]) * (1 + eta[i]) * (1 + z[i]),
-                            (1 - xi[i]) * (1 + eta[i]) * (1 + z[i]),
-                        ]
-                    )
-                )
+                N[i] = hexa8N(xi[i], eta[i], z[i])
         elif nNodes == 20:  # Hexa20
             for i in range(nInt):
-                N[i] = (
-                    1
-                    / 8
-                    * np.array(
-                        [
-                            -(1 - xi[i]) * (1 - eta[i]) * (1 - z[i]) * (2 + xi[i] + eta[i] + z[i]),
-                            -(1 + xi[i]) * (1 - eta[i]) * (1 - z[i]) * (2 - xi[i] + eta[i] + z[i]),
-                            -(1 + xi[i]) * (1 + eta[i]) * (1 - z[i]) * (2 - xi[i] - eta[i] + z[i]),
-                            -(1 - xi[i]) * (1 + eta[i]) * (1 - z[i]) * (2 + xi[i] - eta[i] + z[i]),
-                            -(1 - xi[i]) * (1 - eta[i]) * (1 + z[i]) * (2 + xi[i] + eta[i] - z[i]),
-                            -(1 + xi[i]) * (1 - eta[i]) * (1 + z[i]) * (2 - xi[i] + eta[i] - z[i]),
-                            -(1 + xi[i]) * (1 + eta[i]) * (1 + z[i]) * (2 - xi[i] - eta[i] - z[i]),
-                            -(1 - xi[i]) * (1 + eta[i]) * (1 + z[i]) * (2 + xi[i] - eta[i] - z[i]),
-                            2 * (1 - xi[i] ** 2) * (1 - eta[i]) * (1 - z[i]),
-                            2 * (1 - eta[i] ** 2) * (1 + xi[i]) * (1 - z[i]),
-                            2 * (1 - xi[i] ** 2) * (1 + eta[i]) * (1 - z[i]),
-                            2 * (1 - eta[i] ** 2) * (1 - xi[i]) * (1 - z[i]),
-                            2 * (1 - xi[i] ** 2) * (1 - eta[i]) * (1 + z[i]),
-                            2 * (1 - eta[i] ** 2) * (1 + xi[i]) * (1 + z[i]),
-                            2 * (1 - xi[i] ** 2) * (1 + eta[i]) * (1 + z[i]),
-                            2 * (1 - eta[i] ** 2) * (1 - xi[i]) * (1 + z[i]),
-                            2 * (1 - xi[i]) * (1 - eta[i]) * (1 - z[i] ** 2),
-                            2 * (1 + xi[i]) * (1 - eta[i]) * (1 - z[i] ** 2),
-                            2 * (1 + xi[i]) * (1 + eta[i]) * (1 - z[i] ** 2),
-                            2 * (1 - xi[i]) * (1 + eta[i]) * (1 - z[i] ** 2),
-                        ]
-                    )
-                )
+                N[i] = hexa20N(xi[i], eta[i], z[i])
     return N
 
 
@@ -392,115 +358,9 @@ def _Ndiff3D(xi: np.ndarray, eta: np.ndarray, z: np.ndarray, nNodes: int):
 
     # Node ordering matches computeNOperator (Marmot's/standard Abaqus C3D8/C3D20 convention).
     if nNodes == 8:  # Hexa8
-        return (
-            1
-            / 8
-            * np.array(
-                [
-                    [
-                        -(1 - eta) * (1 - z),
-                        (1 - eta) * (1 - z),
-                        (1 + eta) * (1 - z),
-                        -(1 + eta) * (1 - z),
-                        -(1 - eta) * (1 + z),
-                        (1 - eta) * (1 + z),
-                        (1 + eta) * (1 + z),
-                        -(1 + eta) * (1 + z),
-                    ],
-                    [
-                        -(1 - xi) * (1 - z),
-                        -(1 + xi) * (1 - z),
-                        (1 + xi) * (1 - z),
-                        (1 - xi) * (1 - z),
-                        -(1 - xi) * (1 + z),
-                        -(1 + xi) * (1 + z),
-                        (1 + xi) * (1 + z),
-                        (1 - xi) * (1 + z),
-                    ],
-                    [
-                        -(1 - xi) * (1 - eta),
-                        -(1 + xi) * (1 - eta),
-                        -(1 + xi) * (1 + eta),
-                        -(1 - xi) * (1 + eta),
-                        (1 - xi) * (1 - eta),
-                        (1 + xi) * (1 - eta),
-                        (1 + xi) * (1 + eta),
-                        (1 - xi) * (1 + eta),
-                    ],
-                ]
-            )
-        )
+        return hexa8DNdXi(xi, eta, z)
     else:  # Hexa20
-        return np.array(
-            [
-                [
-                    0.125 * (1 - eta) * (1 - z) * (1 + 2 * xi + eta + z),
-                    -0.125 * (1 - eta) * (1 - z) * (1 - 2 * xi + eta + z),
-                    -0.125 * (1 + eta) * (1 - z) * (1 - 2 * xi - eta + z),
-                    0.125 * (1 + eta) * (1 - z) * (1 + 2 * xi - eta + z),
-                    0.125 * (1 - eta) * (1 + z) * (1 + 2 * xi + eta - z),
-                    -0.125 * (1 - eta) * (1 + z) * (1 - 2 * xi + eta - z),
-                    -0.125 * (1 + eta) * (1 + z) * (1 - 2 * xi - eta - z),
-                    0.125 * (1 + eta) * (1 + z) * (1 + 2 * xi - eta - z),
-                    -0.5 * xi * (1 - eta) * (1 - z),
-                    0.25 * (1 - eta * eta) * (1 - z),
-                    -0.5 * xi * (1 + eta) * (1 - z),
-                    -0.25 * (1 - eta * eta) * (1 - z),
-                    -0.5 * xi * (1 - eta) * (1 + z),
-                    0.25 * (1 - eta * eta) * (1 + z),
-                    -0.5 * xi * (1 + eta) * (1 + z),
-                    -0.25 * (1 - eta * eta) * (1 + z),
-                    -0.25 * (1 - eta) * (1 - z * z),
-                    0.25 * (1 - eta) * (1 - z * z),
-                    0.25 * (1 + eta) * (1 - z * z),
-                    -0.25 * (1 + eta) * (1 - z * z),
-                ],
-                [
-                    0.125 * (1 - xi) * (1 - z) * (1 + xi + 2 * eta + z),
-                    0.125 * (1 + xi) * (1 - z) * (1 - xi + 2 * eta + z),
-                    -0.125 * (1 + xi) * (1 - z) * (1 - xi - 2 * eta + z),
-                    -0.125 * (1 - xi) * (1 - z) * (1 + xi - 2 * eta + z),
-                    0.125 * (1 - xi) * (1 + z) * (1 + xi + 2 * eta - z),
-                    0.125 * (1 + xi) * (1 + z) * (1 - xi + 2 * eta - z),
-                    -0.125 * (1 + xi) * (1 + z) * (1 - xi - 2 * eta - z),
-                    -0.125 * (1 - xi) * (1 + z) * (1 + xi - 2 * eta - z),
-                    -0.25 * (1 - xi * xi) * (1 - z),
-                    -0.5 * eta * (1 + xi) * (1 - z),
-                    0.25 * (1 - xi * xi) * (1 - z),
-                    -0.5 * eta * (1 - xi) * (1 - z),
-                    -0.25 * (1 - xi * xi) * (1 + z),
-                    -0.5 * eta * (1 + xi) * (1 + z),
-                    0.25 * (1 - xi * xi) * (1 + z),
-                    -0.5 * eta * (1 - xi) * (1 + z),
-                    -0.25 * (1 - xi) * (1 - z * z),
-                    -0.25 * (1 + xi) * (1 - z * z),
-                    0.25 * (1 + xi) * (1 - z * z),
-                    0.25 * (1 - xi) * (1 - z * z),
-                ],
-                [
-                    0.125 * (1 - xi) * (1 - eta) * (1 + xi + eta + 2 * z),
-                    0.125 * (1 + xi) * (1 - eta) * (1 - xi + eta + 2 * z),
-                    0.125 * (1 + xi) * (1 + eta) * (1 - xi - eta + 2 * z),
-                    0.125 * (1 - xi) * (1 + eta) * (1 + xi - eta + 2 * z),
-                    -0.125 * (1 - xi) * (1 - eta) * (1 + xi + eta - 2 * z),
-                    -0.125 * (1 + xi) * (1 - eta) * (1 - xi + eta - 2 * z),
-                    -0.125 * (1 + xi) * (1 + eta) * (1 - xi - eta - 2 * z),
-                    -0.125 * (1 - xi) * (1 + eta) * (1 + xi - eta - 2 * z),
-                    -0.25 * (1 - xi * xi) * (1 - eta),
-                    -0.25 * (1 - eta * eta) * (1 + xi),
-                    -0.25 * (1 - xi * xi) * (1 + eta),
-                    -0.25 * (1 - eta * eta) * (1 - xi),
-                    0.25 * (1 - xi * xi) * (1 - eta),
-                    0.25 * (1 - eta * eta) * (1 + xi),
-                    0.25 * (1 - xi * xi) * (1 + eta),
-                    0.25 * (1 - eta * eta) * (1 - xi),
-                    -0.5 * (1 - xi) * (1 - eta) * z,
-                    -0.5 * (1 + xi) * (1 - eta) * z,
-                    -0.5 * (1 + xi) * (1 + eta) * z,
-                    -0.5 * (1 - xi) * (1 + eta) * z,
-                ],
-            ]
-        )
+        return hexa20DNdXi(xi, eta, z)
 
 
 def _J2D4(xi: np.ndarray, eta: np.ndarray, x: np.ndarray, nInt: int):


### PR DESCRIPTION
## Summary

The pure-Python `Hexa8`/`Hexa20` elements (`displacementelement` and `displacementtlelement`) used
a local node ordering that split the two corner rings by the second natural coordinate (eta),
differing from Marmot's genuine Abaqus C3D8/C3D20 convention (rings split by zeta). Both
conventions were internally self-consistent on their own, but this meant the framework had two
silently-different node orderings for the same nominal element type ("hexa8") depending on which
provider backed it -- confirmed directly against Marmot's C++ shape functions
(`MarmotFiniteElementCore/src/MarmotFiniteElement3D.cpp`).

This surfaced while investigating a `surfaceElementGenerator` face-numbering review finding on
#57 (contact-facet generation) -- the actual defect turned out to be one level deeper, in the
element formulation itself, not just the facet-generator's face-number lookup.

## What changed

- `computeNOperator` and the Jacobian/B-operator machinery for `Hexa8`/`Hexa20` (both
  `displacementelement` and `displacementtlelement`) now use Marmot's node ordering.
- The old Jacobian/B-operator code hardcoded a full closed-form polynomial per node order
  (duplicated across `_J3D8`, `_B3D8`, `_J3D20`, `_B3D20`, and again in the TL variant) -- this is
  exactly the kind of silent-drift risk that caused the mismatch in the first place. Replaced with
  a single, shared dN/dxi-based generic isoparametric construction, so the node ordering only needs
  to be correct in one place (`computeNOperator`/the dNdXi helper) going forward.

## What did *not* need to change (verified, not assumed)

- `boxGen`/`pipeGen`'s own node-generation loops -- confirmed numerically that Marmot's real shape
  functions, applied directly to boxgen's *unchanged* connectivity, give a valid, positive-Jacobian
  element (the two conventions are related by a consistent, orientation-preserving axis
  permutation). boxGen's own face-number registration (1=Ymin, 2=Ymax, 3=Xmin, 4=Zmax, 5=Xmax,
  6=Zmin) also already matches Marmot's own face IDs exactly.
- The one hand-written hex mesh in the test suite (`CantileverBeamHexa8/test.inp`+`mesh.inp`, 160
  explicit `C3D8` elements) -- checked the same way, needs no reordering.

## Verification

- Patch tests: constant strain field correctly reproduced by the new B-operator on a skewed
  (non-cubic) hexahedron, both `Hexa8` and `Hexa20`.
- Full `testfiles/edelweiss-only/` suite: 0 failures (results are physically identical to before,
  as expected for a pure internal relabeling on boxgen/pipegen-generated meshes).

## Related

- Closes/supersedes [#82](https://github.com/Edelweiss-Numerics/EdelweissFE/issues/82).
- #57 cherry-picks this commit and re-derives its own `_FACE_TABLES` on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)