### PR TITLE
fix(ci): pin freethreaded python build to work around conda-forge regression

### DIFF
--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -9,8 +9,13 @@ gstools
 make
 numpy
 numpydoc
-python=3.14
-python-freethreading
+# conda-forge's freethreaded python 3.14.7 build h1945688_5_cp314t ships broken sysconfig CFLAGS
+# ("-partition=none") that make g++ reject any pip source build of a C/C++ extension (e.g. pyamg,
+# which has no cp314t wheel). Pinning python-freethreading's build alone does not pin the python
+# package it pulls in, so both must be pinned to the last known-good build until conda-forge
+# fixes it upstream (unreported as of 2026-09-02). TODO: unpin once fixed.
+python=3.14.7=h1945688_4_cp314t
+python-freethreading=3.14.7=h92d6c8b_4
 pytest
 prettytable
 scipy


### PR DESCRIPTION
## Summary
- `next_v26.11` started failing CI right after #101 merged, but not because of #101 — `git diff` shows no dependency changes in that commit.
- Root cause, isolated by diffing installed package versions between the last green run and the first red one: conda-forge published a new build of freethreaded Python 3.14.7, `h1945688_5_cp314t`, whose sysconfig CFLAGS carry a broken `-partition=none` flag. Any pip source build of a C/C++ extension fails under it — here, `pyamg`, which has no `cp314t` wheel and always source-builds.
- Pins `python` and `python-freethreading` to the last known-good build (`h1945688_4_cp314t` / `h92d6c8b_4`) to unblock CI. This is a temporary workaround for an upstream conda-forge regression, not a fix in this repo — flagged with a TODO to unpin once conda-forge corrects it.

## Test plan
- [x] `mamba create --dry-run -c conda-forge --file conda_requirements.txt` resolves cleanly with the pinned builds (184 packages, no conflicts).
- [ ] CI on this PR goes green (was failing at "Install pip packages" / pyamg build on unpinned `next_v26.11`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)