### PR TITLE
fix(timesteppers): report whether the next increment really is zero

### DIFF
--- a/edelweissfe/timesteppers/adaptivetimestepper.py
+++ b/edelweissfe/timesteppers/adaptivetimestepper.py
@@ -93,7 +93,20 @@ class AdaptiveTimeStepper(TimeStepperBase):
         self.makeZeroIncrementFirst = makeZeroIncrementFirst
 
     def doesZeroIncrement(self):
-        return True
+        """Whether the *next* generated time step will be a zero increment.
+
+        This reports what will actually happen, not merely that zero increments are configured: the
+        zero increment is only emitted as the very first step of a step, so after a restart -- which
+        restores a non-zero increment counter -- there is none. Callers that require a zero increment
+        in order to initialise themselves have to know the difference.
+
+        Returns
+        -------
+        bool
+            True if the next generated time step will have a zero increment.
+        """
+
+        return self.makeZeroIncrementFirst and self.incrementCounter == 0
 
     def generateTimeStep(self, enforcedTimeIncrement: float = None) -> TimeStep:
         """

--- a/tests/test_adaptivetimestepper.py
+++ b/tests/test_adaptivetimestepper.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#  ---------------------------------------------------------------------
+#
+#  _____    _      _              _         _____ _____
+# | ____|__| | ___| |_      _____(_)___ ___|  ___| ____|
+# |  _| / _` |/ _ \ \ \ /\ / / _ \ / __/ __| |_  |  _|
+# | |__| (_| |  __/ |\ V  V /  __/ \__ \__ \  _| | |___
+# |_____\__,_|\___|_| \_/\_/ \___|_|___/___/_|   |_____|
+#
+#
+#  Unit of Strength of Materials and Structural Analysis
+#  University of Innsbruck,
+#  2017 - today
+#
+#  Matthias Neuner matthias.neuner@uibk.ac.at
+#
+#  This file is part of EdelweissFE.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2.1 of the License, or (at your option) any later version.
+#
+#  The full text of the license can be found in the file LICENSE.md at
+#  the top level directory of EdelweissFE.
+#  ---------------------------------------------------------------------
+"""Pins ``AdaptiveTimeStepper.doesZeroIncrement()`` to what will actually happen next, not merely
+whether zero increments are configured -- it used to return a hardcoded ``True``, so its one
+intended use case (a caller that needs to know whether the *next* generated step has zero length,
+e.g. to skip initialisation logic that only applies to a genuine zero increment) could never
+distinguish "still at the zero increment" from "already past it", most obviously after a restart,
+which resumes with a non-zero ``incrementCounter``.
+"""
+
+from unittest.mock import MagicMock
+
+from edelweissfe.timesteppers.adaptivetimestepper import AdaptiveTimeStepper
+
+
+def _timeStepper(**overrides) -> AdaptiveTimeStepper:
+    kwargs = dict(
+        currentTime=0.0,
+        stepLength=1.0,
+        startIncrement=0.1,
+        maxIncrement=1.0,
+        minIncrement=0.01,
+        maxNumberIncrements=100,
+        journal=MagicMock(),
+    )
+    kwargs.update(overrides)
+    return AdaptiveTimeStepper(**kwargs)
+
+
+def test_reports_zero_increment_only_before_the_first_increment_is_generated():
+    timeStepper = _timeStepper()
+    assert timeStepper.doesZeroIncrement()
+
+    timeStepper.incrementCounter = 1
+    assert not timeStepper.doesZeroIncrement()
+
+
+def test_reports_no_zero_increment_when_disabled():
+    timeStepper = _timeStepper(makeZeroIncrementFirst=False)
+    assert not timeStepper.doesZeroIncrement()
+
+
+def test_reports_no_zero_increment_after_restart_resumes_a_non_zero_increment_counter():
+    """The motivating case: a restarted run's timestepper never sees ``incrementCounter == 0``, so
+    it must not claim the next generated step will be a zero increment."""
+    timeStepper = _timeStepper()
+    timeStepper.incrementCounter = 42
+    assert not timeStepper.doesZeroIncrement()


### PR DESCRIPTION
## Summary
`AdaptiveTimeStepper.doesZeroIncrement()` returned a hardcoded `True`. It described the *configuration* -- that zero increments are enabled -- rather than what the next generated step will actually be. The zero increment is only ever emitted as the very first step of a step, so after a restart, which restores a non-zero `incrementCounter`, there is none; a caller relying on this method to distinguish that case could never do so.

No current caller depends on this (verified: no callers anywhere in `edelweissfe/`), so this has no observable effect today -- it corrects the method to actually satisfy its own contract for whenever one is added (e.g. initialization logic that only applies to a genuine zero increment).

## Note on scope
This branch previously carried a large amount of unrelated, already-stale ancestry (a much older fork point that predated several since-merged PRs) plus a separate, substantial, still-unmerged performance feature (direct-to-CSR assembly + blockamg AMG-hierarchy tuning) that happened to be stacked on top of it. Force-pushed a clean single commit, rebuilt directly onto current `next_v26.11`, so this PR is scoped to just the timestepper fix. The direct-to-CSR-assembly work is being landed separately, as its own PR.

## Test plan
- [x] `pre-commit` clean
- [x] New unit tests (`tests/test_adaptivetimestepper.py`): fresh timestepper reports zero increment next, disabled config never does, and the motivating case -- a restored non-zero `incrementCounter` (as after a restart) never does either
- [x] `python -m pytest` (full suite): 312 passed, 5 pre-existing failures (unrelated `tests/`-not-in-CI drift, same class as [#93](https://github.com/Edelweiss-Numerics/EdelweissFE/issues/93))
- [x] `run_tests_edelweissfe ./testfiles/edelweiss-only/`: 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)