### PR TITLE
feat(restart): make restart AMR-aware by persisting topologyHistory

### DIFF
--- a/edelweissfe/models/femodel.py
+++ b/edelweissfe/models/femodel.py
@@ -41,7 +41,7 @@ from edelweissfe.config.phenomena import getFieldSize, phenomena
 from edelweissfe.fields.nodefield import NodeField
 from edelweissfe.journal.journal import Journal
 from edelweissfe.models.modelchange import ModelChange, TopologyRecord, coalesce
-from edelweissfe.utils.exceptions import TopologyError
+from edelweissfe.utils.exceptions import RestartError, TopologyError
 from edelweissfe.utils.performancetiming import timeit
 from edelweissfe.variables.fieldvariable import FieldVariable
 from edelweissfe.variables.scalarvariable import ScalarVariable
@@ -905,6 +905,21 @@ class FEModel:
             for entryName, entryValues in restartData.items():
                 constraintGroup.create_dataset(entryName, data=entryValues)
 
+        # The ordered record of every applied model-modifier decision (e.g. AMR refinements). A
+        # resumed run replays these through the modifiers' own apply() -- see readRestart and
+        # replayTopologyHistory -- rather than serializing the resulting topology directly, so there
+        # is exactly one code path that mutates topology, live or replayed.
+        historyGroup = f.create_group("topologyHistory")
+        historyGroup.attrs["count"] = len(self.topologyHistory)
+        for index, record in enumerate(self.topologyHistory):
+            recordGroup = historyGroup.create_group("{:06d}".format(index))
+            recordGroup.attrs["modifier"] = record.modifier
+            recordGroup.attrs["roundNumber"] = record.roundNumber
+            recordGroup.attrs["time"] = record.time
+            recordGroup.attrs["fingerprint"] = record.fingerprint
+            for entryName, entryValues in record.plan.items():
+                recordGroup.create_dataset(entryName, data=entryValues)
+
     def readRestart(self, restartFile: h5py.File):
         """Read the state of the model from a restart checkpoint written by :meth:`writeRestart`.
 
@@ -921,6 +936,25 @@ class FEModel:
 
         self.time = f.attrs["time"]
 
+        # Must run before every restore below: replaying the topology history can materialize
+        # elements/nodes a plain rebuild from the .inp file cannot reproduce (e.g. AMR-refined
+        # children) -- the node-field and element-statevar restores that follow address elements by
+        # label and would silently miss anything not already in self.elements/self.nodeFields yet.
+        records = []
+        historyGroup = f["topologyHistory"]
+        for index in range(int(historyGroup.attrs["count"])):
+            recordGroup = historyGroup["{:06d}".format(index)]
+            records.append(
+                TopologyRecord(
+                    modifier=str(recordGroup.attrs["modifier"]),
+                    roundNumber=int(recordGroup.attrs["roundNumber"]),
+                    time=float(recordGroup.attrs["time"]),
+                    plan={entryName: values[:] for entryName, values in recordGroup.items()},
+                    fingerprint=str(recordGroup.attrs["fingerprint"]),
+                )
+            )
+        self.replayTopologyHistory(records)
+
         for nf in self.nodeFields.values():
             for entryName, entryValues in nf._values.items():
                 nf[entryName][:] = f["nodeFields"][nf.name][entryName]
@@ -928,11 +962,19 @@ class FEModel:
         for name, scalarVariable in self.scalarVariables.items():
             scalarVariable.value = f["scalarVariables"].attrs[name]
 
-        for elNumber, element in self.elements.items():
-            elementKey = str(elNumber)
-            if elementKey not in f["elements"]:
-                continue
-            element.setStateVars(f["elements"][elementKey][:])
+        # One uniform loop, by element number, with no skip set and nothing swallowed -- sound only
+        # because the replay above reproduces the original numbering exactly, verified round by
+        # round via each record's own fingerprint. A missing element here means the replayed model
+        # does not match the one checkpointed, which must be reported, not silently skipped.
+        for elementKey, stateVars in f["elements"].items():
+            elNumber = int(elementKey)
+            element = self.elements.get(elNumber)
+            if element is None:
+                raise RestartError(
+                    "the checkpoint holds state for element {:}, which does not exist after the "
+                    "topology replay -- the replayed model does not match the one checkpointed".format(elNumber)
+                )
+            element.setStateVars(stateVars[:])
 
         for name, constraint in self.constraints.items():
             if name not in f["constraints"]:

--- a/tests/test_restart_integration.py
+++ b/tests/test_restart_integration.py
@@ -152,6 +152,92 @@ def test_restart_resume_matches_uninterrupted_reference(tmp_path, linsolver):
     np.testing.assert_allclose(resumedU, referenceU, atol=1e-10)
 
 
+_AMR_MATERIAL_AND_MESH = """
+*material, name=linearelastic, id=mat
+30000, 0.15
+
+*section, name=sec, material=mat, type=solid
+all
+
+*modelGenerator, generator=boxGen, name=gen
+nX      =1
+nY      =1
+nZ      =1
+lX      =1
+lY      =1
+lZ      =1
+elType  =C3D20
+
+*modelModifier, type=hAdaptivity, name=amr
+>>marker, type=fieldOutput, fieldOutput=stressForAMR, operator='>', threshold=300.0
+maxLevel=1
+
+*job, name=amrRestartTestJob, domain=3d
+*solver, solver=NIST, name=theSolver
+*fieldOutput
+>>perNode, elSet=all, field=displacement, result=U, name=U
+>>perElement, elSet=all, result=stress, quadraturePoint=0:27, name=stressForAMR, f(x)='np.abs(x)'
+"""
+
+
+def _amrStep(maxNumInc) -> str:
+    # A single 1x1x1 C3D20 block, pushed on its right face against a fixed left face -- stress
+    # crosses the marker's threshold partway through, refining 1 -> 8 active elements mid-step (not
+    # at model setup, so this actually exercises replay -- unlike an initialOnly marker, which would
+    # refine identically on every fresh rebuild regardless of whether restart's replay mechanism
+    # works at all; see tests/test_hadaptivity_restart.py for the initialOnly-marker, lower-level
+    # round-trip instead).
+    return f"""
+*step, solver=theSolver
+maxInc=0.02, minInc=1e-6, maxNumInc={maxNumInc}, maxIter=25, stepLength=1
+>>options, name=theSolver, extrapolation=off
+>>dirichlet, name=fixLeft, nSet=gen_left, field=displacement, 1=0.0
+>>dirichlet, name=fixBottomLeftFront, nSet=gen_bottomLeftFront, field=displacement, 2=0.0, 3=0.0
+>>dirichlet, name=fixBottomLeftBack, nSet=gen_bottomLeftBack, field=displacement, 2=0.0
+>>dirichlet, name=pushRight, nSet=gen_right, field=displacement, 1=-0.1
+"""
+
+
+def test_restart_resume_matches_uninterrupted_reference_with_amr(tmp_path):
+    """The gap #97 shipped without: AMR-refined topology can't be reconstructed from the .inp file,
+    so a checkpoint records FEModel.topologyHistory (the refinement decisions) instead, and a
+    resumed run replays them through hAdaptivity's own apply() before restoring node/element state.
+    This is the actual read/write of that history through a real checkpoint file -- the lower-level
+    replayTopologyHistory() round-trip in test_hadaptivity_restart.py never touches an HDF5 file.
+    """
+
+    fullPath = tmp_path / "full.inp"
+    fullPath.write_text(_AMR_MATERIAL_AND_MESH + _amrStep(maxNumInc=10000))
+    referenceModel = _runInputFile(fullPath)
+    referenceU = referenceModel.nodeFields["displacement"]["U"].copy()
+    assert len(referenceModel.elements) > 1, "the stress marker never triggered a refinement"
+
+    checkpointBaseName = tmp_path / "ckpt"
+
+    truncatedPath = tmp_path / "truncated.inp"
+    truncatedPath.write_text(
+        _AMR_MATERIAL_AND_MESH + f"\n*output, type=restart, name=restartwriter\n"
+        f"writeInterval=1, baseName={checkpointBaseName}, numberOfFilesToKeep=3\n"
+        + _amrStep(maxNumInc=6)  # deliberately too low: truncates before the step finishes
+    )
+    truncatedModel = _runInputFile(truncatedPath)
+    # the truncation point must be past the refinement, or this test would not exercise replay at
+    # all -- resuming an unrefined checkpoint doesn't touch the new code paths this is meant to pin.
+    assert len(truncatedModel.elements) > 1, "truncated too early: refinement had not happened yet"
+    assert truncatedModel.time < 1.0, "the step already finished within maxNumInc -- not a real truncation"
+
+    checkpoint = _mostRecentCheckpoint(tmp_path)
+
+    resumePath = tmp_path / "resume.inp"
+    resumePath.write_text(_AMR_MATERIAL_AND_MESH + f"\n*restart, readFrom={checkpoint}\n" + _amrStep(maxNumInc=10000))
+    resumedModel = _runInputFile(resumePath)
+    resumedU = resumedModel.nodeFields["displacement"]["U"]
+
+    assert set(resumedModel.elements.keys()) == set(referenceModel.elements.keys())
+    assert set(resumedModel.nodes.keys()) == set(referenceModel.nodes.keys())
+    np.testing.assert_allclose(resumedU, referenceU, atol=1e-10)
+
+
 def test_restart_ensight_output_continues_across_resume(tmp_path):
     """Found via a real end-to-end validation run (AnchorPryOut): a resumed run's Ensight output
     used to restart its transient sequence numbering from zero -- since a fresh OutputManager


### PR DESCRIPTION
## Summary
The gap left after `#95`/`#97`: `FEModel.topologyHistory` (every applied model-modifier decision, e.g. AMR refinements) was recorded and replayable in-memory, but `writeRestart`/`readRestart` never actually wrote or read it, so resuming a checkpoint from a run that had refined would silently lose the refined topology.

- `writeRestart` now serializes `topologyHistory` (one group per record: modifier name, round number, time, its own encoded plan, and the resulting `topologyFingerprint`) alongside the existing node-field/element/scalar-variable/constraint state.
- `readRestart` replays it via the model's own `replayTopologyHistory()` **before** restoring any other state, since replay can materialize elements/nodes a plain `.inp` rebuild cannot reproduce, and the node-field/element-statevar restores that follow address elements by label.
- Element state restore is now a strict loop over the checkpoint's own element keys, raising if a checkpointed element does not exist after replay, rather than silently skipping it -- sound only because the replay reproduces the original numbering exactly, verified round by round via each record's own fingerprint. Previously this was a lenient skip, which was only correct because nothing could materialize elements not already in the rebuilt model.

## Provenance
This was already implemented and tested once, on `feat/topology-pipeline` (commit `5850147a`) -- but that branch's restart serialization was deliberately excluded from `#95`'s transplant, since restart didn't exist on trunk yet at the time. The in-memory replay machinery it depends on (`topologyHistory`, `replayTopologyHistory`, `restoreDecisionState`) already landed via `#95` and is already fully tested (`tests/test_hadaptivity_restart.py`); only the actual HDF5 serialization was missing. Re-derived directly against current trunk's more-evolved `recordTopologyChange`/`replayTopologyHistory` (which gained a `time` param and moved `notifyModelChanged` inside itself since `5850147a` was written) -- not a straight port of the old diff, which no longer applies cleanly given how much independent evolution happened in between.

## Test plan
- [x] `pre-commit` clean
- [x] Existing restart/topology suites unaffected: `test_femodel_restart.py`, `test_hadaptivity_restart.py`, `test_topology_pipeline.py`, `test_restart_output_manager.py`, `test_adaptivetimestepper_restart.py` -- 59-64 passed depending on selection, 0 regressions
- [x] New test: `tests/test_restart_integration.py::test_restart_resume_matches_uninterrupted_reference_with_amr` -- a real `.inp`-driven round trip through an actual checkpoint file (unlike `test_hadaptivity_restart.py`'s `replayTopologyHistory()` round-trip, which never touches HDF5): a C3D20 block whose stress-based marker refines mid-step, truncated and resumed, asserting the resumed run's element/node sets and displacement field match an uninterrupted reference
- [x] `python -m pytest` (full suite, x9 and xeon): 333 passed, 4 pre-existing failures reproduced identically on unmodified `next_v26.11` (`tests/`-not-in-CI drift, same class as [#93](https://github.com/Edelweiss-Numerics/EdelweissFE/issues/93))
- [x] `run_tests_edelweissfe ./testfiles/edelweiss-only/` (xeon): 2 pre-existing failures (`MeshPlot`/latex, `NEDParallel`/`OMP_NUM_THREADS>1`), 0 new
- [x] `run_tests_edelweissfe ./testfiles/marmot/` (xeon, full suite): 2 pre-existing latex failures, 0 new

🤖 Generated with [Claude Code](https://claude.com/claude-code)