### PR TITLE
perf(solvers): report what the explicit timing table does not measure

### DIFF
--- a/edelweissfe/solvers/nonlinearexplicitdynamic.py
+++ b/edelweissfe/solvers/nonlinearexplicitdynamic.py
@@ -91,6 +91,7 @@ does not.
 
 from copy import deepcopy
 from dataclasses import dataclass
+from time import perf_counter
 
 import numpy as np
 
@@ -354,6 +355,12 @@ class NED(NonlinearSolverBase):
 
         self.validateModelCapabilities(model)
 
+        # Against this the timing table reports what it did *not* measure, so it has to span
+        # everything this method does -- the initial topology refinement and the first equation
+        # system included, since both are timed categories that would otherwise be subtracted from a
+        # window they never ran in and drive the residue negative.
+        stepWallClockTic = perf_counter()
+
         self._externalWork = 0.0
         self._cumulativeMassDrift = 0.0
         self._warnedAboutMissingInternalEnergy = False
@@ -514,30 +521,38 @@ class NED(NonlinearSolverBase):
                     if timeStep.timeIncrement > 0.0:
                         prevTimeStep = timeStep
 
-                    for fieldName, field in model.nodeFields.items():
-                        self.theDofManager.writeDofVectorToNodeField(U, field, "U")
-                        self.theDofManager.writeDofVectorToNodeField(P, field, "P")
+                    with performancetiming.timeit("publish node fields"):
+                        for fieldName, field in model.nodeFields.items():
+                            self.theDofManager.writeDofVectorToNodeField(U, field, "U")
+                            self.theDofManager.writeDofVectorToNodeField(P, field, "P")
 
-                        # Published every increment, not only on output increments, for two reasons:
-                        # an h-adaptivity event can fall on any increment and its interpolation reads
-                        # this entry, and a restart checkpoint written from a node field is the only
-                        # way an explicit run can resume with its kinetic state intact. It is an
-                        # O(nDof) copy.
-                        self.theDofManager.writeDofVectorToNodeField(V, field, "V")
+                            # Published every increment, not only on output increments, for two
+                            # reasons: an h-adaptivity event can fall on any increment and its
+                            # interpolation reads this entry, and a restart checkpoint written from a
+                            # node field is the only way an explicit run can resume with its kinetic
+                            # state intact. It is an O(nDof) copy.
+                            self.theDofManager.writeDofVectorToNodeField(V, field, "V")
 
-                    for variable in model.scalarVariables.values():
-                        variable.value = U[self.theDofManager.idcsOfScalarVariablesInDofVector[variable]]
+                        for variable in model.scalarVariables.values():
+                            variable.value = U[self.theDofManager.idcsOfScalarVariablesInDofVector[variable]]
 
                     self.updateRigidBodies(model, timeStep)
 
-                    model.advanceToTime(timeStep.totalTime)
+                    # Timed because it is not what it looks like. FEModel.advanceToTime is a generic
+                    # method shared with the implicit solvers, where it runs once per *converged*
+                    # increment and is amortised over a Newton loop; here it runs on every one of
+                    # millions of increments, and it is a serial Python loop over every element,
+                    # constraint and multi-point constraint in the model.
+                    with performancetiming.timeit("accept state"):
+                        model.advanceToTime(timeStep.totalTime)
 
                     if timeStep.number % self.options["output-frequency"] == 0:
-                        fieldOutputController.finalizeIncrement()
-                        for man in outputmanagers:
-                            man.finalizeIncrement(
-                                statusInfoDict=None,
-                            )
+                        with performancetiming.timeit("finalize output"):
+                            fieldOutputController.finalizeIncrement()
+                            for man in outputmanagers:
+                                man.finalizeIncrement(
+                                    statusInfoDict=None,
+                                )
 
                     # --- h-adaptivity, mid-run ------------------------------------------------
                     # Placed exactly here for three independent reasons. The marker refines on the
@@ -612,7 +627,7 @@ class NED(NonlinearSolverBase):
             self.applyStepActionsAtStepEnd(model, step.actions)
 
         finally:
-            prettyTable = performancetiming.makePrettyTable()
+            prettyTable = performancetiming.makePrettyTable(wallTime=perf_counter() - stepWallClockTic)
             self.journal.printPrettyTable(prettyTable, self.identification)
             performancetiming.reset()
 
@@ -685,44 +700,46 @@ class NED(NonlinearSolverBase):
                 timeStep.totalTime - timeStep.timeIncrement,
             )
 
-        # Enforce the Dirichlet boundary conditions on the constrained DOFs:
-        # there is no free equilibrium there, so their force P is set to zero,
-        # and their velocity is prescribed as (prescribed increment) / (time step).
-        for dirichlet in dirichlets:
-            prescribedIncrement = dirichlet.getPrescribedIncrement(timeStep).flatten()
+        with performancetiming.timeit("kinematic update"):
+            # Enforce the Dirichlet boundary conditions on the constrained DOFs:
+            # there is no free equilibrium there, so their force P is set to zero,
+            # and their velocity is prescribed as (prescribed increment) / (time step).
+            for dirichlet in dirichlets:
+                prescribedIncrement = dirichlet.getPrescribedIncrement(timeStep).flatten()
 
-            # The work put into the model at a prescribed degree of freedom is the reaction force
-            # there times the motion it is dragged through. At this point P holds the carried-over
-            # net nodal force from the previous increment (external minus internal plus constraint
-            # contributions), and the support reaction balancing it is its negative -- so this has to
-            # be accumulated HERE, immediately before the zeroing below, which is the only moment the
-            # reaction is available.
-            self._externalWork -= float(np.dot(P[dirichlet.constrainedDofIndices], prescribedIncrement))
+                # The work put into the model at a prescribed degree of freedom is the reaction force
+                # there times the motion it is dragged through. At this point P holds the carried-over
+                # net nodal force from the previous increment (external minus internal plus constraint
+                # contributions), and the support reaction balancing it is its negative -- so this has
+                # to be accumulated HERE, immediately before the zeroing below, which is the only
+                # moment the reaction is available.
+                self._externalWork -= float(np.dot(P[dirichlet.constrainedDofIndices], prescribedIncrement))
 
-            P[dirichlet.constrainedDofIndices] = 0.0
-            V[dirichlet.constrainedDofIndices] = prescribedIncrement / timeStep.timeIncrement
+                P[dirichlet.constrainedDofIndices] = 0.0
+                V[dirichlet.constrainedDofIndices] = prescribedIncrement / timeStep.timeIncrement
 
-        if self.ids_1st is not None:
-            V[self.ids_1st] = Minv[self.ids_1st] * P[self.ids_1st]
-        if self.ids_2nd is not None:
-            V[self.ids_2nd] += (
-                Minv[self.ids_2nd] * P[self.ids_2nd] * 0.5 * (timeStep.timeIncrement + prevTimeStep.timeIncrement)
-            )
+            if self.ids_1st is not None:
+                V[self.ids_1st] = Minv[self.ids_1st] * P[self.ids_1st]
+            if self.ids_2nd is not None:
+                V[self.ids_2nd] += (
+                    Minv[self.ids_2nd] * P[self.ids_2nd] * 0.5 * (timeStep.timeIncrement + prevTimeStep.timeIncrement)
+                )
 
-        # slave DOFs of multi-point constraints do not integrate their own equations of motion --
-        # they ride along on their masters (Minv is zero there, so the updates above left them
-        # untouched); displacements follow automatically via dU = V * dt
-        if self.mpcTransformation is not None:
-            self.mpcTransformation.applySlaveKinematics(V)
+            # slave DOFs of multi-point constraints do not integrate their own equations of motion --
+            # they ride along on their masters (Minv is zero there, so the updates above left them
+            # untouched); displacements follow automatically via dU = V * dt
+            if self.mpcTransformation is not None:
+                self.mpcTransformation.applySlaveKinematics(V)
 
-        # update displacement increment vector
-        np.multiply(V, timeStep.timeIncrement, out=dU)
-        np.add(U_n, dU, out=U_n)
+            # update displacement increment vector
+            np.multiply(V, timeStep.timeIncrement, out=dU)
+            np.add(U_n, dU, out=U_n)
 
-        self.applyStepActionsAtIncrementStart(model, timeStep, stepActions)
+        with performancetiming.timeit("step actions"):
+            self.applyStepActionsAtIncrementStart(model, timeStep, stepActions)
 
-        for geostatic in stepActions["geostatic"].values():
-            geostatic.applyAtIterationStart()
+            for geostatic in stepActions["geostatic"].values():
+                geostatic.applyAtIterationStart()
 
         P[:] = 0.0
         P, psi = self.computeElements(elements, U_n, dU, P, timeStep)
@@ -734,7 +751,8 @@ class NED(NonlinearSolverBase):
         # rigid interpolation link); done here so the Dirichlet handling at the start of the next
         # increment operates on the already-folded vector
         if self.mpcTransformation is not None:
-            P[:] = self.mpcTransformation.foldExplicitForce(P)
+            with performancetiming.timeit("mpc force fold"):
+                P[:] = self.mpcTransformation.foldExplicitForce(P)
 
         if timeStep.number % self.options["output-frequency"] == 0:
             Wint = psi
@@ -964,6 +982,7 @@ class NED(NonlinearSolverBase):
 
         return P, psi
 
+    @performancetiming.timeit("assemble loads")
     def assembleLoads(
         self,
         nodeForces: list[StepActionBase],

--- a/edelweissfe/utils/performancetiming.py
+++ b/edelweissfe/utils/performancetiming.py
@@ -236,7 +236,7 @@ def _makeTable(branch: dict, level: int, maxLevels: int) -> list[tuple]:
     return table
 
 
-def makePrettyTable(maxLevels: int = 4) -> PrettyTable:
+def makePrettyTable(maxLevels: int = 4, wallTime: float = None) -> PrettyTable:
     """Create a pretty formatted table of the measured times, merged across every thread that has
     recorded a measurement.
 
@@ -244,6 +244,18 @@ def makePrettyTable(maxLevels: int = 4) -> PrettyTable:
     ----------
     maxLevels
         The maximum number of stack levels considered in the table.
+    wallTime
+        The wall-clock time the timed work actually took, measured by the caller. If given, two
+        summary rows are appended: the sum of the top-level categories, and the difference between
+        that sum and this figure.
+
+        The difference row is the point of the parameter. Without it a reader adds up the categories
+        and takes the total for the whole run, which it is not: only what somebody thought to
+        decorate is in this table, and code that runs between the timed calls appears nowhere. On the
+        explicit anchor pry-out run this was 21.3 % of the step -- 19 766 s of 92 978 s, spent almost
+        entirely in one undecorated call -- and the table gave no hint that anything was missing.
+        Whatever is left over is not necessarily a defect, but it is a number that has to be *seen*
+        before it can be judged.
 
     Returns
     -------
@@ -265,6 +277,20 @@ def makePrettyTable(maxLevels: int = 4) -> PrettyTable:
                 calls,
                 "{:.5f}s".format(t_per_call),
             )
+        )
+
+    if wallTime is not None:
+        # Top level only: the nested rows are already counted inside their parents, so summing every
+        # row would double-count everything below level 0.
+        timed = sum(t for level, _, t, _ in theTable if level == 0)
+        unaccounted = wallTime - timed
+        share = unaccounted / wallTime * 100.0 if wallTime > 0.0 else 0.0
+
+        prettytable.add_row(("=" * 24, "", "", ""))
+        prettytable.add_row(("sum of the above", "{:.5f}s".format(timed), "", ""))
+        prettytable.add_row(("wall clock", "{:.5f}s".format(wallTime), "", ""))
+        prettytable.add_row(
+            ("unaccounted", "{:.5f}s".format(unaccounted), "", "{:.1f}%".format(share)),
         )
 
     return prettytable


### PR DESCRIPTION
The performance table printed at the end of an explicit step listed the increment and its
element/constraint phases and nothing else, with no total. A reader adds up its rows and takes the
result for the run. On the 337 471-dof anchor pry-out model that sum was **1030 s against a step
that took 1246 s**: 216 s -- 17 % -- was in code no timer covered, and nothing in the table hinted
that anything was missing.

On the 32-hour production run of the same model the gap was **23 691 s, 20.4 %**.

### What this changes

`makePrettyTable` takes the wall-clock time the caller measured and appends three rows: the sum of
its own top-level categories, that figure, and the difference.

```
| ========================              |               |       |              |
| sum of the above                      | 1241.82937s   |       |              |
| wall clock                            | 1246.27305s   |       |              |
| unaccounted                           | 4.44368s      |       | 0.4%         |
```

The solver measures the whole of `solveStep` -- initial refinement and first equation system
included -- so the residue is about undecorated work rather than about where the tic happens to sit.

The blocks that were invisible are now timed: the per-increment node-field publish, the state
acceptance, output finalization, the kinematic update, the step actions, the load assembly and the
multi-point-constraint force fold.

### Measured

Same model, 10 000 increments, 32 threads:

| | before | after |
|---|--:|--:|
| rows the table accounts for | ~83 % | **99.6 %** |
| unaccounted | not reported | 4.44 s of 1246.27 s |

The two largest previously-invisible items were `accept state` at 19.44 ms/increment (15.6 % of the
step) and `publish node fields` at 2.47 ms/increment. There was also 14.4 ms/increment inside
`increment` that its own children did not cover, now split into `kinematic update`, `step actions`,
`assemble loads` and `mpc force fold`, leaving a 1.43 ms/increment residue.

### Why it is worth landing on its own

It touches no numerics and changes no results. It is also load-bearing for diagnosis rather than
just for optimisation: a later run of this model hid an entire numerical blow-up between two
outputs, and the fact that a phase had become expensive was invisible for the same reason the
timings were.

Verified: `tests/` passes (5 pre-existing failures unrelated, confirmed identical on the merge
target); `testfiles/edelweiss-only` and `testfiles/marmot` pass apart from three `latex was not
found` environment failures.
