### PR TITLE
refactor(journal): clean up increment/blockamg/contact console output

### DIFF
--- a/edelweissfe/constraints/surfacetodeformablesurfacepenalty.py
+++ b/edelweissfe/constraints/surfacetodeformablesurfacepenalty.py
@@ -261,6 +261,11 @@ class Constraint(ConstraintBase, MeshDependent):
     #: Option schema for this constraint, per OptionSchemaProvider.
     schema = SurfaceToDeformableSurfacePenaltySchema
 
+    #: Journal sender tag: a short, class-level identification, not this instance's own (potentially
+    #: long, user-chosen) name -- so the log's fixed-width sender column never has to truncate it. The
+    #: instance name is still reported in full, in the message text itself (see __init__/updateConnectivity).
+    identification = "SurfaceContact"
+
     def __init__(
         self,
         name: str,
@@ -308,10 +313,10 @@ class Constraint(ConstraintBase, MeshDependent):
         self.totalNormalForce = 0.0
 
         self.journal.message(
-            f"{self.nPoints} contact points ({len(self._slaveFacets)} slave facets x "
+            f"contact '{self.name}': {self.nPoints} points ({len(self._slaveFacets)} slave facets x "
             f"{self.nQuadraturePoints} quadrature points), {len(self.facetElements)} master facets, "
             f"sliding={self.sliding}, type={self.type}",
-            name,
+            self.identification,
         )
 
     def _buildFromSurfaces(self, slaveSurface: ElementSet, masterSurface: ElementSet):
@@ -567,9 +572,8 @@ class Constraint(ConstraintBase, MeshDependent):
         if activity != self._lastReportedActivity:
             self._lastReportedActivity = activity
             self.journal.message(
-                f"{activity[0]} of {self.nPoints} contact points assigned, "
-                f"{activity[1]} closed at the last evaluation",
-                self.name,
+                f"contact '{self.name}': {activity[0]}/{self.nPoints} active, {activity[1]} closed",
+                self.identification,
                 level=2,
             )
 

--- a/edelweissfe/linsolve/blockamg/blockamg.py
+++ b/edelweissfe/linsolve/blockamg/blockamg.py
@@ -97,7 +97,11 @@ from edelweissfe.linsolve.nullspace import rigidBodyNullspace, translationNullsp
 # not affect, the Journal instance's own message-level suppression (see _log()) -- this gate decides
 # whether blockamg attempts to log at all; Journal's own level decides whether the attempt is shown.
 _VERBOSITY_LEVELS = ("silent", "warning", "info", "debug")
-_JOURNAL_LEVEL = {"warning": 0, "info": 1, "debug": 2}
+# Journal indentation level, not verbosity: "info"/"debug" both nest at level 2, alongside the Newton
+# residual line each solve corresponds to -- they are the same nesting depth (a per-Newton-iteration
+# detail), just gated by different verbosity settings. "warning" stays at level 0 (the least indented,
+# most visible spot in the log) regardless of nesting, since a warning is rare and meant to stand out.
+_JOURNAL_LEVEL = {"warning": 0, "info": 2, "debug": 2}
 _IDENTIFICATION = "BlockAMGSolver"
 
 # "backendPrecision" and "backendBlockSize" are not AMGCL parameters -- they select the AMGCL
@@ -860,7 +864,16 @@ class BlockAMGSolver(LinearSolver):
 
         fieldNames = [block.name for block in blocks]
         if fieldNames != self._fieldsAnnounced:
-            self._log("info", "blockamg: fields = {:}".format(fieldNames))
+            self._log("info", "blockamg linear solver: fields = {:}".format(", ".join(fieldNames)))
+            # The column header for every per-solve line below, printed once here (same trigger as the
+            # fields announcement, since the columns themselves never change without it) instead of on
+            # every single solve -- once you know what the columns mean, the compact rows are enough.
+            self._log(
+                "info",
+                "{:<6} {:<8} {:>5} {:>7} {:>7} {:>7} {:>7}".format(
+                    "solve", "precond", "iters", "η", "‖r‖", "retries", "time"
+                ),
+            )
             self._fieldsAnnounced = fieldNames
 
         residualNorm = float(np.linalg.norm(b))
@@ -1251,9 +1264,9 @@ class BlockAMGSolver(LinearSolver):
         solveElapsedTime = time.time() - solveStartTime
         self._log(
             "info",
-            "blockamg: solve #{:<4d} {:7s} {:3d}it eta={:.1e} res={:.1e} cont={:} time={:7.3f}s".format(
-                self._solveCount,
-                "REFRESH" if mustRefresh else "reuse",
+            "{:<6} {:<8} {:>3d}it {:>7.1e} {:>7.1e} {:>7d} {:>6.1f}s".format(
+                "#{:}".format(self._solveCount),
+                "rebuilt" if mustRefresh else "reused",
                 outerIters,
                 eta,
                 trueResidual,
@@ -1262,10 +1275,14 @@ class BlockAMGSolver(LinearSolver):
             ),
         )
         if outerIters > self._warnOuterIterationsThreshold:
+            # Rare and actionable, so this stays at "warning" (Journal level 0, the least indented and
+            # most visible spot in the log) and spells out the likely cause, unlike the routine
+            # per-solve line above it.
             self._log(
                 "warning",
-                "blockamg: WARNING solve #{:} needed {:} outer GMRES iterations (> threshold {:}) -- "
-                "possible preconditioner degradation".format(
+                "⚠ solve #{:} needed {:} outer GMRES iterations, above the warning threshold of {:}. "
+                "Likely a preconditioner-quality problem, not a physics one -- worth checking whether "
+                "the Jacobian changed sharply since the last hierarchy rebuild.".format(
                     self._solveCount, outerIters, self._warnOuterIterationsThreshold
                 ),
             )
@@ -1316,16 +1333,20 @@ class BlockAMGSolver(LinearSolver):
         if trueResidual > eta:
             self._log(
                 "warning",
-                "blockamg: WARNING solve #{:} true residual {:.2e} still exceeds requested eta={:.2e} "
-                "after {:} continuation(s) -- did not fully converge".format(
+                "⚠ solve #{:} did not fully converge: ‖r‖={:.1e} still exceeds η={:.1e} after {:} "
+                "retries. This usually means the block preconditioner no longer matches the current "
+                "system (e.g. after heavy contact/damage changes since it was last rebuilt), not that "
+                "the system itself is unsolvable. If it recurs, try a smaller hierarchyStalenessFactor "
+                "(rebuilds the preconditioner sooner) or a lower etaMax.".format(
                     self._solveCount, trueResidual, eta, continuations
                 ),
             )
         if info != 0:
             self._log(
                 "warning",
-                "blockamg: WARNING solve #{:} GMRES reported info={:} (did not converge within "
-                "maxiter on its own preconditioned-residual criterion)".format(self._solveCount, info),
+                "⚠ solve #{:} GMRES itself did not converge within outerMaxiter x outerRestart "
+                "iterations. Raise outerMaxiter/outerRestart, or check whether the system is simply "
+                "too hard for this preconditioner at its current settings.".format(self._solveCount),
             )
 
         return x

--- a/edelweissfe/solvers/base/nonlinearsolverbase.py
+++ b/edelweissfe/solvers/base/nonlinearsolverbase.py
@@ -605,7 +605,7 @@ class NonlinearSolverBase(OptionSchemaProvider, ABC):
         self.journal.message(
             "eliminating {:} slave DOF(s) via multi-point constraints".format(transformation.nEliminatedDof),
             self.identification,
-            0,
+            2,
         )
 
         return transformation
@@ -674,6 +674,7 @@ class NonlinearSolverBase(OptionSchemaProvider, ABC):
                 "{:} slave DOF(s) of '{:}' are already claimed by an earlier multi-point constraint "
                 "(e.g. hanging nodes); their redundant records were dropped".format(count, name),
                 self.identification,
+                2,
             )
 
         return records
@@ -752,16 +753,25 @@ class NonlinearSolverBase(OptionSchemaProvider, ABC):
                 "reconciled {:} Dirichlet/constraint conflict(s) that were exactly redundant "
                 "(the constraint already delivered the prescribed value)".format(nRedundant),
                 self.identification,
-                1,
+                2,
             )
         if overridden:
             worstDof, worstWeight = max(overridden, key=lambda entry: entry[1])
+            # Rare and actionable, so this stays at level 0 (least indented -- the most visible spot
+            # in the log) and spells out the cause and the fix, unlike the routine messages above it.
             self.journal.message(
-                "WARNING: {:} multi-point-constraint equation(s) were dropped in favour of a Dirichlet "
-                "boundary condition that they did NOT already imply -- the boundary condition wins, and "
-                "the model has changed. Worst case: DOF {:}, {:.3e} of its constraint weight rests on "
-                "unprescribed masters. This usually means the boundary condition's node set is "
-                "incomplete.".format(len(overridden), worstDof, worstWeight),
+                "WARNING: {:} multi-point-constraint equation(s) conflicted with a Dirichlet boundary "
+                "condition and were dropped -- a DOF cannot be both eliminated by a constraint and "
+                "directly prescribed, so the boundary condition wins. This changes the model: those "
+                "DOFs now get exactly their prescribed value instead of whatever the constraint (e.g. "
+                "a tie or hanging-node link) would have computed for them. Worst case: DOF {:}, where "
+                "{:.3e} of its constraint weight depends on masters that are themselves NOT prescribed "
+                "-- meaning the constraint's own value would likely have differed. This usually means "
+                "the boundary condition's node set was built independently of the mesh's tie/hanging-"
+                "node topology and is missing some nodes -- check whether it should be extended, or "
+                "whether these DOFs should be excluded from the constraint.".format(
+                    len(overridden), worstDof, worstWeight
+                ),
                 self.identification,
                 0,
             )

--- a/edelweissfe/solvers/nonlinearimplicitstatic.py
+++ b/edelweissfe/solvers/nonlinearimplicitstatic.py
@@ -275,8 +275,25 @@ class NIST(NonlinearSolverBase):
                 ticked = any([constraint.updateConnectivity(model) for constraint in model.constraints.values()])
                 connectivityHasChanged = refreshed or ticked
 
+                # One separator, marking the start of this increment's block. Everything about this
+                # increment -- an equation-system rebuild if one is needed, the MPC/Dirichlet
+                # diagnostics that come with it, the Newton table, all of it -- is printed after this
+                # single header, nested one level deeper (see the messages below), instead of being
+                # sandwiched between a second separator of its own.
+                self.journal.printSeperationLine()
+                self.journal.message(
+                    "increment {:}: {:8f}, {:8f}; time {:10f} to {:10f}".format(
+                        timeStep.number,
+                        timeStep.stepProgressIncrement,
+                        timeStep.stepProgress,
+                        timeStep.totalTime - timeStep.timeIncrement,
+                        timeStep.totalTime,
+                    ),
+                    self.identification,
+                    level=1,
+                )
+
                 if modelHasChanged or connectivityHasChanged or self.theDofManager is None:
-                    self.journal.message("Creating monolithic equation system", self.identification, 0)
                     self.theDofManager = DofManager(
                         model.nodeFields.values(),
                         model.scalarVariables.values(),
@@ -289,9 +306,9 @@ class NIST(NonlinearSolverBase):
                     # it references) alive for the rest of the run.
                     self._dirichletIndicesCache = None
                     self.journal.message(
-                        "total size of eq. system: {:}".format(self.theDofManager.nDof),
+                        "eq. system rebuilt: {:} dof".format(self.theDofManager.nDof),
                         self.identification,
-                        0,
+                        2,
                     )
 
                     # The per-field block extents, not just the total. Fields are laid out
@@ -300,17 +317,15 @@ class NIST(NonlinearSolverBase):
                     # tells you at a glance how a coupled model's DOFs are actually distributed.
                     for fieldName, fieldIndices in self.theDofManager.idcsOfFieldsInDofVector.items():
                         self.journal.message(
-                            "  field '{:}': {:} dofs, [{:}, {:})".format(
+                            "field '{:}': {:} dof, [{:}, {:})".format(
                                 fieldName,
                                 fieldIndices.stop - fieldIndices.start,
                                 fieldIndices.start,
                                 fieldIndices.stop,
                             ),
                             self.identification,
-                            0,
+                            2,
                         )
-
-                    self.journal.printSeperationLine()
 
                     # The one interface point a solver needs beyond the plain (A, b) call: it
                     # derives whatever it wants (field layout, node coordinates, topology) from
@@ -360,18 +375,6 @@ class NIST(NonlinearSolverBase):
                     "notes": "",
                 }
 
-                self.journal.printSeperationLine()
-                self.journal.message(
-                    "increment {:}: {:8f}, {:8f}; time {:10f} to {:10f}".format(
-                        timeStep.number,
-                        timeStep.stepProgressIncrement,
-                        timeStep.stepProgress,
-                        timeStep.totalTime - timeStep.timeIncrement,
-                        timeStep.totalTime,
-                    ),
-                    self.identification,
-                    level=1,
-                )
                 self.journal.message(self.iterationHeader, self.identification, level=2)
                 self.journal.message(self.iterationHeader2, self.identification, level=2)
 

--- a/edelweissfe/steps/stepmanager.py
+++ b/edelweissfe/steps/stepmanager.py
@@ -26,8 +26,6 @@
 #  the top level directory of EdelweissFE.
 #  ---------------------------------------------------------------------
 
-import textwrap
-
 from edelweissfe.config import registry
 from edelweissfe.config.stepactions import stepActionFactory
 from edelweissfe.config.steps import getStepClassByType
@@ -189,15 +187,14 @@ class StepManager:
         """
 
         def printActionDefinition(intro, options):
-            for line in textwrap.wrap(
+            # A single call: Journal.message() owns all wrapping/indentation for this line, so it
+            # stays consistent with every other multi-line message in the log instead of pre-wrapping
+            # here against a width Journal itself has no knowledge of.
+            journal.message(
                 intro + " [" + ", ".join(("{:}={:}".format(k, v) for k, v in options.items())) + "]",
-                subsequent_indent=" " * (len(intro) + 1),
-            ):
-                journal.message(
-                    line,
-                    self.identification,
-                    2,
-                )
+                self.identification,
+                2,
+            )
 
         for stepNumber, stepDefinition in enumerate(self.stepDefinitions):
             actionNamesInThisStep = set()


### PR DESCRIPTION
## Summary

Reviewing a `run.log` from the AnchorPryOut example turned up several console-output readability problems:

- Two separator lines could bracket a single increment: one printed after the equation-system rebuild, one before the increment header, with unrelated MPC/Dirichlet diagnostics sandwiched between them.
- `StepManager` pre-wrapped its own action-definition messages with a hand-computed indent before handing already-wrapped lines to `Journal`, which wraps and indents on its own -- two independent, disagreeing wrapping schemes producing inconsistent indentation for what looks like the same kind of content.
- `blockamg`'s one-line solve summary routinely exceeded its column budget once the trailing `time=` value was appended, stranding it on its own line with no sender tag.
- The contact constraint used its own (user-chosen, unbounded-length) instance name as the `Journal` sender, which is why `contactPlateConnection` got truncated to `contactPlateCon...` while `contactShaftHole` happened to fit.

## What changed

- **`NonlinearImplicitStatic`**: the increment header and its separator now print once, first; everything about that increment -- an equation-system rebuild if one is needed, MPC/Dirichlet diagnostics, the Newton table -- nests one level deeper underneath it, instead of being sandwiched between two separators.
- **`StepManager`**: no longer wraps its own text; hands the whole action definition to `Journal` in one `message()` call, same as every other multi-line message in the log.
- **`BlockAMGSolver`**: the per-solve line is now a compact, aligned table (header printed once, then one row per solve: preconditioner rebuilt/reused, outer GMRES iterations, the Eisenstat-Walker tolerance η, the achieved true residual ‖r‖, retries, wall time) -- verified character-for-character against `Journal`'s real templates to stay within the existing 100-column width. Its three solve-related warnings, and the Dirichlet/MPC-conflict warning in `NonlinearSolverBase`, are rare enough to afford spelling out what likely went wrong and what to check, matching the level of detail the MPC-conflict warning already had.
- **`SurfaceToDeformableSurfacePenalty`**: the `Journal` sender is now the fixed class tag `SurfaceContact`; the constraint's own name moves into the message text instead, where it has room to print in full.

No behavior outside logging changes -- same solves, same convergence path, same results.

## Test plan

- [x] `black --check`, `isort --check`, `flake8` clean on all five changed files
- [x] `Journal`'s real formatting templates exercised directly to confirm every new line is exactly 100 characters (unchanged total width)
- [x] Full `edelweiss-only` regression suite (~60 cases) run against this branch: only failure is the pre-existing, unrelated `MeshPlot` LaTeX-toolchain issue; every contact, tie, and BlockAMG-solver test passes, including `CantileverBeamQuad4BlockAMG` (the one that actually exercises `blockamg.py`)
- [x] Direct runs of `Tie2D` and `SurfaceToDeformableSurfaceContactPatch` inspected by hand to confirm the new output renders as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)
