### PR TITLE
fix(restart): drop version-negotiation from checkpoint read/write

### DIFF
--- a/edelweissfe/models/femodel.py
+++ b/edelweissfe/models/femodel.py
@@ -41,14 +41,10 @@ from edelweissfe.config.phenomena import getFieldSize, phenomena
 from edelweissfe.fields.nodefield import NodeField
 from edelweissfe.journal.journal import Journal
 from edelweissfe.models.modelchange import ModelChange, TopologyRecord, coalesce
-from edelweissfe.utils.exceptions import RestartError, TopologyError
+from edelweissfe.utils.exceptions import TopologyError
 from edelweissfe.utils.performancetiming import timeit
 from edelweissfe.variables.fieldvariable import FieldVariable
 from edelweissfe.variables.scalarvariable import ScalarVariable
-
-#: Checkpoint layout this build writes and reads. A checkpoint stamped with anything else is
-#: refused rather than partially restored -- see FEModel.readRestart.
-RESTART_FORMAT_VERSION = 2
 
 
 class FEModel:
@@ -876,7 +872,6 @@ class FEModel:
         f = restartFile
 
         f.attrs["time"] = self.time
-        f.attrs["restartFormatVersion"] = RESTART_FORMAT_VERSION
 
         # node fields
         f.create_group("nodeFields")
@@ -895,16 +890,6 @@ class FEModel:
         """
 
         f = restartFile
-
-        version = int(f.attrs.get("restartFormatVersion", 0))
-        if version != RESTART_FORMAT_VERSION:
-            raise RestartError(
-                "this checkpoint is format version {:}, this build reads version {:}. Restart "
-                "checkpoints are not a stable format yet -- regenerate it rather than resuming from "
-                "it, which would restore a topology history this build cannot interpret.".format(
-                    version or "pre-versioning", RESTART_FORMAT_VERSION
-                )
-            )
 
         self.time = f.attrs["time"]
 


### PR DESCRIPTION
## Summary
- `FEModel.writeRestart`/`readRestart` (landed via #95) stamped and checked a `RESTART_FORMAT_VERSION`, implying a migration/negotiation mechanism that isn't wanted here: there is exactly one restart checkpoint format, and an incompatible change to it means regenerating checkpoints, not reading old ones.
- The version check as shipped was also simply wrong: it invalidated every existing checkpoint for zero content change (the write side writes exactly what it always wrote), and its refusal message described a topology history that this build never actually serializes.
- Removes the version stamp/check entirely, restoring the original (pre-#95) `writeRestart`/`readRestart` behavior. No reader-side branching on version, no migration table — per-format compatibility is enforced by not shipping incompatible formats, not by runtime negotiation.

## Test plan
- [x] `pre-commit run --files edelweissfe/models/femodel.py` clean
- [x] Manual `writeRestart`/`readRestart` round-trip on a minimal `FEModel` (time attr survives)
- [x] `writeRestart`/`readRestart` are not currently wired into any output manager on `next_v26.11` (restart lands fully in a follow-up PR), so no existing test exercises this path

🤖 Generated with [Claude Code](https://claude.com/claude-code)