### PR TITLE
fix(adaptivity): identify refined nodes topologically, not by rounded coordinates

### DIFF
--- a/edelweissfe/adaptivity/hex20topology.py
+++ b/edelweissfe/adaptivity/hex20topology.py
@@ -48,6 +48,7 @@ from edelweissfe.adaptivity.hex20shapefunctions import (
     FACEID_TO_FACE,
     FACES,
     face_child_octants,
+    hex20_box_coords,
     hex20_shape,
     hex20_shape_grad,
     quad8_shape,
@@ -70,6 +71,9 @@ class Hex20Topology(TopologyBase):
     @property
     def faceid_to_face(self) -> dict:
         return FACEID_TO_FACE
+
+    def reference_node_param(self) -> np.ndarray:
+        return hex20_box_coords(-1.0, 1.0, -1.0, 1.0, -1.0, 1.0)
 
     def subdivision_children_param(self, n: int) -> list:
         return subdivision_children_param(n)

--- a/edelweissfe/adaptivity/refinement.py
+++ b/edelweissfe/adaptivity/refinement.py
@@ -46,6 +46,26 @@ from edelweissfe.adaptivity.geometry import (
 from edelweissfe.utils.performancetiming import timeit
 
 
+def _latticeOf(params, n: int) -> np.ndarray:
+    """Exact integer lattice indices of parametric coordinates on the subdivision grid.
+
+    Every node a subdivision of a serendipity element can produce lies at ``-1 + k / n`` along each
+    axis for an integer ``k`` in ``[0, 2n]`` -- the corners of the sub-cells and the midside nodes
+    halfway between them. Converting the parametric coordinate to that integer turns a node's
+    position within its parent into exact data, which is what lets node identity be decided by
+    integer arithmetic instead of by rounding a floating-point coordinate.
+    """
+    scaled = (np.asarray(params, dtype=float) + 1.0) * n
+    lattice = np.rint(scaled).astype(np.int64)
+    if np.abs(scaled - lattice).max() > 1e-9:
+        raise ValueError(
+            "a subdivision produced a node off the 1/n parametric lattice, so its position within "
+            "the parent cannot be represented exactly; node identity would have to fall back on "
+            "comparing coordinates"
+        )
+    return lattice
+
+
 class NodeRegistry:
     """Coordinate-keyed node registry that mints unique labels and deduplicates shared nodes.
 
@@ -56,7 +76,8 @@ class NodeRegistry:
 
     def __init__(self, decimals: int = 8, reserve_labels=None):
         self.decimals = decimals
-        self._byKey = {}  # (componentId, rounded-coord) key -> label
+        self._byKey = {}  # (componentId, rounded-coord) key -> label; seeding and root elements only
+        self._byIdentity = {}  # (componentId, topological identity) -> label; everything refinement mints
         self.coordinates = {}  # label -> np.ndarray(coord)
         self.componentOf = {}  # label -> componentId of the body the node belongs to
         self._maxLabel = 0
@@ -114,6 +135,33 @@ class NodeRegistry:
             self.coordinates[lab] = np.array(coord, dtype=float)
             self.componentOf[lab] = componentId
         return lab
+
+    def label_for_identity(self, identity, coord, componentId: int = 0) -> int:
+        """Return the label of a node named by its *topological* identity, minting one if new.
+
+        ``identity`` names the node by which corners of its parent span it and in what exact integer
+        proportion, so two elements sharing a face or an edge derive the identical identity for a
+        point on it -- without comparing coordinates, and regardless of how their local axes happen
+        to be oriented relative to one another.
+
+        This is what :meth:`label` cannot do. Rounding a coordinate to a fixed number of decimals
+        splits one node into two whenever the exact value lands on a rounding tie and the two
+        parents' last bits disagree, and a mesh written with a fixed number of decimals produces
+        such ties systematically rather than by accident: on the anchor pry-out mesh every
+        quarter-point of a graded edge landed on one, giving 156 duplicated nodes with nothing
+        constraining them together.
+        """
+        key = (componentId, identity)
+        label = self._byIdentity.get(key)
+        if label is None:
+            label = self._mint()
+            self._byIdentity[key] = label
+            self.coordinates[label] = np.array(coord, dtype=float)
+            self.componentOf[label] = componentId
+            # Keep the coordinate index populated so seeding still sees these nodes; it is never
+            # consulted to identify a node that has a topological identity.
+            self._byKey.setdefault(self._key(coord, componentId), label)
+        return label
 
     def _mint(self) -> int:
         """One fresh label, from the model's allocator if this registry was given one."""
@@ -211,6 +259,19 @@ class AdaptiveMesh:
         self.nodeSets = {}  # name -> set(node label)
         self.surfaces = {}  # name -> set((eid, faceID))  (element-based, Marmot faceID convention)
         self._next = 1
+        # The subdivision lattice, resolved once: it depends only on the topology and splitFactor.
+        self._childLattice = [
+            _latticeOf(param, splitFactor) for param in self.topology.subdivision_children_param(splitFactor)
+        ]
+        ownLattice = _latticeOf(self.topology.reference_node_param(), splitFactor)
+        #: lattice position -> local slot of the parent's own nodes, so a child node landing on one
+        #: reuses the parent's node instead of minting a second node at the same point
+        self._ownNodeAt = {tuple(row): slot for slot, row in enumerate(ownLattice)}
+        # The corners are the nodes sitting at an extreme of every axis; the rest are midside nodes,
+        # which span no sub-entity of their own and so never appear in an identity.
+        isCorner = np.all((ownLattice == 0) | (ownLattice == 2 * splitFactor), axis=1)
+        self._cornerSlots = np.flatnonzero(isCorner)
+        self._cornerLattice = ownLattice[isCorner]
 
     # ---- topological containers ----
     def define_element_set(self, name, eids):
@@ -223,12 +284,43 @@ class AdaptiveMesh:
         """pairs: iterable of (eid, faceID) with Marmot faceID (1-6)."""
         self.surfaces[name] = set(pairs)
 
-    def _add(self, coords, level, parent, componentId: int = 0):
+    def _childConnectivity(self, parentConn, childIndex, coords, componentId):
+        """The 20 node labels of one child, decided topologically rather than geometrically.
+
+        Each child node is either one of the parent's own nodes -- recognised by an exact lattice
+        match, and reused -- or a new node spanned by some of the parent's corners. In the latter
+        case its identity is the set of spanning corner *labels* paired with exact integer weights.
+        A neighbouring element that shares that face or edge names the same corners with the same
+        weights, so both arrive at one label for one point.
+        """
+        extent = 2 * self.splitFactor
+        conn = []
+        for slot, lattice in enumerate(self._childLattice[childIndex]):
+            own = self._ownNodeAt.get(tuple(lattice))
+            if own is not None:
+                conn.append(parentConn[own])
+                continue
+            spanning = []
+            for cornerSlot, cornerLattice in zip(self._cornerSlots, self._cornerLattice):
+                weight = 1
+                for axis in range(len(lattice)):
+                    weight *= int(lattice[axis]) if cornerLattice[axis] == extent else extent - int(lattice[axis])
+                if weight:
+                    spanning.append((parentConn[cornerSlot], weight))
+            spanning.sort()
+            conn.append(self.registry.label_for_identity(tuple(spanning), coords[slot], componentId))
+        return conn
+
+    def _add(self, coords, level, parent, componentId: int = 0, parentConn=None, childIndex=None):
         coords = np.asarray(coords, dtype=float)
         eid = self._next
         self._next += 1
         self.elements[eid] = dict(
-            conn=self.registry.connectivity(coords, componentId),
+            conn=(
+                self.registry.connectivity(coords, componentId)
+                if parentConn is None
+                else self._childConnectivity(parentConn, childIndex, coords, componentId)
+            ),
             coords=coords,
             level=level,
             active=True,
@@ -273,8 +365,9 @@ class AdaptiveMesh:
             return e["children"]
         parent_conn = e["conn"]
         kids = [
-            self._add(ch, e["level"] + 1, eid, e["componentId"])
-            for ch in self.topology.subdivide(e["coords"], self.splitFactor)  # children stay in the parent's body
+            # children stay in the parent's body, and take their node identities from it
+            self._add(ch, e["level"] + 1, eid, e["componentId"], parent_conn, childIndex)
+            for childIndex, ch in enumerate(self.topology.subdivide(e["coords"], self.splitFactor))
         ]
         e["active"] = False
         e["children"] = kids

--- a/edelweissfe/adaptivity/topologybase.py
+++ b/edelweissfe/adaptivity/topologybase.py
@@ -59,6 +59,15 @@ class TopologyBase(ABC):
         """Mapping from external FaceID to internal face index."""
 
     @abstractmethod
+    def reference_node_param(self) -> np.ndarray:
+        """Parametric coordinates of this element's own nodes, in the same reference cube and the
+        same local order that :meth:`subdivision_children_param` uses.
+
+        Refinement needs this to recognise, in exact arithmetic, that a child node has landed on a
+        node the parent already owns -- so it reuses that node instead of minting a second one at
+        the same place."""
+
+    @abstractmethod
     def subdivision_children_param(self, n: int) -> list:
         """Parametric coordinates (in the parent domain) of the nodes of each child element."""
 

--- a/edelweissfe/outputmanagers/ensight.py
+++ b/edelweissfe/outputmanagers/ensight.py
@@ -1121,6 +1121,16 @@ class OutputManager(OutputManagerBase):
             self.journal.message("Skipping output".format(), self.identification, 1)
             return
 
+        # No time has passed since the last frame, so there is nothing new to record. This is a
+        # step's priming zero increment: on a resumed run it reports the time the checkpoint was
+        # taken at, which already has a frame on disk. Writing a second frame there duplicates the
+        # data and leaves the .case file's time values non-strictly-increasing, which the format
+        # does not allow and which makes a reader pair variables with the wrong geometry. The
+        # sentinel timeAtLastOutput of -1e16 is what keeps a cold start's own first frame, where no
+        # time has passed either but nothing has been written yet.
+        if timeSinceLastOutput <= 0.0:
+            return
+
         self.writeOutput(self.model)
 
     def finalizeFailedIncrement(self, **kwargs):

--- a/edelweissfe/timesteppers/simpletimestepper.py
+++ b/edelweissfe/timesteppers/simpletimestepper.py
@@ -93,8 +93,25 @@ class SimpleTimeStepper(TimeStepperBase):
             The current time step.
         """
 
-        # zero increment; return value for first function call
-        yield TimeStep(0, 0.0, 0.0, 0.0, 0.0, self.currentTime)
+        # A zero increment, yielded once before the first real one, so an explicit integrator can
+        # build its initial state (mass, internal force, contact) before taking a step.
+        #
+        # It reports the stepper's CURRENT position within the step, not the step's start. Those are
+        # the same thing on a cold start, where finishedStepProgress is 0 -- but not on a resumed
+        # run, and reporting the start there did two wrong things. The solver calls
+        # ``model.advanceToTime(timeStep.totalTime)`` on every increment, so model.time was rewound
+        # to the beginning of the step; and this increment's number is 0, hence a multiple of any
+        # ``output-frequency``, so an output frame stamped with that rewound time was written into
+        # the middle of an otherwise increasing Ensight time set -- leaving it non-monotonic, which
+        # is invalid in the format and makes a reader pair variables with the wrong geometry.
+        yield TimeStep(
+            0,
+            0.0,
+            self.finishedStepProgress,
+            0.0,
+            self.stepLength * self.finishedStepProgress,
+            self.currentTime + self.stepLength * self.finishedStepProgress,
+        )
         self.enforcedTimeIncrement = enforcedTimeIncrement
 
         if self.enforcedTimeIncrement is None:

--- a/tests/test_adaptivity_node_identity.py
+++ b/tests/test_adaptivity_node_identity.py
@@ -1,0 +1,132 @@
+"""Node identity across a refinement.
+
+A node created by subdividing an element has to be *the same node* for every parent that
+touches the point -- otherwise the mesh is torn there, silently: two labels at one location,
+no constraint between them, and the two halves are free to separate under load.
+
+The regression these tests pin came from identifying nodes by their rounded coordinates. On the
+anchor pry-out mesh that produced 156 duplicated nodes, one of which opened by 18.9 mm and
+destroyed a 380 000-increment explicit run. The mechanism is exact, not bad luck: a mesh written
+with seven significant decimals has quarter-points whose ninth decimal is a 5, i.e. exactly on the
+rounding tie of an eight-decimal key,
+
+    0.75 * (-3.636364) - 0.125 * (-7.272727) = -1.8181821249999999
+
+so the two neighbours' last-bit differences decide which way it rounds, and they disagree.
+"""
+
+import numpy as np
+
+from edelweissfe.adaptivity.hex20topology import Hex20Topology
+from edelweissfe.adaptivity.refinement import AdaptiveMesh
+
+# Two face-adjacent GC3D20R elements (7271 and 9540) of examples/AnchorPryOut, kept verbatim:
+# they share all eight nodes of one face, and the shared face carries the point
+# (106.9208, -1.818182125, -54.47886), which is a rounding tie.
+PARENT_A = np.array(
+    [
+        [np.float64(138.4114), np.float64(-7.272727), np.float64(-30.53289)],
+        [np.float64(139.1247), np.float64(-7.272727), np.float64(-62.79857)],
+        [np.float64(97.08204), np.float64(-7.272727), np.float64(-70.53423)],
+        [np.float64(114.1268), np.float64(-7.272727), np.float64(-37.08204)],
+        [np.float64(138.4114), np.float64(0.0), np.float64(-30.53289)],
+        [np.float64(139.1247), np.float64(0.0), np.float64(-62.79857)],
+        [np.float64(97.08204), np.float64(0.0), np.float64(-70.53423)],
+        [np.float64(114.1268), np.float64(0.0), np.float64(-37.08204)],
+        [np.float64(138.7681), np.float64(-7.272727), np.float64(-46.66573)],
+        [np.float64(118.1034), np.float64(-7.272727), np.float64(-66.6664)],
+        [np.float64(106.9208), np.float64(-7.272727), np.float64(-54.47886)],
+        [np.float64(126.2691), np.float64(-7.272727), np.float64(-33.80746)],
+        [np.float64(138.7681), np.float64(0.0), np.float64(-46.66573)],
+        [np.float64(118.1034), np.float64(0.0), np.float64(-66.6664)],
+        [np.float64(106.9208), np.float64(0.0), np.float64(-54.47886)],
+        [np.float64(126.2691), np.float64(0.0), np.float64(-33.80746)],
+        [np.float64(138.4114), np.float64(-3.636364), np.float64(-30.53289)],
+        [np.float64(139.1247), np.float64(-3.636364), np.float64(-62.79857)],
+        [np.float64(97.08204), np.float64(-3.636364), np.float64(-70.53423)],
+        [np.float64(114.1268), np.float64(-3.636364), np.float64(-37.08204)],
+    ]
+)
+
+PARENT_B = np.array(
+    [
+        [np.float64(89.73347), np.float64(0.0), np.float64(-65.19518)],
+        [np.float64(105.488), np.float64(0.0), np.float64(-34.27513)],
+        [np.float64(105.488), np.float64(-7.272727), np.float64(-34.27513)],
+        [np.float64(89.73347), np.float64(-7.272727), np.float64(-65.19518)],
+        [np.float64(97.08204), np.float64(0.0), np.float64(-70.53423)],
+        [np.float64(114.1268), np.float64(0.0), np.float64(-37.08204)],
+        [np.float64(114.1268), np.float64(-7.272727), np.float64(-37.08204)],
+        [np.float64(97.08204), np.float64(-7.272727), np.float64(-70.53423)],
+        [np.float64(97.61074), np.float64(0.0), np.float64(-49.73516)],
+        [np.float64(105.488), np.float64(-3.636364), np.float64(-34.27513)],
+        [np.float64(97.61074), np.float64(-7.272727), np.float64(-49.73516)],
+        [np.float64(89.73347), np.float64(-3.636364), np.float64(-65.19518)],
+        [np.float64(106.9208), np.float64(0.0), np.float64(-54.47886)],
+        [np.float64(114.1268), np.float64(-3.636364), np.float64(-37.08204)],
+        [np.float64(106.9208), np.float64(-7.272727), np.float64(-54.47886)],
+        [np.float64(97.08204), np.float64(-3.636364), np.float64(-70.53423)],
+        [np.float64(93.40775), np.float64(0.0), np.float64(-67.86471)],
+        [np.float64(109.8074), np.float64(0.0), np.float64(-35.67859)],
+        [np.float64(109.8074), np.float64(-7.272727), np.float64(-35.67859)],
+        [np.float64(93.40775), np.float64(-7.272727), np.float64(-67.86471)],
+    ]
+)
+
+TIE_POINT = np.array([106.9208, -1.818182125, -54.47886])
+
+
+def _refineBoth():
+    mesh = AdaptiveMesh(splitFactor=2, topology=Hex20Topology())
+    eids = [mesh.add_root(PARENT_A, 0), mesh.add_root(PARENT_B, 0)]
+    for eid in eids:
+        mesh.refine(eid)
+    return mesh
+
+
+def _duplicateGroups(mesh, decimals=9):
+    seen = {}
+    for label, coord in mesh.registry.coordinates.items():
+        seen.setdefault(tuple(np.round(coord, decimals)), []).append(label)
+    return {k: v for k, v in seen.items() if len(v) > 1}
+
+
+def test_the_fixture_really_is_face_adjacent():
+    """Guard the fixture: if these two stop sharing a face, the test below proves nothing."""
+    a = {tuple(np.round(c, 9)) for c in PARENT_A}
+    b = {tuple(np.round(c, 9)) for c in PARENT_B}
+    assert len(a & b) == 8
+
+
+def test_a_point_on_a_shared_face_gets_exactly_one_label():
+    mesh = _refineBoth()
+    duplicates = _duplicateGroups(mesh)
+    assert not duplicates, "refinement minted {:d} node(s) twice, e.g. {:s}".format(
+        len(duplicates), repr(next(iter(duplicates.items())))
+    )
+
+
+def test_the_rounding_tie_point_is_a_single_node():
+    """The specific point that tore the pry-out mesh open."""
+    mesh = _refineBoth()
+    hits = [
+        label
+        for label, coord in mesh.registry.coordinates.items()
+        if np.allclose(coord, TIE_POINT, rtol=0.0, atol=1e-9)
+    ]
+    assert len(hits) == 1, "the tie point carries {:d} labels: {:s}".format(len(hits), repr(hits))
+
+
+def test_distinct_bodies_still_keep_distinct_labels():
+    """The other half of the contract: a tied interface or a crack plane has two topologically
+    distinct nodes at one point, and merging those would weld the model shut."""
+    mesh = AdaptiveMesh(splitFactor=2, topology=Hex20Topology())
+    mesh.refine(mesh.add_root(PARENT_A, 0))
+    mesh.refine(mesh.add_root(PARENT_A, 1))
+    labelsOfBody = []
+    for componentId in (0, 1):
+        labelsOfBody.append(
+            {label for label in mesh.registry.coordinates if mesh.registry.componentOf[label] == componentId}
+        )
+    assert labelsOfBody[0] and labelsOfBody[1]
+    assert not (labelsOfBody[0] & labelsOfBody[1])

--- a/tests/test_simpletimestepper_resume.py
+++ b/tests/test_simpletimestepper_resume.py
@@ -1,0 +1,74 @@
+"""The zero increment a step is primed with, and what it reports on a resumed run.
+
+``SimpleTimeStepper`` yields one zero increment before the first real one, so an explicit
+integrator can build its initial state before taking a step. That increment has to report where
+the stepper actually *is*, which on a cold start is the beginning of the step and on a resumed run
+is not.
+
+Reporting the beginning of the step unconditionally had two consequences, because the explicit
+solver calls ``model.advanceToTime(timeStep.totalTime)`` on every increment and writes an output
+whenever ``timeStep.number`` is a multiple of ``output-frequency`` -- which 0 always is. Model time
+was rewound to the start of the step for one increment, and an output frame stamped with that
+rewound time was written into the middle of an otherwise increasing Ensight time set, leaving it
+non-monotonic. That is invalid in the EnSight Gold format, and it makes a reader pair variable
+frames with the wrong geometry: measured on a restarted anchor pry-out run, 70 of 257 frames.
+"""
+
+import pytest
+
+from edelweissfe.journal.journal import Journal
+from edelweissfe.timesteppers.simpletimestepper import SimpleTimeStepper
+
+STEP_START = 2.0
+STEP_LENGTH = 4.0
+
+
+def _stepper():
+    return SimpleTimeStepper(
+        currentTime=STEP_START,
+        stepLength=STEP_LENGTH,
+        startIncrement=0.25,
+        maxIncrement=0.25,
+        minIncrement=1e-8,
+        maxNumberIncrements=100,
+        journal=Journal(verbose=False),
+    )
+
+
+def test_the_priming_increment_of_a_cold_start_sits_at_the_step_start():
+    first = next(_stepper().generateTimeStep())
+
+    assert first.number == 0
+    assert first.timeIncrement == 0.0
+    assert first.stepProgressIncrement == 0.0
+    assert first.stepProgress == pytest.approx(0.0)
+    assert first.stepTime == pytest.approx(0.0)
+    assert first.totalTime == pytest.approx(STEP_START)
+
+
+def test_the_priming_increment_of_a_resumed_run_sits_where_the_checkpoint_left_off():
+    stepper = _stepper()
+    # what readRestart restores: half of this step was already solved before the checkpoint
+    stepper.finishedStepProgress = 0.5
+    stepper.totalIncrements = 37
+
+    first = next(stepper.generateTimeStep())
+
+    assert first.number == 0
+    assert first.timeIncrement == 0.0, "still a zero increment -- it must not advance the solution"
+    assert first.stepProgress == pytest.approx(0.5)
+    assert first.stepTime == pytest.approx(0.5 * STEP_LENGTH)
+    assert first.totalTime == pytest.approx(STEP_START + 0.5 * STEP_LENGTH), (
+        "the priming increment reported the step's start, so the solver rewound model.time and "
+        "stamped an output frame with it"
+    )
+
+
+def test_the_priming_increment_never_runs_time_backwards():
+    """The property that actually matters downstream: time never decreases across the sequence."""
+    for progress in (0.0, 0.25, 0.5, 0.75):
+        stepper = _stepper()
+        stepper.finishedStepProgress = progress
+        times = [step.totalTime for step in stepper.generateTimeStep()]
+        assert times == sorted(times), "time decreased at progress {:}: {:}".format(progress, times)
+        assert times[0] == pytest.approx(STEP_START + progress * STEP_LENGTH)


### PR DESCRIPTION
A node created by subdividing an element must be *the same node* for every parent that touches the point. The registry decided that by rounding the coordinate to eight decimals and comparing — and a rounding tie makes two parents disagree.

The tie is not a rare accident. A mesh written with seven significant decimals puts the quarter-point of a graded quadratic edge exactly on one:

```
0.75 * (-3.636364) - 0.125 * (-7.272727) = -1.8181821249999999
```

Both neighbours compute that point through their own isoparametric map, so their last bits differ, so one rounds to `-1.81818212` and the other to `-1.81818213`, and each mints its own label. Nothing then constrains the two together: **the mesh is torn at that point, silently**, and the two halves are free to separate.

### What it cost

On `examples/AnchorPryOut` this produced **156 duplicated nodes**, every one of them on the `y = -1.818182125` plane. They separated in proportion to the load from the first refinement onward, and past 25 000 elements the largest opening exceeded the largest real displacement in the model — the "deformation" being computed was the crack:

| frame | duplicate pairs | max separation | max\|u\| |
|---|---|---|---|
| geo_0007 | 6 | 0.040 mm | 0.206 mm |
| geo_0023 | 59 | 0.152 mm | 0.785 mm |
| geo_0026 | 84 | **3.18 mm** | 2.16 mm |
| geo_0032 | 156 | **14.47 mm** | 8.37 mm |

One pair reached 18.9 mm and ended a 380 000-increment explicit run in a `GCDPModel::computeStress: Return mapping failed`, having first driven `max|V|` from 78 to 78 000 mm/s and the kinetic energy from 1.7 % to 41.7 % of external work. It is not mesh-specific: `examples/AnchorPryOutCoarse` has 13 such pairs, with the same `...125` / `...375` signature.

Worth stressing what this looks like from the outside, because it cost a day of misdiagnosis: the Dirichlet conditions stay satisfied exactly, the lumped mass is conserved to `0.0e+00`, momentum and kinetic energy across each topology change look healthy — and the run still tears itself apart. It presents as a time-step instability and is not one.

### The fix

A node's identity is topological, and was available exactly all along. Every node a subdivision produces sits at parametric `-1 + k/n` for an integer `k`, so it is either

- one of the parent's own nodes — matched on the integer lattice and reused, or
- a new node spanned by some of the parent's corners — named by those corner *labels* paired with exact integer weights.

Two elements sharing a face or an edge derive the identical name for a point on it: no coordinate comparison, no tolerance, and no dependence on how their local axes happen to be oriented. Coordinates keep only the roles they are good for — seeding a live model's existing labels, and root elements, where the values are the model's own and are matched exactly rather than reconstructed.

### Verification

- Refining all 11 176 concrete elements of `examples/AnchorPryOut`: **265 duplicated nodes before, 0 after**, with the node count falling by exactly 265.
- `tests/test_adaptivity_node_identity.py` (new): pins the two-element case with elements 7271 and 9540 of that mesh verbatim, and asserts the other half of the contract too — two bodies meeting at a flush interface must **keep** their coincident nodes distinct, so a tied interface is never welded shut.
- Full `tests/` on a build with the Cython extensions: `346 → 350` passed, the same 5 pre-existing failures in both, no regressions.

### Restart compatibility — please read before merging

Node fields are stored positionally and restored with `read_direct`, and `replayTopologyHistory` runs first with `verifyTopologyFingerprints = True`. A checkpoint written before this change therefore **fails loudly** when replayed after it, at the first round whose mesh differs — it cannot silently corrupt. But it also cannot resume.

That is the mechanical answer; the substantive one is that resuming was never valid anyway. The tear is present from the *first* refinement, so every pre-existing checkpoint stores an already-torn mesh, and merging the duplicate pair mid-run means welding an open crack shut. Runs that used live h-adaptivity need redoing from `t = 0`.
