### PR TITLE
fix(config): read the *updateConfiguration dataline payload under its actual key

### DIFF
--- a/edelweissfe/config/configurator.py
+++ b/edelweissfe/config/configurator.py
@@ -52,7 +52,7 @@ def updateConfiguration(newConfiguration, jobInfo, journal):
     if configurationType not in jobInfo:
         raise KeyError("configuration type {:} invalid".format(configurationType))
 
-    settings = convertLinesToStringDictionary(newConfiguration["data"])
+    settings = convertLinesToStringDictionary(newConfiguration["datalines"])
     for key, val in settings.items():
         if key not in jobInfo[configurationType]:
             raise KeyError("configuration type {:}/{:} invalid".format(configurationType, key))


### PR DESCRIPTION
## Problem

`*updateConfiguration` is completely non-functional. Every use raises:

```
KeyError: 'data'
  File "edelweissfe/config/configurator.py", line 55, in updateConfiguration
    settings = convertLinesToStringDictionary(newConfiguration["data"])
```

`UpdateConfigurationSchema` declares its dataline payload as

```python
datalines: list | None = datalineField(description="keyword arguments", required=True)
```

so the parsed keyword exposes it under `datalines` — the key every other consumer uses
(`helpers/inputfilehelpers.py`, `generators/abqmodelconstructor.py`, `_cli/_edelweissfe.py`).
`configurator.py` still read `["data"]`, a leftover from before the input-language registry refactor.

## Why it matters

`*updateConfiguration` is the **only** way to change the convergence tolerances
(`fieldCorrectionTolerance`, `fluxResidualTolerance`, `fluxResidualToleranceAlternative`) from an
input file instead of editing `config/phenomena.py`. With it dead, no input-driven tolerance study
was possible.

## Fix

One line:

```diff
-    settings = convertLinesToStringDictionary(newConfiguration["data"])
+    settings = convertLinesToStringDictionary(newConfiguration["datalines"])
```

## Verification

Manual, on the anchor pry-out model:

- **Before:** any `*updateConfiguration` block aborts the run with `KeyError: 'data'`.
- **After:** the journal reports each setting and the solver uses the new value, e.g.

```
Setting fluxResidualTolerance/displacement to 0.005          configuration
Setting fluxResidualTolerance/nonlocal damage to 0.05        configuration
Setting fieldCorrectionTolerance/displacement to 0.0001      configuration
Setting fieldCorrectionTolerance/nonlocal damage to 0.0001   configuration
```

`pre-commit run --files edelweissfe/config/configurator.py` passes.

> **Note:** `*updateConfiguration` has no test coverage, which is why this drift went unnoticed. A
> regression test was written and confirmed to fail with `KeyError: 'data'` before the fix and pass
> after, but was dropped from this PR at the maintainer's request. Worth adding separately if the
> keyword is to stay supported.

Found while investigating convergence tolerances on the anchor pry-out model, where EdelweissFE's
shipped `fluxResidualTolerance['displacement'] = 1e-8` is ~5 orders of magnitude tighter than
Abaqus' default `5e-3`. That investigation is separate; this PR is only the enabling bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016F7RFdrTgWwtgeYMDGjkp9
