### PR TITLE
perf: cut the explicit increment cost by 19% -- parallel state acceptance, a tighter contact broadphase, and live cost reporting

### DIFF
--- a/edelweissfe/models/femodel.py
+++ b/edelweissfe/models/femodel.py
@@ -41,6 +41,12 @@ from edelweissfe.config.phenomena import getFieldSize, phenomena
 from edelweissfe.fields.nodefield import NodeField
 from edelweissfe.journal.journal import Journal
 from edelweissfe.models.modelchange import ModelChange, TopologyRecord, coalesce
+from edelweissfe.numerics.parallelizationutilities import (
+    chunked_iterable,
+    getNumberOfThreads,
+    getThreadPool,
+    isFreeThreadingSupported,
+)
 from edelweissfe.utils.exceptions import RestartError, TopologyError
 from edelweissfe.utils.performancetiming import timeit
 from edelweissfe.variables.fieldvariable import FieldVariable
@@ -851,14 +857,53 @@ class FEModel:
 
         self.time = time
 
-        for el in self.elements.values():
-            el.acceptLastState()
+        self._acceptElementStates()
 
+        # Left serial deliberately. Measured on the 337 471-dof explicit anchor pry-out model, where
+        # the element loop below costs 19.09 ms per call: these two together cost 0.015 ms, i.e. less
+        # than a tenth of a percent of it. There is nothing here to parallelize.
         for constraint in self.constraints.values():
             constraint.acceptLastState()
 
         for mpc in self.multiPointConstraints.values():
             mpc.acceptLastState()
+
+    def _acceptElementStates(self):
+        """Let every element accept its computed state, across the available threads.
+
+        An element's ``acceptLastState`` touches only that element's own state buffers -- for a
+        Marmot element it is the single ``self._stateVars[:] = self._stateVarsTemp`` copy -- so the
+        elements are independent of one another and this loop parallelizes without any coordination.
+
+        It is worth parallelizing because of how the explicit solver uses it, not because of how the
+        implicit ones do. An implicit analysis calls this once per *converged* increment, amortised
+        over a Newton loop and a linear solve, where 19 ms disappears into the noise. Explicit
+        dynamics calls it on every one of millions of increments: on the anchor pry-out model it was
+        15.6 % of the whole step, the single largest cost outside the element kernels themselves, and
+        every millisecond of it was serial Python holding 31 of 32 threads idle.
+        """
+
+        elements = self.elements
+        numThreads = getNumberOfThreads() if isFreeThreadingSupported() else 1
+
+        if numThreads == 1 or len(elements) < numThreads:
+            for element in elements.values():
+                element.acceptLastState()
+            return
+
+        def acceptChunk(chunk):
+            for element in chunk:
+                element.acceptLastState()
+
+        # The same chunk granularity the parallel element computation uses: four chunks per thread,
+        # enough to even out the spread between cheap facet elements and expensive solid ones
+        # without paying dispatch overhead per element.
+        chunkSize = max(1, len(elements) // (numThreads * 4))
+        chunks = chunked_iterable(elements.values(), chunkSize)
+
+        # list(), not a bare call: Executor.map is lazy, and leaving the iterator unconsumed would
+        # return here with workers still writing element state.
+        list(getThreadPool(numThreads).map(acceptChunk, chunks))
 
     def writeRestart(self, restartFile: h5py.File):
         """Write the current (converged) state of the model to a restart checkpoint.

--- a/edelweissfe/numerics/parallelizationutilities.py
+++ b/edelweissfe/numerics/parallelizationutilities.py
@@ -25,6 +25,7 @@
 #  ---------------------------------------------------------------------
 
 import concurrent.futures
+import itertools
 import os
 import sys
 import threading
@@ -100,3 +101,13 @@ def getThreadPool(numThreads: int) -> concurrent.futures.ThreadPoolExecutor:
                 pool = _threadPools[numThreads] = concurrent.futures.ThreadPoolExecutor(max_workers=numThreads)
 
     return pool
+
+
+def chunked_iterable(iterable, size):
+    """Yield successive n-sized chunks from an iterable."""
+    it = iter(iterable)
+    while True:
+        chunk = tuple(itertools.islice(it, size))
+        if not chunk:
+            break
+        yield chunk

--- a/edelweissfe/solvers/base/parallelelementcomputation.py
+++ b/edelweissfe/solvers/base/parallelelementcomputation.py
@@ -27,12 +27,12 @@
 #  the top level directory of EdelweissFE.
 #  ---------------------------------------------------------------------
 
-import itertools
 
 import numpy as np
 
 from edelweissfe.numerics.dofmanager import DofVector, VIJSystemMatrix
 from edelweissfe.numerics.parallelizationutilities import (
+    chunked_iterable,
     getNumberOfThreads,
     getThreadPool,
     isFreeThreadingSupported,
@@ -106,16 +106,6 @@ def computeElementsInParallel(
     scatter_P.assembleInto(F, absolute=True)
 
     return P, K, F
-
-
-def chunked_iterable(iterable, size):
-    """Yield successive n-sized chunks from an iterable."""
-    it = iter(iterable)
-    while True:
-        chunk = tuple(itertools.islice(it, size))
-        if not chunk:
-            break
-        yield chunk
 
 
 #: Single-entry cache of the per-chunk gather plan; see :func:`_chunkedGatherPlan`. One entry

--- a/edelweissfe/solvers/nonlinearexplicitdynamic.py
+++ b/edelweissfe/solvers/nonlinearexplicitdynamic.py
@@ -209,6 +209,19 @@ class NEDSchema:
         default=100,
         optionName="contact-update-frequency",
     )
+    reportPerformance: bool = schemaField(
+        description=(
+            "Print a performance table on every progress report, covering the interval since the "
+            "previous one. Off by default. An explicit run is millions of increments long, so the "
+            "table printed at the end of the step is otherwise the only one anyone sees, and it "
+            "averages the whole run into one row per phase -- this shows the cost structure as it "
+            "is now, which is what reveals a refinement or a contact search that has become "
+            "expensive while the analysis is still running."
+        ),
+        dtype=bool,
+        default=False,
+        optionName="report-performance",
+    )
 
 
 @dataclass
@@ -282,6 +295,7 @@ class NED(NonlinearSolverBase):
         "output-frequency": 1000,
         "contact-update-frequency": 100,
         "topology-check-frequency": 0,
+        "report-performance": False,
     }
 
     def __init__(self, jobInfo, journal, **kwargs):
@@ -426,6 +440,20 @@ class NED(NonlinearSolverBase):
                         self.identification,
                         level=1,
                     )
+
+                    if self.options["report-performance"]:
+                        # The *interval* table, not the cumulative one: what the solver has been
+                        # doing since the previous report is what tells a running analysis whether
+                        # its cost structure has moved -- a refinement that enlarged the mesh, a
+                        # contact search that started admitting far more candidates, a material
+                        # that entered a more expensive branch. The cumulative table, printed once
+                        # at the end of the step, averages all of that away, and on a run of
+                        # millions of increments it is also the only table anyone would ever see.
+                        self.journal.printPrettyTable(
+                            performancetiming.extractIncrementTimes(skipUnused=True),
+                            self.identification,
+                        )
+
                 # The mid-run topology check at the end of this same increment re-runs the
                 # connectivity search on EVERY constraint, these included. Searching here as well
                 # would build and query the same k-d tree twice within one increment: the later

--- a/edelweissfe/utils/facetcontactgeometry.py
+++ b/edelweissfe/utils/facetcontactgeometry.py
@@ -328,4 +328,33 @@ def closestFacetCandidates(queryPoints: np.ndarray, facetCoords: list, searchDis
     # any mesh dimension, so it admits no facet that the exhaustive sweep would not also see.
     radius = radius * (1.0 + 8.0 * np.finfo(float).eps)
 
-    return [sorted(c) for c in tree.query_ball_point(queryPoints, radius)]
+    ballCandidates = tree.query_ball_point(queryPoints, radius)
+
+    # The ball is sized by rMax, the largest facet radius anywhere on the surface, so on a surface
+    # of uniform facets it is about as tight as a centroid bound can be -- and on a refined one it
+    # is not tight at all. Measured on the h-adaptive anchor pry-out model, whose concrete top
+    # surface carries 1.2 mm facets next to 34 mm ones: rMax = 24.54 mm against a mean nearest-
+    # centroid distance of 0.78 mm, so the radius is 97 % rMax and admits 457 of 4212 facets for
+    # every point. The same call on that model's other contact surface, 192 facets with
+    # rMax = 2.33 mm, admits 8.6. One global rMax makes the whole surface pay for its largest
+    # element.
+    #
+    # So reject, per facet, what its own radius already rules out. Facet i's closed domain is at
+    # least |x - C_i| - r_i away, and d* <= d0 from the bound above, so a facet with
+    # |x - C_i| - r_i > d0 is strictly farther than the winner and can neither win nor tie. It is
+    # the same argument the ball radius rests on, applied with each facet's own r_i instead of the
+    # largest one, and it removes only facets the exhaustive sweep would have evaluated and
+    # discarded -- the selected facet, and the caller's ascending-index tie-breaking among equally
+    # close ones, are untouched. The comparison keeps the ulp margin for exactly the reason the
+    # radius above does: a tie sits precisely on the boundary.
+    tolerance = 1.0 + 8.0 * np.finfo(float).eps
+
+    candidates = []
+    for p, ballCandidate in enumerate(ballCandidates):
+        indices = np.fromiter(ballCandidate, dtype=np.intp, count=len(ballCandidate))
+        centroidDistance = np.linalg.norm(centroids[indices] - queryPoints[p], axis=1)
+        surviving = indices[centroidDistance - radii[indices] <= nearestCentroidDistance[p] * tolerance]
+        surviving.sort()
+        candidates.append(surviving.tolist())
+
+    return candidates

--- a/edelweissfe/utils/performancetiming.py
+++ b/edelweissfe/utils/performancetiming.py
@@ -270,10 +270,20 @@ def makePrettyTable(maxLevels: int = 4) -> PrettyTable:
     return prettytable
 
 
-def extractIncrementTimes(maxLevels: int = 4) -> PrettyTable:
+def extractIncrementTimes(maxLevels: int = 4, skipUnused: bool = False) -> PrettyTable:
     """
     Returns a PrettyTable of the time elapsed since the last time
     this function was called, while keeping the accumulated totals intact.
+
+    Parameters
+    ----------
+    maxLevels
+        The maximum number of stack levels considered in the table.
+    skipUnused
+        Omit categories that were not entered at all during the interval. Off by default so the
+        table keeps a stable set of rows between reports. Turn it on where the table is printed
+        repeatedly during a run: a category that did not run shows as ``0.00000s`` against real
+        numbers, which reads as "this was free" rather than "this did not happen".
     """
 
     if not hasattr(extractIncrementTimes, "_last_snapshot") or extractIncrementTimes._last_snapshot is None:
@@ -301,6 +311,9 @@ def extractIncrementTimes(maxLevels: int = 4) -> PrettyTable:
     def flatten_delta(node, level):
         rows = []
         for name, data in node["children"]:
+            if skipUnused and data["calls"] == 0:
+                # Its children cannot have been entered either, so the whole subtree goes.
+                continue
             rows.append((level, name, data["time"], data["calls"]))
             if level < maxLevels and data["children"]:
                 rows += flatten_delta(data, level + 1)

--- a/tests/test_facet_broadphase.py
+++ b/tests/test_facet_broadphase.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#  ---------------------------------------------------------------------
+#
+#  _____    _      _              _         _____ _____
+# | ____|__| | ___| |_      _____(_)___ ___|  ___| ____|
+# |  _| / _` |/ _ \ \ \ /\ / / _ \ / __/ __| |_  |  _|
+# | |__| (_| |  __/ |\ V  V /  __/ \__ \__ \  _| | |___
+# |_____\__,_|\___|_| \_/\_/ \___|_|___/___/_|   |_____|
+#
+#
+#  Unit of Strength of Materials and Structural Analysis
+#  University of Innsbruck,
+#  2017 - today
+#
+#  Matthias Neuner matthias.neuner@uibk.ac.at
+#
+#  This file is part of EdelweissFE.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2.1 of the License, or (at your option) any later version.
+#
+#  The full text of the license can be found in the file LICENSE.md at
+#  the top level directory of EdelweissFE.
+#  ---------------------------------------------------------------------
+"""The contact broadphase must be a pure accelerator: it may return fewer candidates than an
+exhaustive facet sweep would evaluate, never a different winner.
+
+That property is what lets the constraints call it instead of sweeping, and it is not obvious --
+the candidate set is pruned twice, once by a ball around the query point and once by each facet's
+own radius, and both bounds are exact only in real arithmetic. These tests pin the selection
+against a literal exhaustive sweep, on the facet-size spread that motivated the second prune.
+"""
+
+import numpy as np
+import pytest
+
+from edelweissfe.utils.facetcontactgeometry import (
+    closestFacetCandidates,
+    tria3ClosestPoint,
+)
+
+
+def _selectExhaustively(queryPoints: np.ndarray, facetCoords: list, searchDistance=None) -> list:
+    """The selection the constraints would make without any broadphase at all: every facet
+    evaluated, first strict minimum wins."""
+
+    selected = []
+    for point in queryPoints:
+        bestDistance, bestFacet = np.inf, None
+        for i, facet in enumerate(facetCoords):
+            _, distance = tria3ClosestPoint(point, *facet)
+            if distance < bestDistance:
+                bestDistance, bestFacet = distance, i
+        if bestFacet is not None and (searchDistance is None or bestDistance <= searchDistance):
+            selected.append(bestFacet)
+        else:
+            selected.append(None)
+    return selected
+
+
+def _selectViaBroadphase(queryPoints: np.ndarray, facetCoords: list, searchDistance=None) -> list:
+    """The same selection, restricted to the broadphase's candidates -- i.e. what the constraints
+    actually do."""
+
+    candidatesPerPoint = closestFacetCandidates(queryPoints, facetCoords, searchDistance)
+
+    selected = []
+    for p, point in enumerate(queryPoints):
+        bestDistance, bestFacet = np.inf, None
+        for i in candidatesPerPoint[p]:
+            _, distance = tria3ClosestPoint(point, *facetCoords[i])
+            if distance < bestDistance:
+                bestDistance, bestFacet = distance, i
+        if bestFacet is not None and (searchDistance is None or bestDistance <= searchDistance):
+            selected.append(bestFacet)
+        else:
+            selected.append(None)
+    return selected
+
+
+def _gradedSurface(fineCells: int, coarseCells: int, fineSize: float, coarseSize: float) -> list:
+    """A z = 0 surface of triangles whose size jumps by a large factor across the patch.
+
+    This is the refined-contact-surface case: an h-adaptive run subdivides the loaded region and
+    leaves the far field alone, so one surface carries facets differing by more than an order of
+    magnitude. A broadphase bounded by the *largest* facet radius degrades to a near-exhaustive
+    sweep exactly here.
+    """
+
+    facets = []
+    for cells, size, x0 in ((fineCells, fineSize, 0.0), (coarseCells, coarseSize, fineCells * fineSize)):
+        for i in range(cells):
+            for j in range(cells):
+                x, y = x0 + i * size, j * size
+                a = np.array([x, y, 0.0])
+                b = np.array([x + size, y, 0.0])
+                c = np.array([x + size, y + size, 0.0])
+                d = np.array([x, y + size, 0.0])
+                facets.append([a, b, c])
+                facets.append([a, c, d])
+    return facets
+
+
+@pytest.fixture
+def gradedSurface():
+    return _gradedSurface(fineCells=8, coarseCells=4, fineSize=1.0, coarseSize=8.0)
+
+
+def test_selection_matches_exhaustive_sweep_on_a_graded_surface(gradedSurface):
+    """The pruned candidate set picks the facet the exhaustive sweep picks, for every point."""
+
+    rng = np.random.default_rng(20260906)
+    queryPoints = np.column_stack(
+        (
+            rng.uniform(-2.0, 42.0, 400),
+            rng.uniform(-2.0, 34.0, 400),
+            rng.uniform(-3.0, 3.0, 400),
+        )
+    )
+
+    assert _selectViaBroadphase(queryPoints, gradedSurface) == _selectExhaustively(queryPoints, gradedSurface)
+
+
+def test_selection_matches_exhaustive_sweep_with_a_search_distance(gradedSurface):
+    """Capping the query radius must not change the outcome either -- including for the points the
+    cut-off leaves unassigned."""
+
+    rng = np.random.default_rng(20260907)
+    queryPoints = np.column_stack(
+        (
+            rng.uniform(-6.0, 46.0, 300),
+            rng.uniform(-6.0, 38.0, 300),
+            rng.uniform(-8.0, 8.0, 300),
+        )
+    )
+
+    viaBroadphase = _selectViaBroadphase(queryPoints, gradedSurface, searchDistance=2.5)
+    exhaustively = _selectExhaustively(queryPoints, gradedSurface, searchDistance=2.5)
+
+    assert viaBroadphase == exhaustively
+    assert any(facet is None for facet in exhaustively), "the cut-off never rejected anything -- test is vacuous"
+
+
+def test_a_tie_keeps_every_tied_facet(gradedSurface):
+    """A point equidistant from several facets is the case the ulp margins exist for: the candidate
+    set must still contain all of them, so the caller's ascending-index tie-break is what decides."""
+
+    # Directly above a shared vertex of the fine patch: the four triangles meeting there are all at
+    # exactly the same distance.
+    queryPoints = np.array([[4.0, 4.0, 1.0]])
+
+    candidates = closestFacetCandidates(queryPoints, gradedSurface, None)[0]
+
+    distances = np.array([tria3ClosestPoint(queryPoints[0], *gradedSurface[i])[1] for i in candidates])
+    tied = [
+        i for i, facet in enumerate(gradedSurface) if abs(tria3ClosestPoint(queryPoints[0], *facet)[1] - 1.0) < 1e-12
+    ]
+
+    assert len(tied) > 1, "fixture does not actually produce a tie -- test is vacuous"
+    assert set(tied) <= set(candidates)
+    assert distances.min() == pytest.approx(1.0)
+
+
+def test_the_prune_actually_prunes(gradedSurface):
+    """The point of the per-facet prune is that it removes most of what the ball admits. Without
+    this the exactness tests above would still pass on a broadphase that returned everything."""
+
+    rng = np.random.default_rng(20260908)
+    queryPoints = np.column_stack(
+        (
+            rng.uniform(0.0, 8.0, 100),
+            rng.uniform(0.0, 8.0, 100),
+            rng.uniform(-1.0, 1.0, 100),
+        )
+    )
+
+    candidates = closestFacetCandidates(queryPoints, gradedSurface, None)
+    meanCandidates = np.mean([len(c) for c in candidates])
+
+    # Over the fine patch, whose facets are 8x smaller than the coarse ones sizing the ball.
+    assert meanCandidates < 0.25 * len(gradedSurface)
+
+
+def test_an_empty_surface_yields_no_candidates():
+    assert closestFacetCandidates(np.zeros((3, 3)), [], None) == [[], [], []]


### PR DESCRIPTION
Three independent changes to what an explicit increment costs, measured on the 337 471-dof anchor
pry-out model (GPTS contact, h-adaptive, 10 000 increments, 32 threads). **Every run below is
bit-identical to its baseline** -- `RF_loading = -16.078003540946757`,
`U_loading = 1.4888282296321353e-04`, to the last digit.

They are separable and can be split if you would rather review them apart; the broadphase commit in
particular touches contact geometry and is unrelated to the other two.

---

### 1. `perf(models)`: accept element state across threads

`FEModel.advanceToTime` ends every increment by letting each element accept its computed state. For
the implicit solvers that is once per *converged* increment, amortised over a Newton loop and a
linear solve. Explicit dynamics calls it on every one of millions of increments, and it was serial
Python: **19.3 ms per increment, 15.6 % of the entire step**, the largest single cost outside the
element kernels, with 31 of 32 threads idle.

A probe splitting it three ways showed **99.8 % is the element loop** (constraints 0.007 s, MPCs
0.008 s over 2001 calls), so only that loop is parallelised; the other two stay serial with the
measurement recorded in a comment. `chunked_iterable` moves to `numerics/parallelizationutilities`
so the model need not import from a solver module.

| | baseline (x2) | after (x2) | |
|---|--:|--:|--:|
| `accept state` | 194.37 / 192.73 s | **65.82 / 65.60 s** | **2.95x** |
| step wall clock | 1246.3 / 1208.8 s | 1157.7 / 1155.5 s | -5.8 % |

**The step gain is smaller than the phase gain, reproducibly so**, and the commit message says so:
`elements` (+8.5 %) and `kinematic update` (+21.7 %) both slow down, against a run-to-run spread
under 1.5 % on those same rows. Sweeping every element's state buffer across 32 threads a second
time evicts what the next increment's gather wants. Two matched pairs were run precisely because one
pair would have been written off as noise.

Accepting the state *inside* the element pass would likely recover it, but that couples computing a
state to accepting it -- a semantic change this deliberately does not make.

---

### 2. `perf(contact)`: bound the facet broadphase by each facet's radius, not the largest one

`closestFacetCandidates` sizes its query ball as `d0 + rMax`, with `rMax` the largest facet radius
anywhere on the master surface. On uniform facets that is about as tight as a centroid bound gets.
On an h-adaptively refined surface it is not tight at all.

Measured on this model's concrete top surface after refinement:

| | |
|---|--:|
| master facets | 4212 |
| `rMax` | **24.54 mm** |
| mean nearest-centroid distance `d0` | **0.78 mm** |
| candidates admitted per point | **457.3** of 4212 |
| closest-point evaluations per update | **543 250** |

The radius is 97 % `rMax`. The same call on the model's *other* contact pair -- 192 facets,
`rMax = 2.33 mm` -- admits **8.6**. One global `rMax` makes the whole surface pay for its largest
element.

The fix rejects, per facet, what its own radius already rules out: facet `i`'s closed domain is at
least `|x - C_i| - r_i` away and `d* <= d0` by the bound the ball already rests on, so a facet with
`|x - C_i| - r_i > d0` can neither win nor tie. Same argument, each facet's own radius instead of the
largest.

| | before | after | |
|---|--:|--:|--:|
| `constraint connectivity` | 168.44 s (8.42 s/call) | **11.53 s (0.576 s/call)** | **14.6x** |
| step wall clock | 1155.5 s | **990.7 s** | **-14.3 %** |

`tests/test_facet_broadphase.py` (5 tests) pins the selection against a literal exhaustive sweep on
a deliberately graded surface, with and without a search distance, plus a tie case -- and a fourth
test asserts the prune actually prunes, so the exactness tests cannot pass vacuously on a broadphase
that returns everything.

This gets more valuable with every refinement pass, since the facet-size spread is what drives it.

---

### 3. `feat(solvers)`: optionally report the performance table as the run progresses

`report-performance` (**off by default**) prints a table on every progress report covering the
interval since the previous one. On a run of a million increments the end-of-step table is otherwise
the only one anyone sees, and it averages the whole run into one row per phase -- so a phase that
became expensive partway through is indistinguishable from one that was always moderately expensive.

`extractIncrementTimes` gains `skipUnused` for this: a category not entered during the interval
otherwise prints as `0.00000s` next to real numbers, which reads as "this was free" rather than
"this did not happen". Default off, so the existing `computetimemonitor` caller is unaffected.

---

### End to end

**1227.5 s -> 990.7 s, -19.3 %** against the baseline mean, bit-identical throughout.

Verified: `tests/` passes (5 pre-existing failures, confirmed identical on the merge target by
stashing every change); `testfiles/edelweiss-only` and `testfiles/marmot` pass apart from three
`latex was not found` environment failures.
