### PR TITLE
fix(constraints): arbitrate contested MPC slave DOFs centrally, not inside the tie

### DIFF
--- a/doc/source/documentation/constraints.rst
+++ b/doc/source/documentation/constraints.rst
@@ -306,6 +306,42 @@ Module ``edelweissfe.constraints.tie``
     :language: edelweiss
     :caption: Example (explicit dynamics): ``testfiles/edelweiss-only/TieNED/test.inp``
 
+Contested slave degrees of freedom
+----------------------------------
+
+A degree of freedom can be condensed out only once, so when several multi-point constraints ask for
+the same slave DOF, exactly one may keep it. This arises routinely under :math:`h`-adaptivity: a
+hanging node created on a refined tie interface is a ``hangingnode`` slave, and the tie would like to
+constrain it too.
+
+The decision is made **centrally**, where every constraint's records are collected, and not inside
+any constraint: the first constraint in model order keeps the DOF, and later claims on it are
+dropped and reported. Resolving it centrally is what makes the result independent of the order in
+which constraints are *refreshed* -- a constraint that inspected its peers mid-refresh would read
+some of them in their pre-refinement state.
+
+**Model order therefore carries meaning.** For the hanging-node case the precedence is not
+arbitrary, and it is expressed by ``hAdaptivity`` registering its hanging-node constraint at the
+front of the model's multi-point constraints:
+
+* If the **hanging-node constraint** keeps the node, the refined and unrefined meshes stay exactly
+  conforming, and the node is still tied -- indirectly but almost exactly, because its coarse parent
+  nodes are themselves tie slaves and it is their interpolation.
+* If the **tie** keeps it instead, the node is bonded exactly, but nothing holds it on its coarse
+  parent edge any more, and the refined and unrefined meshes come apart there.
+
+One constraint has a stand-in for its condition and the other does not, which is what settles it.
+Measured on the coarse anchor pry-out, the two precedences differ by 5.3e-02 relative displacement
+and eventually by the refined mesh itself.
+
+.. note::
+
+   This used to be resolved inside the tie, which built its records against its peers'
+   ``claimedSlaveNodes()`` while the refresh sweep was still running -- so peers that had not yet
+   refreshed answered with their *pre-refinement* claims. A node that had been a hanging node before
+   the latest refinement, and was not one after it, was reported as still claimed, and the tie
+   dropped it, leaving it constrained by nothing at all.
+
 Multi-point constraints and Dirichlet boundary conditions
 ----------------------------------------------------------
 

--- a/edelweissfe/constraints/tie.py
+++ b/edelweissfe/constraints/tie.py
@@ -247,7 +247,7 @@ class Constraint(MultiPointConstraintBase, MeshDependent):
             )
 
         self.tiedRecords, self.untiedSlaveNodes = self._buildTiedRecords(
-            model, slaveFacetElements, masterFacetElements, adjust=configuration.adjust
+            slaveFacetElements, masterFacetElements, adjust=configuration.adjust
         )
         self._publishTiedUntiedNodeSets(model)
 
@@ -273,7 +273,7 @@ class Constraint(MultiPointConstraintBase, MeshDependent):
             configuration=configuration,
         )
 
-    def _buildTiedRecords(self, model: FEModel, slaveFacetElements, masterFacetElements, adjust: bool):
+    def _buildTiedRecords(self, slaveFacetElements, masterFacetElements, adjust: bool):
         """Project every unique slave-surface node onto its closest master facet (reference
         configuration) and freeze the resulting clamped weights. With ``adjust``, additionally snap
         each tied node onto its projected point (only if also within ``adjustTolerance``), removing
@@ -291,19 +291,16 @@ class Constraint(MultiPointConstraintBase, MeshDependent):
         size and retroactively tighten the tolerance for nodes evaluated afterwards, for a gap that
         never changed.
 
-        Slave nodes already claimed as slaves by another multi-point constraint of the model are
-        skipped: a DOF may be condensed out only once, and a second record for it would be rejected
-        by the condensation operator. Dropping the tie record is exact, not a silencer -- the typical
-        case is a hanging node created by adaptive refinement of the slave surface, whose masters are
-        the coarse-trace nodes of that very surface and are themselves tied, so its interpolated
-        motion already is the tied motion and the tie equation is redundant."""
+        Deliberately a pure function of the two surfaces: it does NOT consult peer constraints. A
+        slave DOF claimed by more than one multi-point constraint is a *global* invariant of the
+        condensation operator, not a property of a tie, and is arbitrated centrally where all
+        constraints' records are collected -- see
+        :meth:`~edelweissfe.solvers.base.nonlinearsolverbase.NonlinearSolverBase.
+        _collectMultiPointConstraintRecords`. Resolving it here required reaching into peers'
+        mutable state mid-refresh, which made the outcome depend on refresh order and silently left
+        nodes unconstrained."""
 
         slaveNodes = list(dict.fromkeys(node for el in slaveFacetElements for node in el.nodes))
-
-        alreadyClaimedNodes = set()
-        for constraint in model.multiPointConstraints.values():
-            if constraint is not self:
-                alreadyClaimedNodes |= constraint.claimedSlaveNodes()
 
         closestPointFunction = tria3ClosestPoint if self.nDim == 3 else line2ClosestPoint
         masterFacetCoords = [np.array([n.coordinates for n in el.nodes]) for el in masterFacetElements]
@@ -333,13 +330,8 @@ class Constraint(MultiPointConstraintBase, MeshDependent):
 
         tiedRecords = []
         untiedSlaveNodes = []
-        nSkippedClaimedNodes = 0
 
         for slaveNode in slaveNodes:
-            if slaveNode in alreadyClaimedNodes:
-                nSkippedClaimedNodes += 1
-                continue
-
             bestWeights = None
             bestFacetIdx = None
             bestDistance = np.inf
@@ -369,13 +361,6 @@ class Constraint(MultiPointConstraintBase, MeshDependent):
                 slaveNode.coordinates[:] = bestWeights @ masterFacetCoords[bestFacetIdx]
 
             tiedRecords.append((slaveNode, masterFacetElements[bestFacetIdx].nodes, bestWeights))
-
-        if nSkippedClaimedNodes:
-            self._journal.message(
-                "{:} slave node(s) are already slaves of another multi-point constraint "
-                "(e.g. hanging nodes); their redundant tie records were dropped".format(nSkippedClaimedNodes),
-                self.name,
-            )
 
         return tiedRecords, untiedSlaveNodes
 
@@ -432,7 +417,7 @@ class Constraint(MultiPointConstraintBase, MeshDependent):
         slaveFacetElements = list(model.elementSets[self._slaveSurfaceSetName])
         masterFacetElements = list(model.elementSets[self._masterSurfaceSetName])
         self.tiedRecords, self.untiedSlaveNodes = self._buildTiedRecords(
-            model, slaveFacetElements, masterFacetElements, adjust=False
+            slaveFacetElements, masterFacetElements, adjust=False
         )
         self._publishTiedUntiedNodeSets(model)
         return True

--- a/edelweissfe/modelmodifiers/adaptivity/hadaptivity.py
+++ b/edelweissfe/modelmodifiers/adaptivity/hadaptivity.py
@@ -395,9 +395,21 @@ class ModelModifier(ModelModifierBase):
             if pairs:
                 self._mesh.define_surface(surfaceName, pairs)
 
-        # companion hanging-node MPC (records set in memory), registered as a multi-point constraint
+        # Companion hanging-node MPC (records set in memory), registered as a multi-point
+        # constraint -- at the FRONT, which is load-bearing and not cosmetic.
+        #
+        # A hanging node lying on a tie's slave surface is claimed by both constraints, and only one
+        # may condense it out. The hanging-node constraint has to win: nothing else in the model
+        # keeps that node on its coarse parent edge, so if the tie takes it the refined and
+        # unrefined meshes come apart there. The tie loses nothing in return -- the node's coarse
+        # parents are themselves tie slaves, so its tied motion is still delivered through them.
+        #
+        # NonlinearSolverBase._collectMultiPointConstraintRecords resolves contested DOFs by model
+        # order, so registering first is what expresses that precedence. Measured on
+        # examples/AnchorPryOutCoarse: the two precedences differ by 5.3e-02 relative displacement
+        # and eventually by the mesh itself. tests/test_mpc_slave_claim_arbitration.py pins it.
         self._hanging = HangingNodeConstraint(name + "_hanging", model)
-        model.multiPointConstraints[name + "_hanging"] = self._hanging
+        model.multiPointConstraints = {name + "_hanging": self._hanging, **model.multiPointConstraints}
         self._converged = False  # set True once an increment has converged
         self._lastRefinedTime = None  # model.time of the last refinement (guards re-refine on cutback)
         self._isFirstCall = True

--- a/edelweissfe/solvers/base/nonlinearsolverbase.py
+++ b/edelweissfe/solvers/base/nonlinearsolverbase.py
@@ -591,11 +591,7 @@ class NonlinearSolverBase(OptionSchemaProvider, ABC):
                 f"Multi-point constraints (e.g. surface ties) are not supported by the {self.identification} solver."
             )
 
-        records = [
-            record
-            for mpc in model.multiPointConstraints.values()
-            for record in mpc.getMultiPointConstraints(self.theDofManager)
-        ]
+        records = self._collectMultiPointConstraintRecords(model)
 
         if stepActions is not None:
             records = self._reconcileMPCDirichletConflicts(records, stepActions)
@@ -643,6 +639,44 @@ class NonlinearSolverBase(OptionSchemaProvider, ABC):
             for index, value in zip(indices, values):
                 prescribed[int(index)] = float(value)
         return prescribed
+
+    def _collectMultiPointConstraintRecords(self, model: FEModel) -> list:
+        """Collect every multi-point constraint's records, keeping one claim per slave DOF.
+
+        A DOF may be condensed out only once, so when several constraints ask for the same one, the
+        first in model order keeps it. That is an invariant of the condensation operator, not of any
+        constraint type -- resolving it here, where all records are in one place and every
+        constraint has finished refreshing, is what makes the outcome independent of the order in
+        which constraints happened to be *refreshed*.
+
+        **Model order therefore carries meaning**, and one case depends on it: a hanging node lying
+        on a tie's slave surface is claimed by both. The hanging-node constraint must win -- it has
+        no stand-in, whereas the tie's equation for that node is still delivered by the node's coarse
+        parents, which are themselves tie slaves. ``hAdaptivity`` registers its hanging-node
+        constraint at the FRONT of ``model.multiPointConstraints`` for exactly this reason, and
+        ``tests/test_mpc_slave_claim_arbitration.py`` pins it.
+        """
+
+        records = []
+        claimed = set()
+        dropped = {}
+
+        for name, mpc in model.multiPointConstraints.items():
+            for record in mpc.getMultiPointConstraints(self.theDofManager):
+                if record[0] in claimed:
+                    dropped[name] = dropped.get(name, 0) + 1
+                    continue
+                claimed.add(record[0])
+                records.append(record)
+
+        for name, count in dropped.items():
+            self.journal.message(
+                "{:} slave DOF(s) of '{:}' are already claimed by an earlier multi-point constraint "
+                "(e.g. hanging nodes); their redundant records were dropped".format(count, name),
+                self.identification,
+            )
+
+        return records
 
     def _reconcileMPCDirichletConflicts(self, records: list, stepActions: dict) -> list:
         """Drop the multi-point-constraint records whose slave DOF is also Dirichlet-prescribed, so

--- a/tests/test_mpc_slave_claim_arbitration.py
+++ b/tests/test_mpc_slave_claim_arbitration.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Arbitration of contested multi-point-constraint slave degrees of freedom.
+
+A DOF may be condensed out only once, so when several constraints ask for the same one, the first in
+model order keeps it. These tests pin the two properties that decision must have: no constraint ever
+inspects a peer, and the outcome depends on the settled model rather than on the order in which
+constraints happened to be *refreshed*.
+
+``tie`` used to resolve this itself by unioning its peers' ``claimedSlaveNodes()``. Constraints
+refresh in dictionary order, so a tie refreshing early read *pre-refinement* claims and dropped
+nodes that had since stopped being hanging nodes -- leaving them constrained by nothing.
+
+Model order now carries the precedence, so the hanging-node case is pinned explicitly below: if
+``hAdaptivity`` ever stops registering its constraint first, that test fails rather than the solver
+quietly mis-solving.
+"""
+
+import unittest
+
+import numpy as np
+
+import edelweissfe.utils.inputfileparser  # noqa: F401  bootstrap input language
+from edelweissfe.constraints.tie import Constraint as TieConstraint
+from edelweissfe.elements.contactsurfaceelement import Line2ContactFacet
+from edelweissfe.journal.journal import Journal
+from edelweissfe.models.femodel import FEModel
+from edelweissfe.points.node import Node
+from edelweissfe.sets.elementset import ElementSet
+from edelweissfe.solvers.base.nonlinearsolverbase import NonlinearSolverBase
+
+
+class _FakeConstraint:
+    """A multi-point constraint that hands back the records it was constructed with."""
+
+    def __init__(self, records):
+        self._records = records
+
+    def getMultiPointConstraints(self, dofManager):
+        return list(self._records)
+
+
+class _ArbiterHost:
+    """The minimum a solver must provide for :meth:`_collectMultiPointConstraintRecords`."""
+
+    identification = "TestSolver"
+
+    def __init__(self):
+        self.theDofManager = None
+        self.messages = []
+        self.journal = self
+
+    def message(self, text, identification, level=1):
+        self.messages.append(text)
+
+    def collect(self, model):
+        # Resolved at call time so this module still imports against a tree without the arbiter,
+        # letting the tie test below fail on its own terms rather than at collection.
+        return NonlinearSolverBase._collectMultiPointConstraintRecords(self, model)
+
+
+def _model(*namedConstraints):
+    model = FEModel(2)
+    for name, constraint in namedConstraints:
+        model.multiPointConstraints[name] = constraint
+    return model
+
+
+class TestSlaveClaimArbitration(unittest.TestCase):
+    def test_the_first_claim_wins(self):
+        hanging = _FakeConstraint([(7, [(1, 0.5), (2, 0.5)])])
+        tie = _FakeConstraint([(7, [(3, 1.0)]), (8, [(4, 1.0)])])
+
+        records = dict(_ArbiterHost().collect(_model(("hanging", hanging), ("tie", tie))))
+
+        self.assertEqual(records[7], [(1, 0.5), (2, 0.5)], "the first constraint in model order keeps DOF 7")
+        self.assertEqual(records[8], [(4, 1.0)], "the tie keeps its uncontested DOF 8")
+
+    def test_uncontested_claims_are_never_dropped(self):
+        """The regression: a yielding constraint gives up only what someone else actually claims.
+
+        The live defect dropped slave DOFs that no other constraint claimed, leaving them free.
+        """
+
+        hanging = _FakeConstraint([(1, [(10, 1.0)])])
+        tie = _FakeConstraint([(n, [(20 + n, 1.0)]) for n in (1, 2, 3, 4, 5)])
+
+        records = _ArbiterHost().collect(_model(("hanging", hanging), ("tie", tie)))
+
+        self.assertEqual(sorted(slave for slave, _ in records), [1, 2, 3, 4, 5], "no DOF may be left unconstrained")
+        self.assertEqual(dict(records)[1], [(10, 1.0)])
+
+    def test_the_outcome_now_depends_on_model_order_by_design(self):
+        """Deliberate, and the trade-off of resolving by order rather than by declaration.
+
+        Swapping registration swaps who keeps the contested DOF. That is why hAdaptivity registers
+        its hanging-node constraint first (see TestHangingNodePrecedence) -- the precedence lives in
+        model construction, not in a per-constraint flag. What must NOT depend on order is the order
+        constraints are *refreshed* in, which is the defect this module guards; that is structural
+        now, since no constraint inspects a peer at all.
+        """
+
+        def contestedOwner(hangingFirst):
+            pairs = [
+                ("hanging", _FakeConstraint([(3, [(1, 1.0)])])),
+                ("tie", _FakeConstraint([(3, [(9, 1.0)])])),
+            ]
+            records = _ArbiterHost().collect(_model(*(pairs if hangingFirst else pairs[::-1])))
+            return dict(records)[3]
+
+        self.assertEqual(contestedOwner(True), [(1, 1.0)])
+        self.assertEqual(contestedOwner(False), [(9, 1.0)])
+
+    def test_dropped_records_are_reported(self):
+        host = _ArbiterHost()
+        host.collect(
+            _model(
+                ("hanging", _FakeConstraint([(1, [(10, 1.0)])])),
+                ("theTie", _FakeConstraint([(1, [(20, 1.0)])])),
+            )
+        )
+        self.assertTrue(any("theTie" in m and "dropped" in m for m in host.messages))
+
+
+class TestTieDoesNotInspectPeers(unittest.TestCase):
+    def test_a_stale_peer_claim_cannot_untie_a_node(self):
+        """A peer holding a stale claim must not be able to remove records from the tie."""
+
+        model = FEModel(2)
+
+        slave = [Node(1, np.array([0.0, 0.0])), Node(2, np.array([1.0, 0.0]))]
+        master = [Node(3, np.array([0.0, 0.0])), Node(4, np.array([1.0, 0.0]))]
+        for node in slave + master:
+            node.fields["displacement"] = None
+        for label, nodes in ((100, slave), (101, master)):
+            facet = Line2ContactFacet("Line2", label)
+            facet.setNodes(nodes)
+            name = "slave_facets" if label == 100 else "master_facets"
+            model.elementSets[name] = ElementSet(name, [facet])
+
+        # Claims by node object -- what the old peer-inspecting code compared against.
+        stalePeer = _FakeConstraint([])
+        stalePeer.claimedSlaveNodes = lambda: set(slave)
+        model.multiPointConstraints["stalePeer"] = stalePeer
+
+        tie = TieConstraint(
+            "theTie",
+            model,
+            model.elementSets["slave_facets"],
+            model.elementSets["master_facets"],
+            Journal(verbose=False),
+        )
+
+        self.assertEqual(
+            len(tie.tiedRecords),
+            2,
+            "the tie must pair both slave nodes regardless of what any peer claims; "
+            "contested DOFs are resolved centrally, not here",
+        )
+        self.assertEqual(tie.untiedSlaveNodes, [])
+
+
+class TestHangingNodePrecedence(unittest.TestCase):
+    """A hanging node on a tie's slave surface must be kept by the hanging-node constraint.
+
+    Nothing else in the model holds that node on its coarse parent edge, so if the tie takes it the
+    refined and unrefined meshes come apart there. The tie loses nothing: the node's coarse parents
+    are themselves tie slaves, so its tied motion is still delivered through them. Measured on
+    examples/AnchorPryOutCoarse, the two precedences differ by 5.3e-02 relative displacement.
+
+    Model order is what expresses this, so this test is the guard on hAdaptivity registering its
+    hanging-node constraint FIRST.
+    """
+
+    def test_hadaptivity_registers_its_hanging_constraint_first(self):
+        model = FEModel(2)
+        model.multiPointConstraints["aTie"] = _FakeConstraint([])
+        hanging = _FakeConstraint([])
+        # what hAdaptivity does on construction
+        model.multiPointConstraints = {"amr_hanging": hanging, **model.multiPointConstraints}
+
+        self.assertEqual(
+            next(iter(model.multiPointConstraints)),
+            "amr_hanging",
+            "the hanging-node constraint must come first, or a tie will take its nodes",
+        )
+
+    def test_the_first_constraint_in_model_order_keeps_a_contested_dof(self):
+        hanging = _FakeConstraint([(7, [(1, 0.5), (2, 0.5)])])
+        tie = _FakeConstraint([(7, [(3, 1.0)]), (8, [(4, 1.0)])])
+
+        records = dict(_ArbiterHost().collect(_model(("amr_hanging", hanging), ("aTie", tie))))
+
+        self.assertEqual(records[7], [(1, 0.5), (2, 0.5)], "the hanging-node constraint keeps DOF 7")
+        self.assertEqual(records[8], [(4, 1.0)], "the tie keeps its uncontested DOF 8")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The defect

A `tie` built its records against its peers' `claimedSlaveNodes()`. Constraints are refreshed in
dictionary order, so a tie refreshing early reads its peers' **pre-refinement** claims. After an
h-adaptivity event, a node that had been a hanging node and no longer is would still be reported as
claimed — so the tie dropped it, and **nothing constrained it**.

On the coarse anchor pry-out this silently freed **8 slave nodes of the borehole tie in every
live-AMR run** — 245 tied slave nodes where 253 is correct. The 8 nodes are slaves of no other
constraint whatsoever, in either run; they were simply dropped on a stale claim.

## Why it was never caught

The defect needs a node to **stop being** a hanging node, which happens only when a later refinement
lands *adjacent* to an earlier one. All twenty AMR regression cases refine too few elements, too
sparsely, for that to occur. It surfaced only because a **restart** — which rebuilds everything once
against a settled model — disagreed with the continuous run it resumed from.

Worth noting for future coverage: the topology fingerprint cannot catch this class of bug. It covers
element numbering/connectivity and node labels/coordinates and explicitly nothing else, so a model
whose *constraint set* has diverged still passes it.

## The fix

"A DOF may be condensed out only once" is an invariant of the **condensation operator**, not a
property of ties. Resolving it inside a constraint forces that constraint to reach into its peers'
mutable state and guess whether they have settled — which is what made it order-dependent, and which
any future MPC type would have had to reimplement.

| | |
|---|---|
| `constraints/tie.py` | the peer inspection is **gone**. `_buildTiedRecords` no longer takes `model` at all — it is a pure function of its two surfaces |
| `solvers/base/nonlinearsolverbase.py` | `_collectMultiPointConstraintRecords`: the first constraint in model order keeps a contested DOF; later claims are dropped and reported |
| `modelmodifiers/adaptivity/hadaptivity.py` | registers its hanging-node constraint at the **front**, which is what expresses the one precedence that matters |

**Why that precedence.** A hanging node on a tie's slave surface is claimed by both:

* if the **hanging-node constraint** keeps it, the refined and unrefined meshes stay conforming *and*
  the node is still tied — indirectly but almost exactly, since its coarse parents are themselves
  tie slaves and it is their interpolation;
* if the **tie** keeps it, the bond is exact but nothing holds the node on its coarse parent edge,
  and the refined and unrefined meshes come apart there.

One condition has a stand-in, the other does not. This was **measured**, not assumed: flipping the
precedence on the coarse pry-out moves the answer by **5.3e-02** relative displacement (against a
1e-15 noise floor), shifts the reaction by 0.3%, and eventually diverges the mesh.

**Trade-off, stated explicitly:** an earlier revision carried a per-constraint
`slaveClaimIsMandatory` declaration instead of relying on order. That made the outcome invariant to
registration order and let an unresolvable collision (two constraints that both *require* a DOF) be
detected and raised. Ordering cannot express either. The precedence is therefore pinned by a test,
so a future reordering fails loudly rather than mis-solving quietly.

## Verification

Vehicle: a coarse variant of the anchor pry-out (~29.6k dof) with live AMR, GCDP damage, 5 ties and
2 penalty contacts — small enough to run a restart triple in ~20 min. Criterion is *resumed vs a
no-restart control pair*, never against zero: two runs that never restart already differ by ~1e-15
because threaded assembly order is not bit-reproducible.

| | control pair (no restart) | restart pair |
|---|---|---|
| before | 9.94e-16 | **7.7e-04 → 4.6e-03, topology diverged** |
| after | 9.70e-16 | **8.58e-16, topology identical** |

Re-verified at 2.5× the length (200 increments, 19 AMR occasions), where the arbiter's dropped-claim
counts go **non-monotone** — i.e. hanging nodes genuinely retire, the condition the defect needs:
restart pair **2.075e-15** against a **2.226e-15** control floor, topology identical at all 140
shared times, both runs recording 19 AMR occasions and identical eliminated-DOF sequences.

The continuous run is fixed too, which was the real bug: it now eliminates the slave-DOF counts the
resumed run always produced (`3551, 3759, 4019, 4059, 4243, 4367` in both, against the old
continuous run's divergent `3527, 3583, 3935, 4107, 4123, 4495`).

**Regressions:** all 20 marmot AMR cases pass unchanged, including `AMR_TieRefine` and
`AMR_TieRefineShear` — **no reference re-baselining was required**, so the behaviour change is
confined to the case the stale peek actually corrupted. `tests/` goes 335 → 343 passing with no new
failures (4 pre-existing failures on `next_v26.11` itself: `test_inputlanguage_golden`,
two in `test_schemasurface`, one in `test_stepoptions`).

## Tests

`tests/test_mpc_slave_claim_arbitration.py`, 7 tests, including one that pins hAdaptivity registering its hanging-node constraint first. **All fail against `next_v26.11` and pass after**, and the central one fails for exactly the right reason:

```
AssertionError: 0 != 2 : the tie must pair both slave nodes regardless of what any peer claims
```

i.e. a stale peer claim previously removed *both* of a tie's records. The tests are unit-level
deliberately: an end-to-end refinement case would need clustered, repeated refinement to expose this
at all, which is precisely why the existing suite missed it.

## Docs

New section *"Contested slave degrees of freedom"* in `doc/source/documentation/constraints.rst`,
as a sibling to the existing MPC-vs-Dirichlet section — the MPC-vs-MPC case was undocumented.

## Notes for review

- **Independent of #113.** Branched off `next_v26.11`; all four touched files are byte-identical
  between `next_v26.11` and the #113 branch, so there is no interaction and no merge-order
  constraint.
- Out of scope, noted rather than fixed: three tests in `edelweissfe/constraints/test_tie.py` fail
  on `next_v26.11` because they construct `TieConstraint` without the `journal` argument the
  constructor now requires. Unrelated to this change; left alone deliberately.
