### PR TITLE
fix(ci): resolve Marmot branch from the branch under test, not just the PR base

### DIFF
--- a/.github/workflows/run_tests_with_marmot.yml
+++ b/.github/workflows/run_tests_with_marmot.yml
@@ -80,27 +80,36 @@ jobs:
       - name: Install Marmot
         shell: bash -l {0}
         run: |
-          # Use github.base_ref (target of PR).
-          # If not a PR (like a push to a feature branch), fall back to next_v26.11, the shared
-          # development branch - NOT github.ref_name, since the EdelweissFE branch
-          # name essentially never matches a Marmot branch name, and falling through to Marmot's
-          # default branch ("master") silently builds against a stale, possibly API-incompatible
-          # Marmot revision.
-          TARGET_BRANCH="${{ github.base_ref || 'next_v26.11' }}"
-
-          echo "Pull Request Target/Current Branch is: $TARGET_BRANCH"
+          # Try, in order: the branch actually under test (github.head_ref, set for a pull_request
+          # event), the PR's base branch (github.base_ref), then next_v26.11, the shared
+          # development branch - NOT github.ref_name, since the EdelweissFE branch name essentially
+          # never matches a Marmot branch name, and falling through to Marmot's default branch
+          # ("master") silently builds against a stale, possibly API-incompatible Marmot revision.
+          #
+          # head_ref must be tried before base_ref: for a PR whose head branch itself has a
+          # same-named Marmot branch (e.g. a "next_v26.11 -> master" promotion PR), the code under
+          # test depends on that head branch's Marmot revision, not the base branch's -- using
+          # base_ref there would silently build against the wrong (older/incompatible) Marmot.
+          CANDIDATE_BRANCHES=("${{ github.head_ref }}" "${{ github.base_ref }}" "next_v26.11")
 
           git clone --recurse-submodules https://github.com/MAteRialMOdelingToolbox/Marmot/
           cd Marmot
 
-          # Attempt to switch to the branch matching the target branch
-          if git show-ref --verify --quiet refs/remotes/origin/$TARGET_BRANCH; then
-            echo "Matching branch found. Checking out $TARGET_BRANCH..."
-            git checkout $TARGET_BRANCH
-          else
-            echo "::error::Branch $TARGET_BRANCH not found in Marmot, and there is no safe default to fall back to."
+          TARGET_BRANCH=""
+          for candidate in "${CANDIDATE_BRANCHES[@]}"; do
+            if [ -n "$candidate" ] && git show-ref --verify --quiet "refs/remotes/origin/$candidate"; then
+              TARGET_BRANCH="$candidate"
+              break
+            fi
+          done
+
+          if [ -z "$TARGET_BRANCH" ]; then
+            echo "::error::None of the candidate branches (${CANDIDATE_BRANCHES[*]}) exist in Marmot, and there is no safe default to fall back to."
             exit 1
           fi
+
+          echo "Using Marmot branch: $TARGET_BRANCH"
+          git checkout "$TARGET_BRANCH"
 
           mkdir build
           cd build

--- a/.github/workflows/run_tests_with_marmot.yml
+++ b/.github/workflows/run_tests_with_marmot.yml
@@ -109,7 +109,7 @@ jobs:
           fi
 
           echo "Using Marmot branch: $TARGET_BRANCH"
-          git checkout "$TARGET_BRANCH"
+          git checkout --detach "origin/$TARGET_BRANCH"
 
           mkdir build
           cd build


### PR DESCRIPTION
## Problem

\`.github/workflows/run_tests_with_marmot.yml\`'s "Install Marmot" step resolves which Marmot branch to build via:

\`\`\`
TARGET_BRANCH="${{ github.base_ref || 'next_v26.11' }}"
\`\`\`

This picks the wrong Marmot revision for a PR whose *head* branch (not base branch) is what needs to build against a specific Marmot revision -- e.g. #45 (\`next_v26.11 -> master\`): \`base_ref\` is \`master\`, so its CI checks out Marmot's \`master\` branch, which is stale/incompatible with what \`next_v26.11\`'s EdelweissFE code actually needs. That causes Marmot-backed extensions to fail to build/mismatch, cascading into unrelated test failures on that PR's checks (e.g. \`MeshDataToFileFromBoxGen\`, whose prerequisite \`BoxGen\` test gets skipped for want of Marmot, so the file it's supposed to produce never exists).

Confirmed this is the actual cause: PR #45's \`pull_request\`-triggered \`Run tests\` job has failed with this exact symptom identically both before and after #68 merged, while the authoritative \`push\`-triggered CI on \`next_v26.11\` itself has stayed green throughout -- so it's a standing CI configuration bug, unrelated to #68 or any other recent code change.

## Fix

Try, in order: \`github.head_ref\` (the branch actually under test, set for a \`pull_request\` event), \`github.base_ref\`, then \`next_v26.11\` -- checking each against Marmot's branches in sequence instead of picking one via a single fallback expression. \`head_ref\` must be tried first: for a PR whose head branch itself has a same-named Marmot branch (like #45), the code under test depends on *that* branch's Marmot revision, not the base's.

## Test plan

- [x] YAML validated (\`python3 -c "import yaml; yaml.safe_load(...)"\`)
- [x] Branch-resolution logic verified in isolation for all 4 relevant cases: push to \`next_v26.11\` (head_ref/base_ref both empty) -> \`next_v26.11\`; typical feature PR into \`next_v26.11\` -> \`next_v26.11\`; PR #45's exact case (\`head_ref=next_v26.11\`, \`base_ref=master\`) -> now correctly resolves to \`next_v26.11\` instead of \`master\`; no match anywhere -> falls through to the \`next_v26.11\` default.
- [ ] Confirm PR #45's \`Run tests\` job goes green once this lands on \`next_v26.11\` and PR #45 re-syncs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)