### PR TITLE
fix(restart): stop a resumed run misreporting its own state

### DIFF
--- a/edelweissfe/drivers/inputfiledrivensimulation.py
+++ b/edelweissfe/drivers/inputfiledrivensimulation.py
@@ -224,7 +224,20 @@ def finiteElementSimulation(
                     continue
                 if step.number == resumeStepNumber:
                     step.timeStepper.readRestart(resumeCheckpoint)
+                    # Accumulators the solver cannot recompute from the converged solution -- the
+                    # explicit solver's external work is one; see its own readRestart.
+                    step.solver.readRestart(resumeCheckpoint)
                     resumeStepNumber = None
+
+                    # Nothing reads the checkpoint after this point, and it must not stay open:
+                    # the restart output manager's ring buffer rotates onto the oldest slot by
+                    # mtime, which -- once the ring has filled -- can be this very file, and HDF5
+                    # cannot truncate a file it still holds open. The resumed run then dies
+                    # mid-step with "unable to truncate a file which is already open", which reads
+                    # like a solver failure and is not one. Closing it here rather than after the
+                    # step loop is what keeps the writer's slot free.
+                    resumeCheckpoint.close()
+                    resumeCheckpoint = None
 
             tic = getCurrentTime()
             try:

--- a/edelweissfe/outputmanagers/restart.py
+++ b/edelweissfe/outputmanagers/restart.py
@@ -183,6 +183,7 @@ class OutputManager(OutputManagerBase):
             f.attrs["stepNumber"] = self._currentStep.number
             self.model.writeRestart(f)
             self._currentStep.timeStepper.writeRestart(f)
+            self._currentStep.solver.writeRestart(f)
 
             # Sibling output managers' own sequence bookkeeping (e.g. Ensight's transient time/file
             # sets, whose file numbering a resumed run would otherwise restart from zero, orphaning

--- a/edelweissfe/solvers/base/nonlinearsolverbase.py
+++ b/edelweissfe/solvers/base/nonlinearsolverbase.py
@@ -143,6 +143,33 @@ class NonlinearSolverBase(OptionSchemaProvider, ABC):
             else:
                 self.options[canonicalKey] = type(defaultValue)(v)
 
+    def writeRestart(self, restartFile):
+        """Write solver state that a resumed run cannot reconstruct from the converged solution.
+
+        Called once per checkpoint by the restart output manager, alongside the model's and the
+        time stepper's own ``writeRestart``. Most solvers need nothing here: an implicit solver
+        rebuilds everything it uses from the solution it just converged. A no-op by default, so a
+        solver declares such state only when it actually carries some.
+
+        Parameters
+        ----------
+        restartFile
+            The open checkpoint to write to.
+        """
+
+    def readRestart(self, restartFile):
+        """Restore what :meth:`writeRestart` wrote.
+
+        Must tolerate a checkpoint that carries no state for this solver -- one written by a
+        different solver, or written before this solver carried any. A resumed run then behaves as
+        it did before the state was checkpointed, rather than failing.
+
+        Parameters
+        ----------
+        restartFile
+            The open checkpoint to read from.
+        """
+
     def applyOptionsOverride(self, fieldValues: dict) -> None:
         """Apply a partial override of this solver's own ``schema`` fields onto ``self.options``.
 

--- a/edelweissfe/solvers/nonlinearexplicitdynamic.py
+++ b/edelweissfe/solvers/nonlinearexplicitdynamic.py
@@ -318,6 +318,10 @@ class NED(NonlinearSolverBase):
         #: increment. Compared against the kinetic energy to detect energy creation; see
         #: _ENERGY_CREATION_TOLERANCE.
         self._externalWork = 0.0
+        #: The external work a resumed checkpoint carried, handed to the next solveStep. Staged
+        #: rather than assigned directly because readRestart necessarily runs before solveStep,
+        #: which resets the live accumulator; see :meth:`readRestart`.
+        self._resumedExternalWork = 0.0
         #: Per-constraint force buffer and scatter plan, by constraint name; see
         #: :meth:`assembleConstraintForces`. Cleared whenever the DofManager is rebuilt.
         self._constraintForcePlans = {}
@@ -343,6 +347,55 @@ class NED(NonlinearSolverBase):
                     self.options[k] = type(self.NEDOptions[k])(updatedOptions[k])
             else:
                 raise AttributeError("Invalid option {:} for {:}".format(k, self.identification))
+
+    def writeRestart(self, restartFile):
+        """Persist the accumulated external work.
+
+        It is an ACCUMULATOR, not a state that can be recomputed: it is summed increment by
+        increment from the reaction forces at the prescribed degrees of freedom, so nothing in a
+        converged solution reproduces it.
+
+        A resumed run that started it at zero compared its kinetic energy against only the work
+        done since the resume -- and that comparison is the check on whether the run is still
+        quasi-static and whether energy is being created, so the one diagnostic that would flag a
+        run going wrong instead read as though the model were mostly kinetic. The anchor pry-out
+        run resumed at 22 % of its ramp reported kinetic energy at 41.7 % of external work for
+        that reason alone.
+
+        Parameters
+        ----------
+        restartFile
+            The open checkpoint to write to.
+        """
+        restartFile.require_group("solver").attrs["externalWork"] = self._externalWork
+
+    def _consumeResumedExternalWork(self) -> float:
+        """The external work a resumed checkpoint carried, handed over exactly once.
+
+        The energy balance is per step, so the step being resumed picks up where the checkpoint
+        left off while any later step in the same job correctly starts from zero -- hence consumed
+        rather than merely read. It is staged in the first place because
+        :meth:`readRestart` necessarily runs BEFORE :meth:`solveStep`, which resets the live
+        accumulator and would otherwise wipe the restored value before the first increment.
+        """
+        resumed = self._resumedExternalWork
+        self._resumedExternalWork = 0.0
+        return resumed
+
+    def readRestart(self, restartFile):
+        """Restore the accumulated external work; see :meth:`writeRestart`.
+
+        Tolerates a checkpoint written before this state was carried, in which case the resumed
+        step's energy balance is wrong in the old way rather than the run failing.
+
+        Parameters
+        ----------
+        restartFile
+            The open checkpoint to read from.
+        """
+        if "solver" not in restartFile or "externalWork" not in restartFile["solver"].attrs:
+            return
+        self._resumedExternalWork = float(restartFile["solver"].attrs["externalWork"])
 
     def solveStep(
         self,
@@ -375,7 +428,7 @@ class NED(NonlinearSolverBase):
         # window they never ran in and drive the residue negative.
         stepWallClockTic = perf_counter()
 
-        self._externalWork = 0.0
+        self._externalWork = self._consumeResumedExternalWork()
         self._cumulativeMassDrift = 0.0
         self._warnedAboutMissingInternalEnergy = False
         self._warnedAboutMissingExternalWork = False

--- a/edelweissfe/timesteppers/adaptivetimestepper.py
+++ b/edelweissfe/timesteppers/adaptivetimestepper.py
@@ -299,6 +299,7 @@ class AdaptiveTimeStepper(TimeStepperBase):
         self.currentTime = f["timestepper"].attrs["currentTime"]
         self.nPassedGoodIncrements = f["timestepper"].attrs["nPassedGoodIncrements"]
         self.incrementCounter = f["timestepper"].attrs["incrementCounter"]
+        self.warnIfResumedAtIncrementCap(self.incrementCounter, self.maxNumberIncrements, self.journal)
         self.finishedStepProgress = f["timestepper"].attrs["finishedStepProgress"]
         self.increment = f["timestepper"].attrs["increment"]
         self.allowedToIncreasedNext = f["timestepper"].attrs["allowedToIncreasedNext"]

--- a/edelweissfe/timesteppers/base/timestepperbase.py
+++ b/edelweissfe/timesteppers/base/timestepperbase.py
@@ -41,6 +41,47 @@ class TimeStepperBase(ABC):
     the incrementation of a simulation step.
     """
 
+    #: Overridden by every stepper; a default so base-class diagnostics can name their source.
+    identification = "TimeStepper"
+
+    def warnIfResumedAtIncrementCap(self, incrementsAlreadyDone: int, maxNumberIncrements: int, journal):
+        """Warn when a checkpoint is resumed at or past the step's increment cap.
+
+        ``maxNumInc`` counts increments from the start of the analysis, not from the resume, and it
+        is deliberately taken from the step's own configuration rather than the checkpoint -- see
+        the subclasses' ``writeRestart`` -- precisely so it can be raised between runs. The
+        consequence is a trap: resume without raising it far enough and the stepper's very first
+        check ends the step, the solver catches that as a step which finished normally, and the job
+        exits reporting success having advanced nothing. That is indistinguishable from a completed
+        run, and it has been mistaken for one: a diagnostic arm resumed at increment 130 000 with
+        maxNumInc still at 60 000 ran a single zero increment, reported success, and was very
+        nearly read as evidence that a crash did not reproduce.
+
+        This does not change the behaviour -- the cap is absolute by design -- only the silence.
+
+        Parameters
+        ----------
+        incrementsAlreadyDone
+            The increment count restored from the checkpoint.
+        maxNumberIncrements
+            The cap this step was configured with.
+        journal
+            The journal to report on.
+        """
+        if incrementsAlreadyDone < maxNumberIncrements:
+            return
+
+        journal.message(
+            "WARNING: this checkpoint is already at increment {:}, at or past this step's "
+            "maxNumInc of {:}, so the resumed step will end immediately WITHOUT advancing the "
+            "solution -- and the job will then report success. maxNumInc counts increments from "
+            "the start of the analysis, not from the resume: raise it above {:} to continue.".format(
+                incrementsAlreadyDone, maxNumberIncrements, incrementsAlreadyDone
+            ),
+            self.identification,
+            0,
+        )
+
     @abstractmethod
     def generateTimeStep(self, enforcedTimeIncrement: float = None) -> TimeStep:
         """Generate the (sequence of) time steps.

--- a/edelweissfe/timesteppers/simpletimestepper.py
+++ b/edelweissfe/timesteppers/simpletimestepper.py
@@ -322,6 +322,7 @@ class SimpleTimeStepper(TimeStepperBase):
         f = restartFile
         self.currentTime = f["timestepper"].attrs["currentTime"]
         self.totalIncrements = f["timestepper"].attrs["totalIncrements"]
+        self.warnIfResumedAtIncrementCap(self.totalIncrements, self.maxNumberIncrements, self.journal)
         self.finishedStepProgress = f["timestepper"].attrs["finishedStepProgress"]
         self.increment = f["timestepper"].attrs["increment"]
         self.dT = f["timestepper"].attrs["dT"]

--- a/tests/test_restart_selfreporting.py
+++ b/tests/test_restart_selfreporting.py
@@ -1,0 +1,118 @@
+"""What a resumed run reports about its own state.
+
+Three defects in one theme, each of which cost real diagnosis time on the anchor pry-out campaign:
+a resumed run crashed on the checkpoint it had been resumed from, reported an energy balance
+computed from an accumulator that had been reset to zero, and could exit "success" having advanced
+nothing at all.
+
+The ring-buffer collision is not unit-testable here -- it needs two runs against the same directory,
+and is covered by resuming NEDLiveAMR from a slot the ring is due to overwrite.
+"""
+
+import h5py
+import pytest
+
+from edelweissfe.journal.journal import Journal
+from edelweissfe.solvers.nonlinearexplicitdynamic import NED
+from edelweissfe.timesteppers.simpletimestepper import SimpleTimeStepper
+
+
+class _RecordingJournal:
+    """Records what would have been reported, so a diagnostic can be asserted on."""
+
+    def __init__(self):
+        self.messages = []
+
+    def message(self, text, identification, level=1):
+        self.messages.append(text)
+
+    def errorMessage(self, text, identification):
+        self.messages.append(text)
+
+
+def _solver():
+    return NED({}, Journal(verbose=False))
+
+
+def _stepper(maxNumberIncrements=60000):
+    return SimpleTimeStepper(
+        currentTime=0.0,
+        stepLength=1.0,
+        startIncrement=0.1,
+        maxIncrement=0.1,
+        minIncrement=1e-8,
+        maxNumberIncrements=maxNumberIncrements,
+        journal=Journal(verbose=False),
+    )
+
+
+def test_the_accumulated_external_work_survives_a_checkpoint(tmp_path):
+    solver = _solver()
+    solver._externalWork = -1234.5
+
+    checkpoint = tmp_path / "chk.h5"
+    with h5py.File(checkpoint, "w") as f:
+        solver.writeRestart(f)
+
+    resumed = _solver()
+    with h5py.File(checkpoint, "r") as f:
+        resumed.readRestart(f)
+
+    # Staged rather than applied: solveStep resets the live accumulator and necessarily runs after
+    # readRestart, so a direct assignment here would be wiped before the first increment.
+    assert resumed._resumedExternalWork == pytest.approx(-1234.5)
+    assert resumed._externalWork == 0.0
+
+
+def test_a_checkpoint_carrying_no_solver_state_is_tolerated(tmp_path):
+    """Written by a different solver, or before this state was carried at all. A resumed run then
+    has the old, wrong energy balance -- which is strictly better than refusing to start."""
+    checkpoint = tmp_path / "old.h5"
+    with h5py.File(checkpoint, "w") as f:
+        f.create_group("timestepper")
+
+    solver = _solver()
+    with h5py.File(checkpoint, "r") as f:
+        solver.readRestart(f)
+
+    assert solver._resumedExternalWork == 0.0
+
+
+def test_resuming_at_or_past_the_increment_cap_is_reported():
+    """The trap: maxNumInc counts from the start of the analysis, so a resume that does not raise
+    it far enough ends the step on its first check and the job reports success regardless."""
+    for alreadyDone in (60000, 130000):
+        journal = _RecordingJournal()
+        _stepper().warnIfResumedAtIncrementCap(alreadyDone, 60000, journal)
+
+        assert len(journal.messages) == 1, "no warning at {:} of 60000".format(alreadyDone)
+        reported = journal.messages[0]
+        assert str(alreadyDone) in reported and "60000" in reported
+        assert "without advancing" in reported.lower()
+
+
+def test_resuming_below_the_increment_cap_is_silent():
+    journal = _RecordingJournal()
+    _stepper().warnIfResumedAtIncrementCap(59999, 60000, journal)
+    assert journal.messages == []
+
+
+def test_the_resumed_external_work_is_handed_over_exactly_once(tmp_path):
+    """Per-step semantics: the resumed step continues the checkpoint's accumulator, and any later
+    step in the same job starts from zero rather than inheriting it again."""
+    solver = _solver()
+    solver._externalWork = 42.0
+    checkpoint = tmp_path / "chk.h5"
+    with h5py.File(checkpoint, "w") as f:
+        solver.writeRestart(f)
+
+    resumed = _solver()
+    with h5py.File(checkpoint, "r") as f:
+        resumed.readRestart(f)
+
+    assert resumed._consumeResumedExternalWork() == pytest.approx(42.0)
+    assert resumed._consumeResumedExternalWork() == 0.0, "a later step must not inherit it again"
+
+
+def test_a_cold_start_consumes_nothing():
+    assert _solver()._consumeResumedExternalWork() == 0.0


### PR DESCRIPTION
Three defects, one theme: **a resumed run lying about its own state at the boundaries.** None changes solver physics. Each cost real diagnosis time on the anchor pry-out campaign, and two of them actively produced wrong conclusions that were then acted on.

### 1. The ring buffer wrote the checkpoint it had been resumed from

The driver opened the checkpoint and closed it only *after the whole step loop*, because the time stepper's `readRestart` is called lazily inside that loop. Meanwhile the restart manager's ring rotates and, once full, writes the oldest slot by mtime — which can be that very file. HDF5 cannot truncate a file it still holds open:

```
OSError: unable to truncate a file which is already open
```

That reads like a solver failure and is not one. It is what made a halved-time-step experiment look like it had failed to fix a divergence, when the run had actually died on a file handle.

`_RestartFileRingBuffer`'s own docstring shows the *silent overwrite* half of this was anticipated and solved (resume the on-disk ring state); the *still open* half wasn't. Nothing reads the checkpoint once the stepper and solver have taken what they need, so it's closed there.

**Verified on the failing path, not around it:** resuming `NEDLiveAMR` from a slot the ring is due to overwrite now completes, and `chk_3`'s mtime confirms that slot really was rewritten during the resumed run rather than the run stopping short of it.

### 2. The energy balance was computed from an accumulator reset to zero

`_externalWork` is summed increment by increment from the reactions at prescribed DOFs, so nothing in a converged solution reproduces it — and it wasn't checkpointed. A resumed run compared its kinetic energy against only the work done *since the resume*.

That comparison is the check on whether a run is still quasi-static and whether energy is being created. So the one diagnostic that would flag a run going wrong instead read as though the model were mostly kinetic: the pry-out run resumed at 22 % of its ramp reported **kinetic energy at 41.7 % of external work** for this reason alone — and that number was quoted as evidence of a physical problem.

Solvers now get `writeRestart`/`readRestart` alongside the model's and the stepper's: no-ops in the base, so a solver declares such state only if it carries some, and tolerant of a checkpoint that has none (another solver's, or one predating this) so old checkpoints still resume. The explicit solver stages the value and consumes it **exactly once**, because `readRestart` necessarily runs before `solveStep`, which resets the live accumulator.

### 3. A resume past `maxNumInc` reported success having computed nothing

`maxNumInc` counts increments from the start of the analysis, and is deliberately taken from the step's configuration rather than the checkpoint so it can be raised between runs. Resume without raising it far enough and the stepper's first check ends the step, the solver catches that as a step which finished normally, and the job exits **successfully**.

A diagnostic arm resumed at increment 130 000 with `maxNumInc` still at 60 000 ran a single zero increment, reported success, and was very nearly read as evidence that a crash did not reproduce.

The cap stays absolute — only the silence goes. Both steppers report it from `readRestart`, through one helper on `TimeStepperBase` so they can't drift apart.

### Verification

`tests/test_restart_selfreporting.py` covers 2 and 3, including the `>=` boundary, the old-checkpoint path, and the consume-exactly-once semantics. Defect 1 needs two runs against one directory, so it's covered by the `NEDLiveAMR` resume above. Full `tests/`: **353 → 359 passed**, same 5 pre-existing failures.

### One note for the diff

`adaptivetimestepper.py` is stored with **CRLF**, alone among these files. It's edited with newline preservation — a plain text-mode rewrite turns it into a 305-line whitespace diff that buries the one real line.
