### PR TITLE
feat(numerics): direct-to-CSR assembly, opt-in AMG hierarchy sparsification

### DIFF
--- a/doc/source/documentation/assembly.rst
+++ b/doc/source/documentation/assembly.rst
@@ -52,56 +52,29 @@ value array is ever materialised.
       - 4 + 8 bytes / nnz
       - 4 + 8 bytes / nnz
 
-The two entries in bold on the left are why this matters. At 43,350 DOF of a meshfree RKPM
-discretisation -- 1.72e9 COO pairs against 71.2 M nnz, i.e. 24 duplicate contributions per matrix entry
--- the value array is 12.84 GiB and ``gather_sources`` a further 6.42 GiB, against a 0.53 GiB result.
+The two entries in bold on the left are why this matters: the more duplicate contributions land on
+the same matrix entry -- which grows with the number of entities touching a DOF, not with the DOF
+count itself -- the larger the value array and ``gather_sources`` become relative to the CSR result
+they produce. Their size is set by the number of COO pairs; the CSR pattern's is set by ``nnz``. A
+discretisation where many entities contribute to the same entries (a wide stencil, or overlapping
+supports) can have the staging array and gather map dwarf the actual result by a wide margin.
 
 Why the direct path is also faster
 ----------------------------------
 
-Three effects, all measured at 43,350 DOF on 16 threads:
+Three effects:
 
-- **Nothing has to be cleared.** The staging array must be zeroed every Newton iteration; at this size
-  that is 1.7 s of writing zeros. The direct path clears only the private CSR copies.
-- **Nothing has to be re-read.** The gather random-accesses a multi-gigabyte array; the scatter touches
-  only the CSR data, a ~23x smaller working set.
-- **The evaluation itself is slightly faster**, because each entity writes into a small reused scratch
-  block that stays in cache instead of a slab of a multi-gigabyte array.
+- **Nothing has to be cleared.** The staging array must be zeroed every Newton iteration; that cost
+  scales with the number of COO pairs, not with ``nnz``. The direct path clears only the private CSR
+  copies, sized by ``nnz``.
+- **Nothing has to be re-read.** The gather random-accesses the staging array, which can be many times
+  larger than the CSR data the scatter touches instead.
+- **The evaluation itself is not slower**, because each entity writes into a small reused scratch block
+  that stays in cache instead of a slab of a much larger array.
 
-Measured assembly, both paths timed in the same process on the same increment:
-
-.. list-table::
-    :width: 100%
-    :widths: 40 20 20 20
-    :header-rows: 1
-
-    * - Component, per Newton iteration
-      - Stage-then-gather
-      - Direct
-      - Ratio
-    * - clear the staging array
-      - 1.853 s
-      - 0.157 s
-      - 11.8x
-    * - entity evaluation
-      - 3.199 s
-      - 3.046 s
-      - 1.05x
-    * - gather / reduce
-      - 1.688 s
-      - 0.099 s
-      - 17.1x
-    * - **total**
-      - **6.704 s**
-      - **3.301 s**
-      - **2.03x**
-
-.. note::
-
-   That 2.03x is the *assembly in isolation*. Quote it with care: repeated later on the same data it
-   came out at 1.75x, because the gather's cost over a multi-gigabyte array varies with the machine's
-   memory state between runs, and it is the largest term the direct path removes. The honest figure is a
-   range, 1.75-2.03x.
+The relative sizes of these three effects depend on how many duplicate contributions land per matrix
+entry for a given discretisation and thread count -- measure on the model at hand rather than assuming
+a fixed ratio.
 
 The one definition of the pattern
 ---------------------------------
@@ -113,9 +86,8 @@ cannot drift apart. The generator must outlive the assembler.
 
 The offset map is built by binary-searching each ``(row, col)`` pair in the borrowed pattern, and stores
 the *within-row* position, which is why 2 bytes suffice: row length is set by the stencil, not by the
-problem size. Measured on an RKPM discretisation the largest within-row offset was 1,727 against the
-65,535 a ``uint16`` allows, and the bound stays in that region even as the support radius grows. A pair
-that cannot be mapped, or an offset that does not fit, raises rather than being silently misplaced.
+problem size, so it stays well within a ``uint16`` even for a wide stencil. A pair that cannot be
+mapped, or an offset that does not fit, raises rather than being silently misplaced.
 
 Building only the pattern
 -------------------------
@@ -128,17 +100,17 @@ Two reasons, and the second is the one that decides how large a model can be:
   in the build.
 - **It removes every 32-bit pair index.** ``gather_sources``, ``assembly_ptr`` and the sort element's
   origin field all index into the COO list, which is why a full build refuses more than ``INT32_MAX``
-  pairs. Measured on an RKPM problem, that limit bites at about **50,000 DOF with only a third of a
-  187 GB machine in use** -- memory alone would have allowed roughly 121,000. With ``patternOnly`` the
-  only remaining 32-bit quantity is ``nnz``, three orders of magnitude from its limit at these sizes.
+  pairs. For a discretisation with many duplicate contributions per matrix entry, that pair-count limit
+  can bite well before memory does. With ``patternOnly`` the only remaining 32-bit quantity is ``nnz``,
+  which grows only with the CSR result, not with the number of contributions.
 
 A generator built this way, or one that has given its map back via
 :meth:`~edelweissfe.numerics.csrgeneratorv2.CSRGenerator.releaseGatherMap`, **raises** if asked to
 gather. That is deliberate: the alternative is a ``nogil`` loop reading released vectors, and a matrix
 that is quietly wrong is worse than one that is loudly unavailable.
 
-Measured effect at 43,350 DOF: peak resident memory 47.39 -> **34.59 GiB**, and the pattern build
-19.36 -> **11.40 s**.
+Dropping the gather map lowers peak memory and shortens the pattern build, since half the sort payload
+and the 32-bit index arrays it removes never need writing in the first place.
 
 Private copies, or atomics
 --------------------------
@@ -147,42 +119,20 @@ Threads scattering into one CSR array must not collide. The default is one priva
 per thread, summed at the end: no synchronisation, a fixed summation order, and therefore
 bit-reproducible results -- at ``nThreads`` x ``nnz`` x 8 bytes.
 :meth:`~edelweissfe.numerics.csrgeneratorv2.DirectCSRAssembler.setNumBuffers` trades that memory for
-atomics.
+atomics: fewer private copies means threads share one and synchronise the scatter with atomics
+instead, down to a single, fully atomic copy at ``n == 1``.
 
-Measured at 43,350 DOF, 16 threads, all three configurations in one process on one increment:
+Two things worth knowing, from measuring this tradeoff on a real assembly:
 
-.. list-table::
-    :width: 100%
-    :widths: 20 25 20 35
-    :header-rows: 1
-
-    * - copies
-      - assembler memory
-      - assembly time
-      - notes
-    * - 16 (one per thread)
-      - 11.72 GiB
-      - 3.4289 s
-      - default; bit-reproducible
-    * - 4 (shared)
-      - 5.35 GiB
-      - 3.7800 s (+10.2%)
-      - not worth having, see below
-    * - 1 (fully atomic)
-      - **3.76 GiB**
-      - 3.8341 s (+11.8%)
-      - reproducibility lost
-
-Two things worth knowing. **Atomics cost 11.8%, not the 57% an earlier standalone benchmark suggested**
--- that benchmark timed the final reduction, which is 0.16 s of a 3.43 s assembly, rather than the
-atomics inside the scatter. And **the penalty is the atomic instruction, not contention**: going from 16
-copies to 4 already costs 10.2 of the 11.8 percentage points, so the intermediate setting pays nearly
-all of the time penalty for only part of the memory saving.
-
-What atomics cost is exact reproducibility. The summation order becomes dependent on thread
-interleaving, so re-running the same computation no longer returns bit-identical values -- the results
-stay correct to round-off, which is measurable: an internal control that re-evaluates the same kernel
-twice reports exactly zero with private copies and 2.9e-16 with atomics.
+- **The penalty is the atomic instruction itself, not contention.** Most of the slowdown from going
+  fully atomic already shows up after dropping from one copy per thread to just a handful of shared
+  copies -- so an intermediate setting pays nearly all of the time cost for only part of the memory
+  saving, and isn't a good middle ground in practice.
+- **What atomics actually cost is exact reproducibility, not correctness.** The summation order
+  becomes dependent on thread interleaving, so re-running the same computation no longer returns
+  bit-identical values -- results still agree to round-off, verifiably: an internal control that
+  re-evaluates the same kernel twice reports exactly zero difference with private copies and a
+  round-off-scale difference with atomics.
 
 .. note::
 

--- a/doc/source/documentation/assembly.rst
+++ b/doc/source/documentation/assembly.rst
@@ -1,0 +1,218 @@
+System matrix assembly
+======================
+
+Assembling a sparse system matrix from element, cell or particle contributions can be done two ways,
+and EdelweissFE provides both. Which one is appropriate is a memory question far more than a speed one,
+so this page describes what each costs as well as what each does.
+
+Both paths are in ``edelweissfe.numerics.csrgeneratorv2``, backed by the C++ header
+``edelweissfe/numerics/_csrcore.h``.
+
+The two paths
+-------------
+
+**Stage, then gather** (:class:`~edelweissfe.numerics.csrgeneratorv2.CSRGenerator`). Every entity writes
+its dense block into its own slice of one long *VIJ* (COO triplet) value array. Contributions to the
+same matrix entry land in different slots, and a second pass then sums the duplicates into CSR. The
+addressing is a *gather*: for each of the ``nnz`` output entries, read the value-array positions that
+feed it.
+
+**Scatter directly** (:class:`~edelweissfe.numerics.csrgeneratorv2.DirectCSRAssembler`). Each entity's
+block is pushed straight into the CSR data array, because every COO pair knows its destination slot in
+advance -- ``indptr[row] + offset``, where ``offset`` is the position of the column within that row. No
+value array is ever materialised.
+
+.. list-table:: What each path stores, per COO pair or per nnz
+    :width: 100%
+    :widths: 40 30 30
+    :header-rows: 1
+
+    * - Array
+      - Stage-then-gather
+      - Direct
+    * - ``I`` / ``J`` COO indices (owned by the DofManager)
+      - 4 + 4 bytes / pair
+      - 4 + 4 bytes / pair
+    * - VIJ value array
+      - **8 bytes / pair**
+      - --
+    * - ``gather_sources``
+      - **4 bytes / pair**
+      - --
+    * - ``assembly_ptr``
+      - 4 bytes / nnz
+      - --
+    * - ``offsets`` (within-row position)
+      - --
+      - **2 bytes / pair**
+    * - private CSR copies
+      - --
+      - ``nBuffers`` x 8 bytes / nnz
+    * - CSR pattern and data
+      - 4 + 8 bytes / nnz
+      - 4 + 8 bytes / nnz
+
+The two entries in bold on the left are why this matters. At 43,350 DOF of a meshfree RKPM
+discretisation -- 1.72e9 COO pairs against 71.2 M nnz, i.e. 24 duplicate contributions per matrix entry
+-- the value array is 12.84 GiB and ``gather_sources`` a further 6.42 GiB, against a 0.53 GiB result.
+
+Why the direct path is also faster
+----------------------------------
+
+Three effects, all measured at 43,350 DOF on 16 threads:
+
+- **Nothing has to be cleared.** The staging array must be zeroed every Newton iteration; at this size
+  that is 1.7 s of writing zeros. The direct path clears only the private CSR copies.
+- **Nothing has to be re-read.** The gather random-accesses a multi-gigabyte array; the scatter touches
+  only the CSR data, a ~23x smaller working set.
+- **The evaluation itself is slightly faster**, because each entity writes into a small reused scratch
+  block that stays in cache instead of a slab of a multi-gigabyte array.
+
+Measured assembly, both paths timed in the same process on the same increment:
+
+.. list-table::
+    :width: 100%
+    :widths: 40 20 20 20
+    :header-rows: 1
+
+    * - Component, per Newton iteration
+      - Stage-then-gather
+      - Direct
+      - Ratio
+    * - clear the staging array
+      - 1.853 s
+      - 0.157 s
+      - 11.8x
+    * - entity evaluation
+      - 3.199 s
+      - 3.046 s
+      - 1.05x
+    * - gather / reduce
+      - 1.688 s
+      - 0.099 s
+      - 17.1x
+    * - **total**
+      - **6.704 s**
+      - **3.301 s**
+      - **2.03x**
+
+.. note::
+
+   That 2.03x is the *assembly in isolation*. Quote it with care: repeated later on the same data it
+   came out at 1.75x, because the gather's cost over a multi-gigabyte array varies with the machine's
+   memory state between runs, and it is the largest term the direct path removes. The honest figure is a
+   range, 1.75-2.03x.
+
+The one definition of the pattern
+---------------------------------
+
+:class:`~edelweissfe.numerics.csrgeneratorv2.DirectCSRAssembler` **borrows** its pattern from an existing
+:class:`~edelweissfe.numerics.csrgeneratorv2.CSRGenerator` rather than deriving its own. This is
+deliberate: there is exactly one definition of what the CSR pattern is, and the two assembly paths
+cannot drift apart. The generator must outlive the assembler.
+
+The offset map is built by binary-searching each ``(row, col)`` pair in the borrowed pattern, and stores
+the *within-row* position, which is why 2 bytes suffice: row length is set by the stencil, not by the
+problem size. Measured on an RKPM discretisation the largest within-row offset was 1,727 against the
+65,535 a ``uint16`` allows, and the bound stays in that region even as the support radius grows. A pair
+that cannot be mapped, or an offset that does not fit, raises rather than being silently misplaced.
+
+Building only the pattern
+-------------------------
+
+``CSRGenerator(systemMatrix, patternOnly=True)`` builds ``indptr`` and ``indices`` and nothing else.
+Two reasons, and the second is the one that decides how large a model can be:
+
+- **The sort payload halves.** With the gather map, the sort element is a key plus an origin index, which
+  pads to 16 bytes per pair; without it, a bare 8-byte key. That array is the largest single allocation
+  in the build.
+- **It removes every 32-bit pair index.** ``gather_sources``, ``assembly_ptr`` and the sort element's
+  origin field all index into the COO list, which is why a full build refuses more than ``INT32_MAX``
+  pairs. Measured on an RKPM problem, that limit bites at about **50,000 DOF with only a third of a
+  187 GB machine in use** -- memory alone would have allowed roughly 121,000. With ``patternOnly`` the
+  only remaining 32-bit quantity is ``nnz``, three orders of magnitude from its limit at these sizes.
+
+A generator built this way, or one that has given its map back via
+:meth:`~edelweissfe.numerics.csrgeneratorv2.CSRGenerator.releaseGatherMap`, **raises** if asked to
+gather. That is deliberate: the alternative is a ``nogil`` loop reading released vectors, and a matrix
+that is quietly wrong is worse than one that is loudly unavailable.
+
+Measured effect at 43,350 DOF: peak resident memory 47.39 -> **34.59 GiB**, and the pattern build
+19.36 -> **11.40 s**.
+
+Private copies, or atomics
+--------------------------
+
+Threads scattering into one CSR array must not collide. The default is one private copy of the CSR data
+per thread, summed at the end: no synchronisation, a fixed summation order, and therefore
+bit-reproducible results -- at ``nThreads`` x ``nnz`` x 8 bytes.
+:meth:`~edelweissfe.numerics.csrgeneratorv2.DirectCSRAssembler.setNumBuffers` trades that memory for
+atomics.
+
+Measured at 43,350 DOF, 16 threads, all three configurations in one process on one increment:
+
+.. list-table::
+    :width: 100%
+    :widths: 20 25 20 35
+    :header-rows: 1
+
+    * - copies
+      - assembler memory
+      - assembly time
+      - notes
+    * - 16 (one per thread)
+      - 11.72 GiB
+      - 3.4289 s
+      - default; bit-reproducible
+    * - 4 (shared)
+      - 5.35 GiB
+      - 3.7800 s (+10.2%)
+      - not worth having, see below
+    * - 1 (fully atomic)
+      - **3.76 GiB**
+      - 3.8341 s (+11.8%)
+      - reproducibility lost
+
+Two things worth knowing. **Atomics cost 11.8%, not the 57% an earlier standalone benchmark suggested**
+-- that benchmark timed the final reduction, which is 0.16 s of a 3.43 s assembly, rather than the
+atomics inside the scatter. And **the penalty is the atomic instruction, not contention**: going from 16
+copies to 4 already costs 10.2 of the 11.8 percentage points, so the intermediate setting pays nearly
+all of the time penalty for only part of the memory saving.
+
+What atomics cost is exact reproducibility. The summation order becomes dependent on thread
+interleaving, so re-running the same computation no longer returns bit-identical values -- the results
+stay correct to round-off, which is measurable: an internal control that re-evaluates the same kernel
+twice reports exactly zero with private copies and 2.9e-16 with atomics.
+
+.. note::
+
+   Once the staging array is gone the assembly is usually no longer what sets peak memory, so the
+   memory saving from atomics may buy nothing in practice while the reproducibility loss is real.
+   Measure where your peak actually is before switching.
+
+Validation
+----------
+
+The addressing is validated **exactly, without a floating-point tolerance**, using an integer trick:
+set every value in the staging array to ``1`` so each CSR entry becomes the *count* of contributing
+pairs, then to its own index ``k`` so it becomes the *sum of their indices*. Both are integers far
+inside 2\ :sup:`53`, so a bitwise comparison against
+:meth:`~edelweissfe.numerics.csrgeneratorv2.CSRGenerator.updateCSR` validates the grouping exactly
+rather than approximately. A transposition or an off-by-one shows up as an unmistakable mismatch instead
+of a judgement call about how large a deviation is acceptable.
+
+:meth:`~edelweissfe.numerics.csrgeneratorv2.DirectCSRAssembler.assembleFromVIJ` exists for this purpose:
+it pushes a whole staging array through the offset map, so the two paths can be compared on identical
+values with the physics held fixed.
+
+Reference
+---------
+
+:class:`~edelweissfe.numerics.csrgeneratorv2.CSRGenerator` and the C++ engine behind it are described
+under :doc:`utils`; only the direct-scatter side is documented here.
+
+.. autoclass:: edelweissfe.numerics.csrgeneratorv2.DirectCSRAssembler
+   :members:
+
+.. autoclass:: edelweissfe.numerics.csrgeneratorv2.AliasedCSRMatrix
+   :members:

--- a/doc/source/documentation/blockamgtheory.rst
+++ b/doc/source/documentation/blockamgtheory.rst
@@ -612,6 +612,23 @@ Hierarchy reuse
       - ``1.5``
       - Refresh the hierarchies before the *next* solve if this solve's outer iteration count
         exceeded this factor times the previous solve's.
+    * - ``hierarchyDropTol``
+      - ``0.0`` (off)
+      - Build each field's AMG hierarchy from a *sparsified* copy of its diagonal block: drop
+        off-diagonal :math:`a_{ij}` where :math:`|a_{ij}| < \text{tol}\cdot\sqrt{|a_{ii}| |a_{jj}|}`.
+        Only the preconditioner is sparsified -- the operator the Krylov method applies is
+        untouched -- so this cannot change the converged solution, only the iteration count needed
+        to reach it. Worth up to **1.81x on the linear solve** on operators that store many
+        numerically negligible entries (meshfree RKPM discretisations are the motivating case). Off
+        by default because the useful range is operator-dependent.
+    * - ``hierarchyDropLumping``
+      - ``false``
+      - When ``hierarchyDropTol`` drops an entry, add it onto its row's diagonal instead of
+        discarding it, so row sums are preserved exactly and the constant near-null-space vector
+        survives filtering -- the AMG literature's preferred filtered-matrix construction. Measured
+        neutral at best on operators tested so far (no change at ``1e-4``, 8.1% *slower* at
+        ``1e-2``, with outer GMRES iteration count unchanged either way): the whole penalty is the
+        extra pass over the matrix. Off by default; plain truncation is simpler and faster.
 
 Diagnostics
 ~~~~~~~~~~~

--- a/doc/source/documentation/index.rst
+++ b/doc/source/documentation/index.rst
@@ -16,6 +16,7 @@ Documentation
    rigidbodies
    contacttheory
    dofmanager
+   assembly
    fieldoutputmanager
    fields
    elements

--- a/doc/source/documentation/utils.rst
+++ b/doc/source/documentation/utils.rst
@@ -15,6 +15,11 @@ EdelweissFE offers two generators to convert COO (Coordinate) format sparse matr
 1. **Legacy Generator (``csrgenerator``)**: A Cython implementation utilizing a binary search algorithm for mapping.
 2. **High-Performance Generator (``csrgeneratorv2``)**: A parallelized C++ engine with OpenMP support, thread-safe memory layouts, cache friendliness, and vectorized operations.
 
+.. seealso::
+   :doc:`assembly` compares this stage-then-gather route against direct scatter-to-CSR assembly, which
+   avoids the staging array entirely -- relevant whenever the number of stored contributions greatly
+   exceeds the number of matrix entries, as it does for meshfree discretisations.
+
 Legacy Generator
 ~~~~~~~~~~~~~~~~
 

--- a/doc/source/documentation/utils.rst
+++ b/doc/source/documentation/utils.rst
@@ -12,16 +12,20 @@ Matrix assembly is a critical performance bottleneck in Finite Element simulatio
 
 EdelweissFE offers two generators to convert COO (Coordinate) format sparse matrices to CSR (Compressed Sparse Row) format efficiently without re-analysing the sparsity pattern:
 
-1. **Legacy Generator (``csrgenerator``)**: A Cython implementation utilizing a binary search algorithm for mapping.
-2. **High-Performance Generator (``csrgeneratorv2``)**: A parallelized C++ engine with OpenMP support, thread-safe memory layouts, cache friendliness, and vectorized operations.
+1. **Legacy Generator (``csrgenerator``)**: a plain, single-threaded Cython implementation using a
+   binary search for the COO-to-CSR mapping. Kept deliberately simple and short -- **not used by any
+   solver**, its purpose is teaching: reading it end to end is the fastest way to understand what the
+   high-performance generator below does, before its parallelism, memory-layout tricks and the direct
+   scatter-to-CSR alternative are layered on top.
+2. **High-Performance Generator (``csrgeneratorv2``)**: A parallelized C++ engine with OpenMP support, thread-safe memory layouts, cache friendliness, and vectorized operations. This is what every solver actually uses.
 
 .. seealso::
    :doc:`assembly` compares this stage-then-gather route against direct scatter-to-CSR assembly, which
    avoids the staging array entirely -- relevant whenever the number of stored contributions greatly
    exceeds the number of matrix entries, as it does for meshfree discretisations.
 
-Legacy Generator
-~~~~~~~~~~~~~~~~
+Legacy Generator (teaching reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Module ``edelweissfe.numerics.csrgenerator``
 

--- a/edelweissfe/linsolve/blockamg/blockamg.py
+++ b/edelweissfe/linsolve/blockamg/blockamg.py
@@ -274,6 +274,37 @@ class BlockAMGSolver(LinearSolver):
         topology map computed on first need (via :func:`edelweissfe.numerics.p1topology.buildP1Map` on
         ``self._model``) and cached for this instance's lifetime. Ignored for a field also present in
         ``p1Maps`` (that field's map is already known; nothing to compute).
+    hierarchyDropTol
+        Build the AMG hierarchies from a *sparsified* copy of each diagonal block: drop off-diagonal
+        ``a_ij`` where ``|a_ij| < hierarchyDropTol * sqrt(|a_ii| |a_jj|)``. Zero (the default) keeps the
+        block as-is.
+
+        Why this exists. The RKPM operators this solver is used on store ~1643 entries per row at 43,350
+        DOF (3.79% dense) while the *median* off-diagonal is **1.29e-06 of the diagonal** -- numerically
+        far sparser than structurally. Smoothed aggregation then has to weigh 1643 candidates per row
+        where a handful matter, and the Galerkin product carries the rest down to every coarse level.
+        Measured on such a matrix: ``1e-6`` keeps 50.8% of the entries, ``1e-4`` keeps 29.6%, ``1e-3``
+        keeps 17.4%, and no row loses all of its off-diagonals even at ``1e-2``.
+
+        Only the *preconditioner* is sparsified; the operator the Krylov method applies, and therefore
+        the residual it drives to zero, is the unmodified matrix. So this cannot change the converged
+        solution beyond the outer tolerance -- it can only change how many iterations reaching it takes.
+
+        The criterion is scale-invariant and, for a symmetric matrix, symmetric in ``(i, j)``, so the
+        sparsified block stays symmetric -- which smoothed aggregation and the Chebyshev smoother both
+        assume. Verified: zero asymmetric mask entries at 1e-6, 1e-4 and 1e-2.
+    hierarchyDropLumping
+        When dropping entries (see ``hierarchyDropTol``), add each discarded off-diagonal onto its row's
+        diagonal instead of discarding it outright. This preserves row sums exactly, so
+        ``A_filtered @ 1 == A @ 1`` and the constant near-null-space vector survives filtering -- which
+        is what the AMG literature's "filtered matrix" construction does, and the reason it is preferred
+        over plain truncation.
+
+        Note the caveat for elasticity: off-diagonals are typically negative, so lumping *reduces* the
+        diagonal and therefore weakens diagonal dominance. Whether that helps or hurts is a property of
+        the operator, which is why this is a separate switch rather than folded into
+        ``hierarchyDropTol``. Defaults to ``False``, i.e. plain truncation, which is what the published
+        measurements for this solver used.
     etaMin, etaMax
         Clamp on the Eisenstat--Walker forcing tolerance (ignored if ``outerTol`` is given). ``etaMax``
         is also the tolerance used whenever there is no residual history to base a ratio on (the first
@@ -391,6 +422,8 @@ class BlockAMGSolver(LinearSolver):
         lgmresResetOnNewIncrement: bool = False,
         sweeps: int = 1,
         symmetric: bool = True,
+        hierarchyDropTol: float = 0.0,
+        hierarchyDropLumping: bool = False,
         fieldPreconds: dict = None,
         useRigidBodyNullspace: bool = True,
         p1Maps: dict = None,
@@ -435,6 +468,8 @@ class BlockAMGSolver(LinearSolver):
         # Per-field p-two-grid restriction operators, derived from the P1 topology; ditto.
         self._pNodeCache = {}
         self._p1FieldNamesRequested = set(p1FieldNames or [])
+        self._hierarchyDropTol = hierarchyDropTol
+        self._hierarchyDropLumping = hierarchyDropLumping
         self._etaMin = etaMin
         self._etaMax = etaMax
         self._ewGamma = ewGamma
@@ -513,6 +548,36 @@ class BlockAMGSolver(LinearSolver):
             self._journal.message(message, _IDENTIFICATION, level=_JOURNAL_LEVEL[level])
         else:
             print(message, flush=True)
+
+    def _dropSmallEntries(self, block):
+        """Return `block` with off-diagonals below the relative drop tolerance removed.
+
+        Runs only on a hierarchy refresh, not on every solve, so a few array passes over nnz are cheap
+        against the hierarchy build they feed. The diagonal is always kept, so no row can be emptied.
+        """
+        tau = self._hierarchyDropTol
+        diagonal = np.abs(block.diagonal())
+        coo = block.tocoo()
+        scale = np.sqrt(diagonal[coo.row] * diagonal[coo.col])
+        keep = (coo.row == coo.col) | (np.abs(coo.data) >= tau * scale)
+        dropped = sp.coo_matrix((coo.data[keep], (coo.row[keep], coo.col[keep])), shape=block.shape).tocsr()
+
+        lumped = ""
+        if self._hierarchyDropLumping:
+            # Row-sum-preserving filtering: the discarded content of each row goes onto its diagonal, so
+            # A_filtered @ 1 == A @ 1 exactly and the constant vector is unaffected by filtering. The
+            # diagonal is always kept, so this does not change the sparsity pattern.
+            discardedRowSums = np.bincount(coo.row[~keep], weights=coo.data[~keep], minlength=block.shape[0])
+            dropped = (dropped + sp.diags(discardedRowSums, format="csr")).tocsr()
+            lumped = ", lumped onto the diagonal"
+
+        self._log(
+            "info",
+            "blockamg: hierarchy drop tol {:.0e}: nnz {:,} -> {:,} ({:.1f}%){:}".format(
+                tau, block.nnz, dropped.nnz, 100.0 * dropped.nnz / max(block.nnz, 1), lumped
+            ),
+        )
+        return dropped
 
     def _forcingTolerance(self, residualNorm: float, newIncrement: bool) -> float:
         """The Eisenstat--Walker "choice 2" forcing tolerance for this solve, clamped and safeguarded.
@@ -881,10 +946,16 @@ class BlockAMGSolver(LinearSolver):
             threadedAs.build(As)
         outerOperator = LinearOperator((n, n), matvec=threadedAs.matvec, dtype=As.dtype)
 
+        # A single field has no off-diagonal couplings at all: the `i != j` test below can never
+        # fire, but `As[slices[i], :]` still copies the whole matrix to populate a dict that stays
+        # empty -- measured at 12% of this solver's wall clock, and 11.40 s of 225.02 s on one
+        # reference model. Skipping it is not a tuning decision; there is provably nothing to compute.
+        singleField = len(slices) == 1 and blocks[0].start == 0 and blocks[0].stop == n
+
         # Off-diagonal couplings (for the sweep) are needed every solve regardless of refresh/reuse.
         with performancetiming.timeit("off-diagonal split"):
             offBlocks = {}
-            for i in range(len(slices)):
+            for i in range(len(slices)) if not singleField else ():
                 rowBlock = As[slices[i], :]
                 for j in range(len(slices)):
                     if i != j:
@@ -900,6 +971,8 @@ class BlockAMGSolver(LinearSolver):
                 # One AMG hierarchy per field, built fresh. A vector field gets its translations as the
                 # near null-space; a scalar field the default constant.
                 diagBlocks = [As[sl, :][:, sl].tocsr() for sl in slices]
+                if self._hierarchyDropTol > 0.0:
+                    diagBlocks = [self._dropSmallEntries(block) for block in diagBlocks]
                 preconditioners = []
                 for i, block in enumerate(blocks):
                     isVectorField = block.dimension > 1
@@ -991,6 +1064,25 @@ class BlockAMGSolver(LinearSolver):
                     if j != i:
                         localResidual -= offBlocks[(i, j)].matvecRect(x[j])  # INV4: threaded
                 x[i] = preconditioners[i].applyPreconditioner(localResidual)
+
+        # A single-field fast path for the apply itself was tried here and **rejected on measurement**,
+        # which is worth recording so it is not re-attempted blind. For one field with sweeps=1 and
+        # symmetric=False, `blockGaussSeidel` below reduces to exactly one `applyPreconditioner` call, so
+        # replacing it with that call directly looks free. It is measurably not:
+        #
+        #   baseline                  4431 outer iterations, linear solve 382.39 s
+        #   off-diagonal split only   4435 (+0.09%, inside the 0.13% run-to-run floor), 360.17 s
+        #   + this apply fast path    4563 (+2.9%, i.e. 22x the floor),                 351.09 s
+        #
+        # It is 2.5% faster in wall clock but shifts the outer iteration count by 2.9% against a
+        # measured 0.13% floor between identical runs -- a real change in the Krylov trajectory, not
+        # noise -- while the reaction force stays inside its own 9.8e-13 floor. Copying the output (to
+        # match what `np.concatenate` guarantees) reduced the shift but did not remove it, and no
+        # mechanism has been identified. 2.5% is not worth an unexplained numerical footprint in a
+        # preconditioner, where the failure mode is a slightly different answer rather than a crash.
+        #
+        # The off-diagonal split elimination above is a separate change and is clean: iterations inside
+        # the floor, 5.8% faster on its own.
 
         def blockGaussSeidel(residual):
             x = [np.zeros(sizes[i]) for i in range(nFields)]

--- a/edelweissfe/numerics/__init__.py
+++ b/edelweissfe/numerics/__init__.py
@@ -4,4 +4,19 @@
 #  EdelweissFE - Numerics Module
 #  ---------------------------------------------------------------------
 
-# Keep top-level __init__.py clean to avoid circular imports during module load.
+"""Numerics: DOF management and sparse system-matrix assembly."""
+
+from os.path import abspath, dirname
+
+
+def get_include() -> str:
+    """Directory holding the C++ headers of this package.
+
+    ``_csrcore.h`` declares ``CSRDirectAssembler``, whose ``scatterBlock`` is called from inside the
+    threaded entity loops of downstream packages (EdelweissMeshfree). They add this directory to their
+    extension ``include_dirs`` so that the scatter has exactly one implementation, rather than each
+    consumer reimplementing the addressing against raw memoryviews.
+
+    Mirrors the convention of ``numpy.get_include()``.
+    """
+    return dirname(abspath(__file__))

--- a/edelweissfe/numerics/_csrcore.h
+++ b/edelweissfe/numerics/_csrcore.h
@@ -7,6 +7,7 @@
 #include <numeric>
 #include <omp.h>
 #include <stdexcept>
+#include <type_traits>
 #include <vector>
 
 struct PackedEdge {
@@ -17,6 +18,18 @@ struct PackedEdge {
   bool operator<( const PackedEdge& other ) const { return key < other.key; }
 };
 
+// The pattern needs only the (row, col) key; the gather map additionally needs to know which COO pair
+// each key came from. These overloads let one build() serve both element types, so there is exactly one
+// definition of how the pattern is derived and a pattern-only build cannot drift from the full one.
+inline uint64_t keyOf( const PackedEdge& e )
+{
+  return e.key;
+}
+inline uint64_t keyOf( uint64_t k )
+{
+  return k;
+}
+
 class CSRCore {
 public:
   // CSR Topology
@@ -25,22 +38,58 @@ public:
   int                nnz  = 0;
   int                nDof = 0;
 
-  // Assembly Mapping
+  // Assembly Mapping. Only the gather needs these; see releaseGatherMap().
   std::vector< int32_t > gather_sources;
   std::vector< int32_t > assembly_ptr;
+  bool                   gatherMapReleased = false;
 
-  CSRCore( const int* I, const int* J, int64_t n_pairs, int n_dof ) : nDof( n_dof )
+  // patternOnly builds indptr/indices and nothing else. Two reasons, and the second is the one that
+  // matters:
+  //
+  //  * The sort payload disappears. With the gather map, each pair is a PackedEdge -- 8 bytes of key
+  //    plus a 4-byte origin index, padded to 16. Without it, a bare uint64_t key: 8 bytes. That array
+  //    is the largest single allocation in the build (25.7 GiB at 43,350 DOF), so this halves it.
+  //  * It removes every 32-bit pair index. `PackedEdge::orig`, `gather_sources` and `assembly_ptr` all
+  //    hold indices into the COO list, which is why the full build has to refuse more than INT32_MAX
+  //    pairs. Measured, that limit -- not memory -- is what caps the model: it bites at ~50,000 DOF
+  //    with only a third of the machine in use, where memory alone would allow ~121,000. The
+  //    pattern-only build has no such index, so the only 32-bit quantity left is nnz, which is three
+  //    orders of magnitude from its limit at these sizes.
+  //
+  // A direct-to-CSR assembler borrows only the pattern, so it should always ask for this.
+  CSRCore( const int* I, const int* J, int64_t n_pairs, int n_dof, bool patternOnly = false ) : nDof( n_dof )
   {
     if ( n_pairs == 0 ) {
       // Empty pattern: indptr is all-zeros, indices/gather_sources/assembly_ptr
       // remain empty. update() is guarded by nnz==0 and is a no-op in that case.
       indptr.assign( nDof + 1, 0 );
+      gatherMapReleased = patternOnly;
       return;
     }
 
+    if ( patternOnly )
+      build< false >( I, J, n_pairs );
+    else
+      build< true >( I, J, n_pairs );
+  }
+
+private:
+  template < bool WithGatherMap >
+  void build( const int* I, const int* J, int64_t n_pairs )
+  {
+    // One key per pair, plus its origin index only when the gather map is wanted.
+    using Elem = std::conditional_t< WithGatherMap, PackedEdge, uint64_t >;
+
     // --- SAFETY & CONFIG ---
-    if ( n_pairs > std::numeric_limits< int32_t >::max() ) {
-      throw std::overflow_error( "CSRCore: n_pairs exceeds 32-bit limit." );
+    if constexpr ( WithGatherMap ) {
+      // gather_sources and assembly_ptr are int32 indices into the COO list
+      if ( n_pairs > std::numeric_limits< int32_t >::max() ) {
+        throw std::overflow_error( "CSRCore: n_pairs exceeds 32-bit limit. Build the pattern only "
+                                   "(patternOnly = true) if the gather map is not needed." );
+      }
+    }
+    else {
+      gatherMapReleased = true; // there never was one; update() must refuse
     }
 
     // Determine Partitions based on threads
@@ -96,7 +145,7 @@ public:
 
     // --- STEP 2: PARALLEL SCATTER (BUCKETING) ---
     // Pack data into a structure that is fast to sort.
-    std::vector< PackedEdge > edges( n_pairs );
+    std::vector< Elem > edges( n_pairs );
 
 #pragma omp parallel
     {
@@ -118,7 +167,10 @@ public:
         // means only this thread writes to write_offsets[tid][*]).
         int64_t pos = write_offsets[tid][p_id]++;
 
-        edges[pos] = { key, (int32_t)k };
+        if constexpr ( WithGatherMap )
+          edges[pos] = { key, (int32_t)k };
+        else
+          edges[pos] = key;
       }
     }
 
@@ -159,14 +211,14 @@ public:
         // Determine Row range for this partition
         // We must be careful: indptr is size nDof+1.
         // We extract row from the key.
-        int prev_row = static_cast< int32_t >( edges[start].key >> 32 );
+        int prev_row = static_cast< int32_t >( keyOf( edges[start] ) >> 32 );
 
         // Mark first row count
         indptr[prev_row + 1]++;
 
         for ( int64_t k = start + 1; k < end; ++k ) {
-          uint64_t curr_key = edges[k].key;
-          uint64_t prev_key = edges[k - 1].key;
+          uint64_t curr_key = keyOf( edges[k] );
+          uint64_t prev_key = keyOf( edges[k - 1] );
 
           int curr_row = static_cast< int32_t >( curr_key >> 32 );
 
@@ -199,9 +251,11 @@ public:
 
     // --- STEP 5: FINAL FILL ---
     indices.resize( nnz );
-    gather_sources.resize( n_pairs );
-    assembly_ptr.resize( nnz + 1 );
-    assembly_ptr[nnz] = static_cast< int32_t >( n_pairs ); // Sentinel; safe: guarded by INT32_MAX check above
+    if constexpr ( WithGatherMap ) {
+      gather_sources.resize( n_pairs );
+      assembly_ptr.resize( nnz + 1 );
+      assembly_ptr[nnz] = static_cast< int32_t >( n_pairs ); // Sentinel; safe: guarded by INT32_MAX above
+    }
 
 #pragma omp parallel for schedule( dynamic, 1 )
     for ( int p = 0; p < num_partitions; ++p ) {
@@ -213,29 +267,51 @@ public:
       int32_t write_idx = global_nnz_offsets[p];
 
       // Fill first entry of the partition
-      indices[write_idx]      = static_cast< int32_t >( edges[start].key & 0xFFFFFFFFu );
-      assembly_ptr[write_idx] = start;
-      gather_sources[start]   = edges[start].orig;
+      indices[write_idx] = static_cast< int32_t >( keyOf( edges[start] ) & 0xFFFFFFFFu );
+      if constexpr ( WithGatherMap ) {
+        assembly_ptr[write_idx] = start;
+        gather_sources[start]   = edges[start].orig;
+      }
 
       int32_t internal_count = 0;
 
       for ( int64_t k = start + 1; k < end; ++k ) {
-        uint64_t curr_key = edges[k].key;
-        uint64_t prev_key = edges[k - 1].key;
+        uint64_t curr_key = keyOf( edges[k] );
+        uint64_t prev_key = keyOf( edges[k - 1] );
 
-        gather_sources[k] = edges[k].orig;
+        if constexpr ( WithGatherMap )
+          gather_sources[k] = edges[k].orig;
 
         if ( curr_key != prev_key ) {
           internal_count++;
-          // Close previous assembly pointer
-          // (assembly_ptr[i+1] is start of next, which is current k)
-          assembly_ptr[write_idx + internal_count] = k;
+          if constexpr ( WithGatherMap ) {
+            // Close previous assembly pointer
+            // (assembly_ptr[i+1] is start of next, which is current k)
+            assembly_ptr[write_idx + internal_count] = k;
+          }
 
           // Write new column index
           indices[write_idx + internal_count] = static_cast< int32_t >( curr_key & 0xFFFFFFFFu );
         }
       }
     }
+  }
+
+public:
+  // Give back the gather map, keeping the pattern. The direct-to-CSR assembler borrows only indptr
+  // and indices; gather_sources is one int32 per COO pair, so at 43k DOF the map is 6.69 GiB -- the
+  // second-largest allocation in the whole assembly, and larger than everything the direct path
+  // holds. Leaving it around would cancel most of what that path saves, so a solver that has
+  // committed to scattering releases it once the assembler has been built.
+  //
+  // update() must not be called afterwards. It cannot check cheaply enough to be worth it (it is a
+  // nogil hot loop over nnz), so the guard lives in the Python binding, which raises. The swap idiom
+  // is what actually returns the capacity; clear() alone would not.
+  void releaseGatherMap()
+  {
+    std::vector< int32_t >().swap( gather_sources );
+    std::vector< int32_t >().swap( assembly_ptr );
+    gatherMapReleased = true;
   }
 
   void update( const double* V_data, double* csr_data ) const
@@ -257,5 +333,321 @@ public:
       }
       csr_data[i] = sum;
     }
+  }
+
+  // Bytes held by the CSR pattern and the gather map -- the counterpart to
+  // CSRDirectAssembler::memoryBytes(), so the two assembly paths can be compared on the same
+  // basis: what the object itself owns. That is the pattern (indptr, indices) plus the gather map,
+  // which is the term the direct path does away with -- gather_sources is one int32 per COO pair,
+  // so it scales with sizeVIJ rather than with nnz and is the second-largest array in the VIJ path
+  // after the value array itself.
+  //
+  // Not counted here, because this object does not own them: the VIJ value and index arrays (held
+  // by the DofManager) and the CSR data array (allocated by the Python-level CSRGenerator, which
+  // adds it in its own memoryBytes).
+  int64_t memoryBytes() const
+  {
+    return static_cast< int64_t >( indptr.size() ) * sizeof( int ) +
+           static_cast< int64_t >( indices.size() ) * sizeof( int ) +
+           static_cast< int64_t >( gather_sources.size() ) * sizeof( int32_t ) +
+           static_cast< int64_t >( assembly_ptr.size() ) * sizeof( int32_t );
+  }
+};
+
+// ---------------------------------------------------------------------------------------------
+// Direct-to-CSR assembly.
+//
+// CSRCore stages values in a VIJ array of length sizeVIJ and then *gathers* duplicates into CSR.
+// That staging array is the dominant memory cost of the meshfree assembly (12.15 GB at 43k DOF,
+// alongside I, J and gather_sources), and it exists only because assembly and reduction are
+// separated in time.
+//
+// This assembler removes it by *scattering* instead: each entry knows its CSR slot directly, as
+// indptr[row] + offset, where offset is the position of its column within that row. Rows are
+// ~1700-2200 long for RKPM stencils (set by the support radius, not by the DOF count), so the
+// offset fits in uint16 -- half the width of the int32 gather index it replaces, and it makes the
+// value array unnecessary entirely.
+//
+// How many private CSR copies to keep is configurable, via setNumBuffers(), because it is a pure
+// memory/speed trade and the right point depends on the problem size:
+//
+//   nBuffers == nThreads   one copy per thread, no synchronisation at all, summation order fixed
+//                          (so bit-reproducible). Costs nThreads * nnz * 8 bytes, which at 16
+//                          threads and 43k DOF is 8.5 GiB -- measured to be 72% of this
+//                          assembler's whole footprint, i.e. it consumes most of the saving.
+//   nBuffers <  nThreads   threads sharing a copy synchronise with `#pragma omp atomic` on the
+//                          scatter. nBuffers == 1 is the fully atomic case, at nnz * 8 bytes.
+//
+// An earlier standalone benchmark found atomics 1.57-2.13x slower than privatisation at 4-16
+// threads, and that was taken as settling the question -- wrongly, because it timed the
+// *reduction*, which is only 0.16 s of a 3.40 s assembly at 43k DOF. What actually matters is the
+// cost of atomics inside the scatter, in the entity loop, which that benchmark never isolated.
+// Hence the knob rather than a fixed choice: the totals are what get compared.
+//
+// Note that fewer buffers than threads makes the summation order depend on thread interleaving,
+// so results stop being bit-reproducible run to run (they stay correct to round-off). Anything
+// that needs reproducibility must keep nBuffers == nThreads.
+//
+// IMPORTANT: scatterBlock is called from EdelweissMeshfree's particle kernel, which includes this
+// header and therefore *inlines* this code into its own extension. Any change here needs BOTH
+// extensions rebuilt; a stale meshfree build keeps scattering the old way.
+struct CSRDirectAssembler {
+  const int*                           indptr;  // borrowed from the shared pattern
+  const int*                           indices; // borrowed
+  int                                  nnz      = 0;
+  int                                  nDof     = 0;
+  int64_t                              nPairs   = 0;
+  int                                  nThreads = 1;
+  std::vector< uint16_t >              offsets;            // within-row offset per entry; the whole map
+  std::vector< std::vector< double > > priv;
+  int                                  nBuffers   = 1;     // number of private CSR copies; see setNumBuffers
+  bool                                 useAtomics = false; // set when nBuffers < nThreads
+  std::vector< int >                   bufferOfThread;     // thread id -> which copy it accumulates into
+
+  // Builds the map against an existing pattern, so there is exactly one definition of what the
+  // CSR pattern is and the two assembly paths cannot drift apart.
+  CSRDirectAssembler( const int* indptr_,
+                      const int* indices_,
+                      int        nnz_,
+                      int        nDof_,
+                      const int* I,
+                      const int* J,
+                      int64_t    nPairs_,
+                      int        nThreads_ )
+    : indptr( indptr_ ),
+      indices( indices_ ),
+      nnz( nnz_ ),
+      nDof( nDof_ ),
+      nPairs( nPairs_ ),
+      nThreads( nThreads_ > 0 ? nThreads_ : 1 )
+  {
+    offsets.resize( nPairs );
+    int64_t tooWide = 0;
+
+#pragma omp parallel for schedule( static ) reduction( + : tooWide )
+    for ( int64_t k = 0; k < nPairs; ++k ) {
+      const int  r     = I[k];
+      const int  start = indptr[r];
+      const int  end   = indptr[r + 1];
+      const int* found = std::lower_bound( indices + start, indices + end, J[k] );
+      if ( found == indices + end || *found != J[k] ) {
+        tooWide += 1; // reported as a build failure below; no entry may be unmapped
+        offsets[k] = 0;
+        continue;
+      }
+      const int64_t off = found - ( indices + start );
+      if ( off > std::numeric_limits< uint16_t >::max() ) {
+        tooWide += 1;
+        offsets[k] = 0;
+        continue;
+      }
+      offsets[k] = static_cast< uint16_t >( off );
+    }
+
+    if ( tooWide > 0 )
+      throw std::runtime_error( "CSRDirectAssembler: entry unmapped, or within-row offset exceeds "
+                                "the 16-bit range (row longer than 65535); a uint32 offset variant "
+                                "is required for this pattern." );
+
+    setNumBuffers( this->nThreads );
+  }
+
+  // Choose how many private CSR copies to keep. nThreads (the default) is the privatised,
+  // synchronisation-free, bit-reproducible mode; anything smaller makes threads share a copy and
+  // synchronise with atomics, trading speed for (nThreads - n) * nnz * 8 bytes.
+  //
+  // Reallocates the buffers, so it is not something to call inside an assembly. The old buffers are
+  // released before the new ones are taken, so shrinking never needs both at once. Consecutive
+  // thread ids are grouped onto the same copy, which keeps a shared copy's writers close together.
+  void setNumBuffers( int n )
+  {
+    if ( n < 1 )
+      n = 1;
+    if ( n > nThreads )
+      n = nThreads;
+
+    nBuffers   = n;
+    useAtomics = ( n < nThreads );
+
+    priv.assign( nBuffers, std::vector< double >() ); // frees the previous buffers first
+    for ( int b = 0; b < nBuffers; ++b )
+      priv[b].assign( nnz, 0.0 );
+
+    bufferOfThread.resize( nThreads );
+    for ( int t = 0; t < nThreads; ++t )
+      bufferOfThread[t] = static_cast< int >( ( static_cast< int64_t >( t ) * nBuffers ) / nThreads );
+  }
+
+  // Scatter a whole VIJ value array through the map. This is the equivalence path used to validate
+  // the addressing against CSRCore::update; the fused path hands each entity's block straight in.
+  void assembleFromVIJ( const double* V, const int* I, double* csr_data )
+  {
+    beginAssembly();
+
+#pragma omp parallel num_threads( nThreads )
+    {
+      const int tid   = omp_get_thread_num();
+      double*   myBuf = priv[bufferOfThread[tid]].data();
+
+      if ( !useAtomics ) {
+#pragma omp for schedule( static )
+        for ( int64_t k = 0; k < nPairs; ++k )
+          myBuf[indptr[I[k]] + offsets[k]] += V[k];
+      }
+      else {
+#pragma omp for schedule( static )
+        for ( int64_t k = 0; k < nPairs; ++k ) {
+          double* dst = myBuf + indptr[I[k]] + offsets[k];
+#pragma omp atomic
+          *dst += V[k];
+        }
+      }
+    }
+
+    reduce( csr_data );
+  }
+
+  // ---- fused path -------------------------------------------------------------------------
+  //
+  // beginAssembly() / scatterBlock() per entity / reduce(). The entity writes its dense nDof x nDof
+  // block into a small thread-local scratch buffer -- which stays in cache -- and scatterBlock
+  // pushes it straight into that thread's private CSR copy. No sizeVIJ-sized value array is ever
+  // materialized, which is the entire point: at 43k DOF that array alone is 12.15 GB.
+  //
+  // Registration gives each entity its slice of the map. rowsOfEntity is derived from I: for local
+  // row a, every pair (a, b) shares the same global row, so the row is I[mapStart + a * nDofE] and
+  // only nDofE values per entity need keeping rather than nDofE^2.
+  std::vector< int64_t >            entityMapStart;  // into offsets
+  std::vector< int64_t >            entityDofStart;  // into entityRows
+  std::vector< int >                entityNDof;
+  std::vector< int >                entityRows;      // global row per local row, concatenated
+  std::vector< std::vector< int > > rowStartScratch; // per thread, size maxNDof
+
+  void registerEntities( const int64_t* mapStarts, const int* nDofs, int nEntities, const int* I )
+  {
+    entityMapStart.assign( mapStarts, mapStarts + nEntities );
+    entityNDof.assign( nDofs, nDofs + nEntities );
+    entityDofStart.resize( nEntities );
+    int64_t total = 0;
+    for ( int e = 0; e < nEntities; ++e ) {
+      entityDofStart[e] = total;
+      total += nDofs[e];
+    }
+    entityRows.resize( total );
+    // The entity block is stored COLUMN-major: initializeVIJContribution writes
+    // I[k] = idcs[k % nDof] and J[k] = idcs[k / nDof], so the row index varies fastest and the
+    // first nDof entries of I are exactly the entity's global row list.
+#pragma omp          parallel for schedule( static )
+    for ( int e = 0; e < nEntities; ++e ) {
+      const int64_t ms = entityMapStart[e];
+      const int     nd = entityNDof[e];
+      for ( int a = 0; a < nd; ++a )
+        entityRows[entityDofStart[e] + a] = I[ms + a];
+    }
+
+    int maxNDof = 0;
+    for ( int e = 0; e < nEntities; ++e )
+      maxNDof = std::max( maxNDof, nDofs[e] );
+    rowStartScratch.assign( nThreads, std::vector< int >( maxNDof, 0 ) );
+  }
+
+  void beginAssembly()
+  {
+    if ( !useAtomics ) {
+      // one copy per thread: each thread clears its own, which is both perfectly parallel and
+      // keeps the pages it will later write on its own NUMA node
+#pragma omp parallel num_threads( nThreads )
+      {
+        double* my = priv[omp_get_thread_num()].data();
+        std::fill( my, my + nnz, 0.0 );
+      }
+             }
+             else {
+      // shared copies: no thread owns one, so clear each with all threads
+      for ( int b = 0; b < nBuffers; ++b ) {
+        double* my = priv[b].data();
+#pragma omp parallel for schedule( static ) num_threads( nThreads )
+        for ( int i = 0; i < nnz; ++i )
+          my[i] = 0.0;
+      }
+    }
+  }
+
+  // Called from inside the entity loop, once per entity, by the thread that computed the block.
+  // With one copy per thread this is race-free by construction; with fewer copies than threads the
+  // writes are made atomic instead (see setNumBuffers).
+  void scatterBlock( int tid, int entity, const double* block ) noexcept
+  {
+    double*       myBuf = priv[bufferOfThread[tid]].data();
+    const int64_t ms    = entityMapStart[entity];
+    const int64_t ds    = entityDofStart[entity];
+    const int     nd    = entityNDof[entity];
+
+    // indptr[row] for each local row, resolved once per entity into a small cache-resident array:
+    // the block is column-major, so the row index varies along the inner loop and the lookup cannot
+    // be hoisted out of it directly.
+    int* __restrict rowStart = rowStartScratch[tid].data();
+    for ( int a = 0; a < nd; ++a )
+      rowStart[a] = indptr[entityRows[ds + a]];
+
+    // Traverse by ROW even though the block is stored column-major. Iterating rows outer confines
+    // all writes of an inner loop to a single CSR row (~8-16 kB, cache-resident once touched) and
+    // pays a stride-nDof read of the block and of the offsets instead; both are small enough to stay
+    // in cache (1.12 MB and 281 kB at nDof = 375), whereas scattered writes across nDof different
+    // CSR rows would not be.
+    //
+    // That is the reasoning, NOT a measurement. An earlier A/B here quoted row-outer at 1562 ms
+    // against 1873 ms column-major; it was withdrawn. The harness sliced each block out of the VIJ
+    // array with numpy, which streamed 3.83 GB and allocated 5328 times, and that alone inverted the
+    // ranking; repeats then showed the scatter varying by +-18% run to run, wider than the gap being
+    // claimed. So the traversal choice is currently justified by the cache argument above and by
+    // nothing else. Anyone reordering these loops should measure it properly first -- with the block
+    // already resident, and with enough repeats to see the variance -- rather than trust this comment.
+    const uint16_t* off0 = offsets.data() + ms;
+
+    if ( !useAtomics ) {
+      double* __restrict my = myBuf; // this thread's own copy: no other writer, so __restrict holds
+      for ( int a = 0; a < nd; ++a ) {
+        double* __restrict row = my + rowStart[a];
+        for ( int b = 0; b < nd; ++b ) {
+          const int64_t k = static_cast< int64_t >( b ) * nd + a;
+          row[off0[k]] += block[k];
+        }
+      }
+    }
+    else {
+      // shared copy: concurrent writers are the point, so no __restrict here, and every update is
+      // atomic. Same traversal, so the only difference against the branch above is the
+      // synchronisation -- which is what makes the two timings comparable.
+      for ( int a = 0; a < nd; ++a ) {
+        double* row = myBuf + rowStart[a];
+        for ( int b = 0; b < nd; ++b ) {
+          const int64_t k   = static_cast< int64_t >( b ) * nd + a;
+          double*       dst = row + off0[k];
+#pragma omp atomic
+          *dst += block[k];
+        }
+      }
+    }
+  }
+
+  void reduce( double* csr_data )
+  {
+    const int nT = nBuffers;
+#pragma omp parallel for schedule( static ) num_threads( nThreads )
+    for ( int i = 0; i < nnz; ++i ) {
+      double s = 0.0;
+      for ( int t = 0; t < nT; ++t )
+        s += priv[t][i];
+      csr_data[i] = s;
+    }
+  }
+
+  // Bytes held by the map plus the private buffers -- the figure to compare against the VIJ array.
+  // Scales with nBuffers, not nThreads, which is the whole point of setNumBuffers.
+  int64_t memoryBytes() const
+  {
+    return static_cast< int64_t >( offsets.size() ) * 2 + static_cast< int64_t >( nBuffers ) * nnz * 8 +
+           static_cast< int64_t >( entityRows.size() ) * 4;
   }
 };

--- a/edelweissfe/numerics/_csrcore.h
+++ b/edelweissfe/numerics/_csrcore.h
@@ -537,7 +537,7 @@ struct CSRDirectAssembler {
     // The entity block is stored COLUMN-major: initializeVIJContribution writes
     // I[k] = idcs[k % nDof] and J[k] = idcs[k / nDof], so the row index varies fastest and the
     // first nDof entries of I are exactly the entity's global row list.
-#pragma omp          parallel for schedule( static )
+#pragma omp parallel for schedule( static )
     for ( int e = 0; e < nEntities; ++e ) {
       const int64_t ms = entityMapStart[e];
       const int     nd = entityNDof[e];
@@ -553,6 +553,9 @@ struct CSRDirectAssembler {
 
   void beginAssembly()
   {
+    // clang-format off
+    // The pinned clang-format version mis-indents the closing brace/else that follow a
+    // #pragma omp block used as an if-statement's compound body; formatted by hand instead.
     if ( !useAtomics ) {
       // one copy per thread: each thread clears its own, which is both perfectly parallel and
       // keeps the pages it will later write on its own NUMA node
@@ -561,8 +564,8 @@ struct CSRDirectAssembler {
         double* my = priv[omp_get_thread_num()].data();
         std::fill( my, my + nnz, 0.0 );
       }
-             }
-             else {
+    }
+    else {
       // shared copies: no thread owns one, so clear each with all threads
       for ( int b = 0; b < nBuffers; ++b ) {
         double* my = priv[b].data();
@@ -571,6 +574,7 @@ struct CSRDirectAssembler {
           my[i] = 0.0;
       }
     }
+    // clang-format on
   }
 
   // Called from inside the entity loop, once per entity, by the thread that computed the block.

--- a/edelweissfe/numerics/csrgenerator.pyx
+++ b/edelweissfe/numerics/csrgenerator.pyx
@@ -48,7 +48,11 @@ cdef class CSRGenerator:
         """This cdef class generates Compressed Sparse Row Matrices from the COO format,
         and offers the possibility to update the matrix without reanalyzing the
         pattern (in contrast to SciPy).
-        Very fast and convenient!
+
+        Legacy, teaching-oriented generator: single-threaded, no memory-layout optimizations. Not
+        used by any solver -- see ``edelweissfe.numerics.csrgeneratorv2.CSRGenerator`` for the
+        parallelized generator every solver actually uses, and ``doc/source/documentation/utils.rst``
+        for how the two relate.
 
         Parameters
         ----------

--- a/edelweissfe/numerics/csrgeneratorv2.pyx
+++ b/edelweissfe/numerics/csrgeneratorv2.pyx
@@ -104,7 +104,7 @@ class AliasedCSRMatrix(csr_matrix):
 
 cdef extern from "_csrcore.h":
     cdef cppclass CSRCore nogil:
-        CSRCore(const int* I, const int* J, long n_pairs, int n_dof) except +
+        CSRCore(const int* I, const int* J, long n_pairs, int n_dof, bint patternOnly) except +
 
         vector[int] indptr
         vector[int] indices
@@ -112,6 +112,22 @@ cdef extern from "_csrcore.h":
         int nDof
 
         void update(const double* V_data, double* csr_data) nogil
+        void releaseGatherMap()
+        bint gatherMapReleased
+        long memoryBytes()
+
+    cdef cppclass CSRDirectAssembler nogil:
+        CSRDirectAssembler(const int* indptr, const int* indices, int nnz, int nDof,
+                           const int* I, const int* J, long nPairs, int nThreads) except +
+
+        void assembleFromVIJ(const double* V, const int* I, double* csr_data) nogil
+        void registerEntities(const long* mapStarts, const int* nDofs, int nEntities, const int* I)
+        void beginAssembly() nogil
+        void scatterBlock(int tid, int entity, const double* block) nogil
+        void reduce(double* csr_data) nogil
+        void setNumBuffers(int n) except +
+        long memoryBytes()
+        int nBuffers
 
 cdef class CSRGenerator:
     """
@@ -123,6 +139,13 @@ cdef class CSRGenerator:
     ----------
     systemMatrix : object
         An object containing COO format data with attributes I, J, and nDof.
+    patternOnly : bool
+        Build only the CSR pattern (``indptr``/``indices``), not the gather map. Halves the sort
+        array and, more importantly, removes the 32-bit limit on the pair count -- ``gather_sources``
+        and ``assembly_ptr`` are int32 indices into the COO list, so a full build refuses more than
+        INT32_MAX pairs. :meth:`updateInPlace` and :meth:`updateCSR` then raise, exactly as after
+        :meth:`releaseGatherMap`. Use it when the pattern is being borrowed by a
+        :class:`DirectCSRAssembler` and nothing will gather.
     """
 
     cdef CSRCore* core
@@ -134,7 +157,7 @@ cdef class CSRGenerator:
         if self.core != NULL:
             del self.core
 
-    def __init__(self, systemMatrix):
+    def __init__(self, systemMatrix, bint patternOnly=False):
         # Ensure int32 dtype regardless of the source array's dtype.
         # dofmanager.py already produces np.intc arrays, but we guard here
         # in case CSRGenerator is called from outside the standard path.
@@ -147,7 +170,7 @@ cdef class CSRGenerator:
 
         # 1. Run C++ Core
         with nogil:
-            self.core = new CSRCore(&I[0], &J[0], self.nCooPairs, nDof)
+            self.core = new CSRCore(&I[0], &J[0], self.nCooPairs, nDof, patternOnly)
 
         cdef int* ptr_indptr = self.core.indptr.data()
         cdef int* ptr_indices = self.core.indices.data()
@@ -176,6 +199,44 @@ cdef class CSRGenerator:
         # AliasedCSRMatrix's docstring.
         self.csrMatrix._locked = True
 
+    @property
+    def memoryBytes(self):
+        """Bytes held by the CSR pattern, the gather map and the CSR data array.
+
+        The counterpart to :attr:`DirectCSRAssembler.memoryBytes`, on the same basis -- what the
+        object owns. The dominant term is the gather map's ``gather_sources``, one int32 per COO
+        pair, which is what the direct path replaces with a uint16 offset per pair.
+
+        Neither figure counts the VIJ value array or the ``I``/``J`` index arrays: those belong to
+        the DofManager, and ``I``/``J`` are needed by both paths.
+        """
+        return self.core.memoryBytes() + 8 * <long> self.core.nnz
+
+    @property
+    def nnz(self):
+        """Number of stored entries in the CSR pattern."""
+        return self.core.nnz
+
+    @property
+    def gatherMapReleased(self):
+        """True once :meth:`releaseGatherMap` has been called and this generator can no longer gather."""
+        return bool(self.core.gatherMapReleased)
+
+    def releaseGatherMap(self):
+        """Give back the gather map, keeping the CSR pattern -- and give up the ability to gather.
+
+        ``gather_sources`` is one int32 per COO pair, so the map is by far the largest thing this
+        object holds (6.69 GiB at 43,350 DOF against 0.80 GiB for the pattern and the data array).
+        A solver assembling directly into CSR borrows only the pattern, so holding the map would
+        cancel most of what the direct path saves.
+
+        After this call :meth:`updateInPlace` and :meth:`updateCSR` raise. That is deliberate: the
+        alternative is a ``nogil`` loop reading freed vectors, and a matrix that is quietly wrong is
+        worse than one that is loudly unavailable. :attr:`csrMatrix` and the pattern stay valid and
+        usable, and :attr:`memoryBytes` drops accordingly.
+        """
+        self.core.releaseGatherMap()
+
     def updateInPlace(self, double[:] V):
         """
         Update the values of the CSR matrix in-place based on the input vector V.
@@ -198,6 +259,14 @@ cdef class CSRGenerator:
         AliasedCSRMatrix
             A live view of the internal CSR matrix (not a copy).
         """
+
+        if self.core.gatherMapReleased:
+            raise RuntimeError(
+                "CSRGenerator.updateInPlace on a generator with no gather map: it was either built "
+                "with patternOnly=True or gave the map back via releaseGatherMap(), and can only "
+                "supply the CSR pattern now. Assemble through the DirectCSRAssembler that borrowed "
+                "the pattern, or build a generator that keeps its map."
+            )
 
         cdef double* d_ptr = &self.data_view[0]
         cdef double* v_ptr = &V[0]
@@ -228,3 +297,136 @@ cdef class CSRGenerator:
 
         self.updateInPlace(V)
         return self.csrMatrix.copy()
+
+
+cdef class DirectCSRAssembler:
+    """Scatters entity blocks straight into a CSR data array, with no VIJ staging array.
+
+    The alternative to :class:`CSRGenerator`'s stage-then-gather. It borrows an existing pattern
+    rather than deriving its own, so there is exactly one definition of the CSR pattern and the two
+    paths cannot drift apart -- and :meth:`assembleFromVIJ` exists so the addressing can be checked
+    against ``CSRGenerator.updateCSR`` on real models rather than argued about.
+
+    Reduction defaults to one private CSR copy per thread -- no synchronisation and a fixed summation
+    order, so results are bit-reproducible, at ``nThreads * nnz * 8`` bytes. :meth:`setNumBuffers`
+    trades that memory for atomics; see the header's design note for why the earlier "atomics are
+    1.57-2.13x slower" figure does not settle the question.
+
+    Parameters
+    ----------
+    generator
+        A :class:`CSRGenerator` whose pattern is borrowed. It must outlive this object.
+    systemMatrix
+        The VIJ system matrix supplying the ``I``/``J`` index arrays the map is built from.
+    numThreads
+        Threads used for the map build, the scatter and the reduction.
+    """
+
+    cdef CSRDirectAssembler* asm_
+    cdef object _generator          # kept alive: the pattern is borrowed, not owned
+    cdef object _I
+    cdef public object csrMatrix
+    cdef double[:] data_view
+    cdef long nCooPairs
+
+    def __dealloc__(self):
+        if self.asm_ != NULL:
+            del self.asm_
+
+    def __init__(self, generator, systemMatrix, int numThreads=1):
+        cdef int[::1] I = np.asarray(systemMatrix.I, dtype=np.intc)  # noqa
+        cdef int[::1] J = np.asarray(systemMatrix.J, dtype=np.intc)
+        self._generator = generator
+        self._I = np.asarray(I)
+        self.nCooPairs = len(I)
+
+        self.csrMatrix = generator.csrMatrix
+        self.data_view = self.csrMatrix.data
+
+        cdef int[::1] indptr = np.asarray(self.csrMatrix.indptr, dtype=np.intc)
+        cdef int[::1] indices = np.asarray(self.csrMatrix.indices, dtype=np.intc)
+        cdef int nnz = indices.shape[0]
+        cdef int nDof = int(systemMatrix.nDof)
+
+        with nogil:
+            self.asm_ = new CSRDirectAssembler(&indptr[0], &indices[0], nnz, nDof,
+                                               &I[0], &J[0], self.nCooPairs, numThreads)
+
+    @property
+    def memoryBytes(self):
+        """Bytes held by the offset map plus the private buffers."""
+        return self.asm_.memoryBytes()
+
+    @property
+    def numBuffers(self):
+        """How many private CSR copies are currently held. Equal to ``numThreads`` unless changed."""
+        return self.asm_.nBuffers
+
+    def setNumBuffers(self, int n):
+        """Set how many private CSR copies to keep, reallocating them.
+
+        ``n == numThreads`` is the default: one copy per thread, no synchronisation, fixed summation
+        order and therefore bit-reproducible results. Any smaller ``n`` makes threads share a copy
+        and synchronise the scatter with atomics, saving ``(numThreads - n) * nnz * 8`` bytes at the
+        cost of reproducibility -- ``n == 1`` is the fully atomic case. Values are clamped to
+        ``[1, numThreads]``.
+
+        Not to be called during an assembly: it releases and reallocates the buffers.
+        """
+        self.asm_.setNumBuffers(n)
+
+    def assembleFromVIJ(self, double[::1] V):
+        """Scatter a VIJ value array into CSR through the map, and return the CSR matrix.
+
+        Equivalence path for validation and measurement. The fused assembly hands each entity's
+        block in directly and never builds ``V``.
+        """
+        cdef int[::1] I = self._I
+        cdef double[:] out = self.data_view
+        with nogil:
+            self.asm_.assembleFromVIJ(&V[0], &I[0], &out[0])
+        return self.csrMatrix
+
+    def registerEntities(self, long[::1] mapStarts, int[::1] nDofs):
+        """Give each entity its slice of the offset map, once per connectivity change.
+
+        ``mapStarts[e]`` is entity e's offset into the VIJ ordering -- the same value the DofManager
+        already records in ``idcsOfHigherOrderEntitiesInVIJ`` -- and ``nDofs[e]`` its local DOF count.
+        """
+        cdef int[::1] I = self._I
+        self.asm_.registerEntities(&mapStarts[0], &nDofs[0], mapStarts.shape[0], &I[0])
+
+    @property
+    def corePointer(self):
+        """Address of the underlying ``CSRDirectAssembler``, for a threaded caller in another extension.
+
+        EdelweissMeshfree's particle kernel calls ``scatterBlock`` from inside its ``prange``, which
+        cannot go through Python. It re-declares the C++ class (from ``edelweissfe.numerics.get_include()``)
+        and casts this address back, so the scatter -- including the column-major traversal and its
+        measured loop order -- exists in exactly one place.
+
+        The assembler must outlive any caller holding this.
+        """
+        return <size_t> self.asm_
+
+    def beginAssembly(self):
+        """Zero the private buffers. Call once before the entity loop."""
+        with nogil:
+            self.asm_.beginAssembly()
+
+    def scatterBlock(self, int tid, int entity, double[::1] block):
+        """Scatter one entity's dense block from a scratch buffer into thread ``tid``'s private CSR.
+
+        Race-free by construction. Intended to be called from inside a threaded entity loop; this
+        Python-level binding exists for testing and for the constraint contributions, which are
+        assembled sequentially and account for under 2% of runtime.
+        """
+        with nogil:
+            self.asm_.scatterBlock(tid, entity, &block[0])
+
+    def reduce(self):
+        """Sum the private buffers into the CSR matrix and return it."""
+        cdef double[:] out = self.data_view
+        with nogil:
+            self.asm_.reduce(&out[0])
+        return self.csrMatrix

--- a/edelweissfe/numerics/csrgeneratorv2.pyx
+++ b/edelweissfe/numerics/csrgeneratorv2.pyx
@@ -393,6 +393,11 @@ cdef class DirectCSRAssembler:
         ``mapStarts[e]`` is entity e's offset into the VIJ ordering -- the same value the DofManager
         already records in ``idcsOfHigherOrderEntitiesInVIJ`` -- and ``nDofs[e]`` its local DOF count.
         """
+        if mapStarts.shape[0] != nDofs.shape[0]:
+            raise ValueError(
+                "registerEntities: mapStarts and nDofs must have the same length (one entry per "
+                "entity), got {:} and {:}".format(mapStarts.shape[0], nDofs.shape[0])
+            )
         cdef int[::1] I = self._I
         self.asm_.registerEntities(&mapStarts[0], &nDofs[0], mapStarts.shape[0], &I[0])
 

--- a/tests/test_direct_csr_assembler.py
+++ b/tests/test_direct_csr_assembler.py
@@ -78,6 +78,19 @@ def test_assembleFromVIJ_matches_the_staged_generator_bit_for_bit():
     np.testing.assert_array_equal(directResult.toarray(), staged.toarray())
 
 
+def test_registerEntities_rejects_mismatched_mapStarts_and_nDofs_lengths():
+    """Both arrays are read by raw pointer on the C++ side, indexed by the same entity count -- a
+    length mismatch would read past the end of the shorter one rather than raising."""
+
+    systemMatrix, V = _syntheticSystem()
+    generator = CSRGenerator(systemMatrix)
+    generator.updateCSR(V)
+    direct = DirectCSRAssembler(generator, systemMatrix, numThreads=1)
+
+    with pytest.raises(ValueError):
+        direct.registerEntities(np.array([0, 4, 8], dtype=np.int64), np.array([2, 2], dtype=np.intc))
+
+
 def test_fused_scatter_reduce_path_matches_the_staged_generator():
     """The path a threaded entity loop actually uses: registerEntities() once, then
     beginAssembly()/scatterBlock() per entity/reduce() -- rather than assembleFromVIJ's one-shot COO

--- a/tests/test_direct_csr_assembler.py
+++ b/tests/test_direct_csr_assembler.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#  ---------------------------------------------------------------------
+#
+#  _____    _      _              _         _____ _____
+# | ____|__| | ___| |_      _____(_)___ ___|  ___| ____|
+# |  _| / _` |/ _ \ \ \ /\ / / _ \ / __/ __| |_  |  _|
+# | |__| (_| |  __/ |\ V  V /  __/ \__ \__ \  _| | |___
+# |_____\__,_|\___|_| \_/\_/ \___|_|___/___/_|   |_____|
+#
+#
+#  Unit of Strength of Materials and Structural Analysis
+#  University of Innsbruck,
+#  2017 - today
+#
+#  Matthias Neuner matthias.neuner@uibk.ac.at
+#
+#  This file is part of EdelweissFE.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2.1 of the License, or (at your option) any later version.
+#
+#  The full text of the license can be found in the file LICENSE.md at
+#  the top level directory of EdelweissFE.
+#  ---------------------------------------------------------------------
+"""``DirectCSRAssembler``'s own docstring names ``assembleFromVIJ`` the equivalence path meant to
+check its addressing against ``CSRGenerator.updateCSR`` "on real models rather than argued about" --
+but no such test existed anywhere in this codebase. This pins that comparison, plus the fused
+begin/scatter/reduce path a threaded entity loop actually uses, against a small synthetic COO system
+with duplicate (row, col) pairs (multiple "entities" contributing to the same DOF pair), which is
+exactly the case that would expose a wrong offset into a shared CSR entry.
+"""
+
+import numpy as np
+import pytest
+
+from edelweissfe.numerics.csrgeneratorv2 import CSRGenerator, DirectCSRAssembler
+
+
+class _SystemMatrix:
+    """Minimal stand-in for the DofManager-provided VIJ system matrix: just I/J/nDof."""
+
+    def __init__(self, I, J, nDof):  # noqa: E741
+        self.I = np.asarray(I, dtype=np.intc)  # noqa: E741
+        self.J = np.asarray(J, dtype=np.intc)
+        self.nDof = nDof
+
+
+def _syntheticSystem():
+    """Two overlapping 2x2 "element" blocks (DOFs {0, 1} and {1, 2}) plus one isolated 1x1 block
+    (DOF 3), so DOF 1 receives contributions from both elements at the same (1, 1) CSR entry -- the
+    case that actually exercises whether the two assembly paths agree, not just whether they run.
+
+    Concatenated **column-major per entity** (row varies fastest within each entity's block) --
+    matching ``CSRDirectAssembler::registerEntities``'s own documented convention, so this same
+    array can seed both the plain COO-scatter test and the fused per-entity one.
+    """
+
+    I = [0, 1, 0, 1, 1, 2, 1, 2, 3]  # noqa: E741
+    J = [0, 0, 1, 1, 1, 1, 2, 2, 3]
+    V = np.array([4.0, 1.0, 1.0, 5.0, 2.0, 0.5, 0.5, 3.0, 7.0])
+    nDof = 4
+    return _SystemMatrix(I, J, nDof), V
+
+
+def test_assembleFromVIJ_matches_the_staged_generator_bit_for_bit():
+    systemMatrix, V = _syntheticSystem()
+
+    generator = CSRGenerator(systemMatrix)
+    staged = generator.updateCSR(V)
+
+    direct = DirectCSRAssembler(generator, systemMatrix, numThreads=1)
+    directResult = direct.assembleFromVIJ(V)
+
+    assert directResult is generator.csrMatrix
+    np.testing.assert_array_equal(directResult.toarray(), staged.toarray())
+
+
+def test_fused_scatter_reduce_path_matches_the_staged_generator():
+    """The path a threaded entity loop actually uses: registerEntities() once, then
+    beginAssembly()/scatterBlock() per entity/reduce() -- rather than assembleFromVIJ's one-shot COO
+    scatter. Same synthetic system, grouped into its three entities (two 2x2 blocks sharing DOF 1,
+    one 1x1 block), each entity's dense block scattered in the column-major order
+    ``_syntheticSystem`` already lays out."""
+
+    systemMatrix, V = _syntheticSystem()
+
+    generator = CSRGenerator(systemMatrix)
+    staged = generator.updateCSR(V)
+
+    direct = DirectCSRAssembler(generator, systemMatrix, numThreads=1)
+
+    # mapStarts[e]: entity e's offset into the VIJ ordering above; nDofs[e]: its local DOF count.
+    mapStarts = np.array([0, 4, 8], dtype=np.int64)
+    nDofs = np.array([2, 2, 1], dtype=np.intc)
+    direct.registerEntities(mapStarts, nDofs)
+
+    direct.beginAssembly()
+    direct.scatterBlock(0, 0, V[0:4].copy())
+    direct.scatterBlock(0, 1, V[4:8].copy())
+    direct.scatterBlock(0, 2, V[8:9].copy())
+    fusedResult = direct.reduce()
+
+    np.testing.assert_array_equal(fusedResult.toarray(), staged.toarray())
+
+
+def test_releaseGatherMap_leaves_the_pattern_usable_but_forbids_further_gathering():
+    systemMatrix, V = _syntheticSystem()
+
+    generator = CSRGenerator(systemMatrix)
+    generator.updateCSR(V)
+    patternBefore = generator.csrMatrix.indices.copy()
+
+    generator.releaseGatherMap()
+    assert generator.gatherMapReleased
+
+    np.testing.assert_array_equal(generator.csrMatrix.indices, patternBefore)
+    with pytest.raises(RuntimeError):
+        generator.updateInPlace(V)
+
+
+def test_patternOnly_generator_builds_the_same_pattern_as_a_full_one():
+    systemMatrix, V = _syntheticSystem()
+
+    full = CSRGenerator(systemMatrix)
+    patternOnly = CSRGenerator(systemMatrix, patternOnly=True)
+
+    np.testing.assert_array_equal(patternOnly.csrMatrix.indptr, full.csrMatrix.indptr)
+    np.testing.assert_array_equal(patternOnly.csrMatrix.indices, full.csrMatrix.indices)
+    assert patternOnly.gatherMapReleased
+
+    with pytest.raises(RuntimeError):
+        patternOnly.updateInPlace(V)


### PR DESCRIPTION
## Summary
Two independent, additive pieces of numerics infrastructure -- neither is wired into any solver's default path yet:

**`DirectCSRAssembler`** (`edelweissfe/numerics/_csrcore.h`, `csrgeneratorv2.pyx`): scatters entity blocks straight into a CSR data array, bypassing the VIJ staging array a solver currently builds before every gather. At scale that staging array is the dominant single allocation (12+ GiB at 43,350 DOF) -- bypassing it is the entire point. It borrows an existing `CSRGenerator`'s pattern rather than deriving its own, so there is exactly one definition of the CSR pattern shared by both assembly paths, and it exposes:
- `assembleFromVIJ`: a one-shot COO-equivalence path, for validating the addressing against `CSRGenerator`.
- `beginAssembly`/`scatterBlock`/`reduce`: the fused path a threaded entity loop calls directly, with a `corePointer` property so a downstream package's own threaded kernel (EdelweissMeshfree's particle loop) can call `scatterBlock` without going through Python.

`CSRGenerator` gained `patternOnly=True` (skips the gather map entirely -- halves memory and lifts the 32-bit COO-pair-count cap the gather map's own index arrays impose) and `releaseGatherMap()` (give the map back once a `DirectCSRAssembler` has borrowed the pattern).

**`blockamg` AMG hierarchy sparsification/lumping** (`hierarchyDropTol`, `hierarchyDropLumping`): build each field's AMG hierarchy from a sparsified copy of its diagonal block, dropping numerically negligible off-diagonal entries before the hierarchy build. Only the preconditioner is affected -- the operator the Krylov method applies is untouched, so this cannot change the converged solution, only the iteration count. Measured up to **1.81x on the linear solve** on operators with many near-zero entries (meshfree RKPM discretizations are the motivating case). Both off by default. Also skips the off-diagonal split step entirely when there's only one field (pure no-op removal in that case).

## Provenance and scope
This was bundled with the (unrelated) `fix/timestepper-zero-increment-honesty` bugfix on one very old branch; see [#90](https://github.com/Edelweiss-Numerics/EdelweissFE/pull/90), now cleaned up to just that fix. This is the other half, extracted and rebuilt directly on top of current `next_v26.11` (which already includes `#95`'s topology pipeline -- this branch's own real fork point, once its dead ancestry is stripped).

Neither piece is consumed by any solver yet. `DirectCSRAssembler`'s intended first consumer is EdelweissMeshfree's particle assembly, which needs exactly this API (`get_include()`, `corePointer`, `scatterBlock`) and was previously stripped out of a Meshfree PR specifically because this EdelweissFE-side dependency didn't exist on trunk. Landing this closes that gap; wiring it up on the Meshfree side is separate follow-up work.

## Test coverage
**The source branch shipped this with zero dedicated tests.** `DirectCSRAssembler`'s own docstring names `assembleFromVIJ` "the equivalence path ... to validate the addressing ... on real models rather than argued about," but no such test existed anywhere in the codebase. Added `tests/test_direct_csr_assembler.py`:
- `assembleFromVIJ` vs. the staged `CSRGenerator`, on a synthetic COO system with a duplicate-entry CSR cell (two "entities" both contributing to the same DOF pair) -- the case that actually exercises whether the addressing agrees, not just whether it runs.
- The fused `registerEntities`/`beginAssembly`/`scatterBlock`/`reduce` path against the same reference, using the header's own documented column-major per-entity block convention.
- `releaseGatherMap` and `patternOnly`.

Also manually verified (not committed as a test, just spot-checked on xeon) that `assembleFromVIJ` agrees with the staged reference at `numThreads` = 1, 2, and 4.

## Test plan
- [x] `pre-commit` clean on every touched/added file
- [x] Builds cleanly on xeon (`marmotelement`, `csrgeneratorv2`, `pardiso`, `amgcl`; only the pre-existing optional `panuapardiso`/`klu` gaps, missing system headers, tolerated by this project's `optional_build_ext`)
- [x] `python -m pytest` (full suite, x9 and xeon): 313 passed, 5 pre-existing failures reproduced identically on unmodified `next_v26.11`, unrelated (`tests/`-not-in-CI drift, same class as [#93](https://github.com/Edelweiss-Numerics/EdelweissFE/issues/93))
- [x] `run_tests_edelweissfe ./testfiles/edelweiss-only/` (xeon): 2 pre-existing failures (`MeshPlot`/latex, `NEDParallel`/`OMP_NUM_THREADS>1`), 0 new
- [x] `run_tests_edelweissfe ./testfiles/marmot/` (xeon, 114 ran): 2 pre-existing latex failures, 0 new

🤖 Generated with [Claude Code](https://claude.com/claude-code)