### PR TITLE
refactor(solvers): merge blockamg's per-solve diagnostics into the Newton table

### DIFF
--- a/edelweissfe/linsolve/base.py
+++ b/edelweissfe/linsolve/base.py
@@ -81,6 +81,40 @@ class FieldBlock:
     dimension: int
 
 
+@dataclass(frozen=True)
+class LinearSolveSummary:
+    """One solver call's diagnostics -- exactly what the nonlinear solver renders as the extra
+    "linear solve" column in its own convergence table (see
+    :meth:`~edelweissfe.solvers.base.nonlinearsolverbase.NonlinearSolverBase.checkConvergence`).
+
+    Attributes
+    ----------
+    iters
+        This call's outer iteration count (e.g. GMRES outer iterations).
+    residual
+        The achieved residual, in whatever norm the solver checks against its own tolerance.
+    residualMet
+        Whether ``residual`` met the solver's own requested tolerance for this call -- rendered with
+        the same "met tolerance" checkmark the Newton residual columns already use.
+    retries
+        How many extra internal attempts this call needed to meet its tolerance (``0`` for a clean
+        first-pass solve). Rendered as a superscript on the iteration count rather than a plain digit,
+        so it can never be misread as part of that number (e.g. iters=65, retries=2 must not look like
+        the single number 652).
+    detailLines
+        Extra lines confined to the "linear solve" column's own width, for detail a routine glance
+        does not need but solver tuning does (e.g. why a preconditioner was rebuilt). Empty unless the
+        solver's own verbosity setting asks for it -- solvers that never populate this simply cost the
+        caller nothing beyond checking for an empty tuple.
+    """
+
+    iters: int
+    residual: float
+    residualMet: bool
+    retries: int
+    detailLines: tuple = ()
+
+
 class LinearSolver:
     """Common base for every ``linsolver`` registry entry. Callable as ``(A, b) -> x``.
 
@@ -93,6 +127,25 @@ class LinearSolver:
     _fieldStructure: "list[FieldBlock] | None" = None
     _model = None
     _dofManager = None
+
+    #: Display name for this solver's own log lines (e.g. a "linear solve" column's debug detail).
+    #: Overridden by a solver that wants its messages attributed to something other than the generic
+    #: base name -- e.g. ``BlockAMGSolver`` sets this to its own identification string.
+    identification = "LinearSolver"
+
+    #: Whether this solver reports per-solve diagnostics (an iteration count, a residual, etc.) that
+    #: the nonlinear solver can render as an extra "linear solve" column in its own convergence table.
+    #: ``False`` for solvers with nothing iterative to report -- a direct factorization has no
+    #: per-solve iteration count or residual, so there is nothing there worth a column. A solver
+    #: overriding this to ``True`` must also populate :attr:`lastSolveSummary` after every
+    #: :meth:`__call__`.
+    reportsSolveSummary = False
+
+    #: The most recent call's diagnostics as a :class:`LinearSolveSummary`, or ``None`` before any
+    #: call, or for a solver that never overrides :attr:`reportsSolveSummary`. Read by the nonlinear
+    #: solver immediately after calling this solver, to build its per-iteration row -- never pushed
+    #: proactively, since the caller alone knows when "this iteration's row" is being assembled.
+    lastSolveSummary: "LinearSolveSummary | None" = None
 
     def setJournal(self, journal) -> None:
         """Receive the shared :class:`~edelweissfe.journal.journal.Journal` instance.

--- a/edelweissfe/linsolve/blockamg/blockamg.py
+++ b/edelweissfe/linsolve/blockamg/blockamg.py
@@ -87,7 +87,7 @@ import scipy.sparse as sp
 from scipy.sparse.linalg import LinearOperator, gmres
 
 import edelweissfe.utils.performancetiming as performancetiming
-from edelweissfe.linsolve.base import FieldBlock, LinearSolver
+from edelweissfe.linsolve.base import FieldBlock, LinearSolver, LinearSolveSummary
 from edelweissfe.linsolve.nullspace import rigidBodyNullspace, translationNullspace
 
 # Ordered low-to-high; index comparison decides whether a message at a given level should print.
@@ -402,6 +402,9 @@ class BlockAMGSolver(LinearSolver):
         can often be answered directly from the manifest without needing a replay at all.
     """
 
+    #: See :attr:`~edelweissfe.linsolve.base.LinearSolver.identification`.
+    identification = _IDENTIFICATION
+
     #: Degradation dumps written across every instance in this process, so
     #: ``dumpOnDegradationMaxDumps`` is a genuine process-wide ceiling -- the same reasoning as
     #: :class:`~edelweissfe.linsolve.matrixdump.matrixdump.MatrixDumpSolver`'s ``_totalDumpsWritten``.
@@ -510,7 +513,6 @@ class BlockAMGSolver(LinearSolver):
         BlockAMGSolver._instancesCreated += 1
 
         self._solveCount = 0
-        self._fieldsAnnounced = None
 
         # Eisenstat-Walker forcing state.
         self._lastResidualNorm = None
@@ -539,6 +541,26 @@ class BlockAMGSolver(LinearSolver):
         # condition under which AMGCL's own preallocated scratch vectors are no longer valid.
         self._lgmresSolver = None
         self._lgmresN = None
+
+        self._lastSolveSummary = None
+
+    @property
+    def reportsSolveSummary(self) -> bool:
+        """Whether the nonlinear solver should render a "linear solve" column for this instance.
+
+        Tied to this instance's own verbosity rather than a bare ``True`` -- at ``"silent"`` or
+        ``"warning"`` (the default) there is nothing routine to show, matching those settings' own
+        contract (see the ``verbosity`` parameter docstring above); only at ``"info"`` or ``"debug"``
+        does :attr:`lastSolveSummary` carry anything worth a column.
+        """
+        return self._verbosityIndex >= _VERBOSITY_LEVELS.index("info")
+
+    @property
+    def lastSolveSummary(self) -> "LinearSolveSummary | None":
+        """The most recent call's diagnostics -- see
+        :attr:`~edelweissfe.linsolve.base.LinearSolver.lastSolveSummary`. ``None`` before the first
+        call."""
+        return self._lastSolveSummary
 
     def _log(self, level: str, message: str) -> None:
         """Emit ``message`` through the injected Journal (see ``setJournal``, inherited from
@@ -862,20 +884,6 @@ class BlockAMGSolver(LinearSolver):
             )
             self._lgmresN = n
 
-        fieldNames = [block.name for block in blocks]
-        if fieldNames != self._fieldsAnnounced:
-            self._log("info", "blockamg linear solver: fields = {:}".format(", ".join(fieldNames)))
-            # The column header for every per-solve line below, printed once here (same trigger as the
-            # fields announcement, since the columns themselves never change without it) instead of on
-            # every single solve -- once you know what the columns mean, the compact rows are enough.
-            self._log(
-                "info",
-                "{:<6} {:<8} {:>5} {:>7} {:>7} {:>7} {:>7}".format(
-                    "solve", "precond", "iters", "η", "‖r‖", "retries", "time"
-                ),
-            )
-            self._fieldsAnnounced = fieldNames
-
         residualNorm = float(np.linalg.norm(b))
         newIncrement = (
             self._lastResidualNorm is not None and residualNorm > self._residualGrowthFactor * self._lastResidualNorm
@@ -894,15 +902,32 @@ class BlockAMGSolver(LinearSolver):
         # nothing to reuse yet, the field-block layout changed (e.g. an AMR event resized the DOF
         # vector), the sparsity pattern changed, a residual jump marks a new increment / cutback, or the
         # previous solve's own outer count asked for it (drifted too far from the one before it).
+        wasStale = self._refreshNext
         mustRefresh = (
             self._preconditioners is None
             or blocks != self._blocks
             or n != self._n
             or patternChanged
             or newIncrement
-            or self._refreshNext
+            or wasStale
         )
         self._refreshNext = False
+
+        # Captured now, in priority order matching mustRefresh above -- by the time the debug detail
+        # is built at the end of this call, self._refreshNext has already been overwritten for the
+        # *next* call, so "why" has to be recorded at the point mustRefresh itself is decided.
+        if not mustRefresh:
+            rebuildReason = None
+        elif self._preconditioners is None:
+            rebuildReason = "first"
+        elif blocks != self._blocks or n != self._n:
+            rebuildReason = "amr"
+        elif patternChanged:
+            rebuildReason = "pattern"
+        elif newIncrement:
+            rebuildReason = "increment"
+        else:
+            rebuildReason = "stale"
 
         with performancetiming.timeit("equilibration"):
             if mustRefresh:
@@ -1262,17 +1287,23 @@ class BlockAMGSolver(LinearSolver):
         self._lastEta = eta
 
         solveElapsedTime = time.time() - solveStartTime
-        self._log(
-            "info",
-            "{:<6} {:<8} {:>3d}it {:>7.1e} {:>7.1e} {:>7d} {:>6.1f}s".format(
-                "#{:}".format(self._solveCount),
-                "rebuilt" if mustRefresh else "reused",
-                outerIters,
-                eta,
-                trueResidual,
-                continuations,
-                solveElapsedTime,
-            ),
+
+        # Populated unconditionally (cheap: one dataclass construction) -- reportsSolveSummary, not
+        # this, is what decides whether the nonlinear solver ever looks at it, so there is nothing to
+        # gate here beyond detailLines, which is genuinely wasted work at anything below "debug".
+        detailLines = ()
+        if self._verbosityIndex >= _VERBOSITY_LEVELS.index("debug"):
+            precondWord = "rebuilt({:})".format(rebuildReason) if mustRefresh else "reused"
+            detailLines = (
+                precondWord,
+                "η={:.1e} · {:.1f}s".format(eta, solveElapsedTime),
+            )
+        self._lastSolveSummary = LinearSolveSummary(
+            iters=outerIters,
+            residual=trueResidual,
+            residualMet=trueResidual <= eta,
+            retries=continuations,
+            detailLines=detailLines,
         )
         if outerIters > self._warnOuterIterationsThreshold:
             # Rare and actionable, so this stays at "warning" (Journal level 0, the least indented and

--- a/edelweissfe/solvers/base/nonlinearsolverbase.py
+++ b/edelweissfe/solvers/base/nonlinearsolverbase.py
@@ -328,7 +328,33 @@ class NonlinearSolverBase(OptionSchemaProvider, ABC):
 
             convergedAtAll = convergedAtAll and convergedCorrection and convergedFlux
 
-        self.journal.message(iterationMessage, self.identification)
+        # The width of the real fields' cells only, captured before the linear-solve cell (if any) is
+        # appended -- this is exactly how far a debug detail line below needs to be blank-padded to
+        # land in the "linear solve" column's own lane instead of sprawling across the whole row.
+        realFieldsWidth = len(iterationMessage)
+
+        summary = self.linSolver.lastSolveSummary if self.linSolver.reportsSolveSummary else None
+        if summary is not None and ddU is not None:
+            # ddU is None on the very first iteration of an increment (no linear solve has happened
+            # yet this increment) -- without this guard, the column would show a stale summary left
+            # over from the previous increment's last solve, which belongs to no residual on this row.
+            superscript = {0: "", 1: "¹", 2: "²", 3: "³"}.get(summary.retries, "")
+            itersPart = "{:}{:}".format(summary.iters, superscript)
+            iterationMessage += "{:<12}{:11.2e}{:1} ".format(
+                itersPart, summary.residual, "✓" if summary.residualMet else " "
+            )
+        elif summary is not None:
+            iterationMessage += " " * 25
+
+        self.journal.message(iterationMessage, self.identification, level=2)
+
+        if summary is not None and ddU is not None:
+            for line in summary.detailLines:
+                self.journal.message(
+                    " " * realFieldsWidth + "{:>25}".format(line),
+                    self.linSolver.identification,
+                    level=2,
+                )
 
         return convergedAtAll, nodesWithLargestResidual
 

--- a/edelweissfe/solvers/nonlinearimplicitstatic.py
+++ b/edelweissfe/solvers/nonlinearimplicitstatic.py
@@ -339,9 +339,17 @@ class NIST(NonlinearSolverBase):
                             "scalar variables",
                         ]
 
-                    nVariables = len(presentVariableNames)
-                    self.iterationHeader = ("{:^25}" * nVariables).format(*presentVariableNames)
-                    self.iterationHeader2 = (" {:<10}  {:<10}  ").format("||R||∞", "||ddU||∞") * nVariables
+                    self.iterationHeader2 = (" {:<10}  {:<10}  ").format("||R||∞", "||ddU||∞") * len(
+                        presentVariableNames
+                    )
+                    if self.linSolver.reportsSolveSummary:
+                        # One more column, exactly like any other field's, for the linear solver's own
+                        # per-iteration diagnostics -- see NonlinearSolverBase.checkConvergence, which
+                        # builds and appends the matching row cell.
+                        presentVariableNames = presentVariableNames + ["linear solve"]
+                        self.iterationHeader2 += (" {:<10}  {:<10}  ").format("iters", "‖r‖")
+
+                    self.iterationHeader = ("{:^25}" * len(presentVariableNames)).format(*presentVariableNames)
                     self.iterationMessageTemplate = "{:11.2e}{:1}{:11.2e}{:1} "
 
                     K = self.theDofManager.constructVIJSystemMatrix()


### PR DESCRIPTION
## Summary

Follow-up to #130. That PR fixed blockamg's header from printing once for the whole run
instead of once per increment, and compacted its per-solve summary into one line -- but that
line still lived on its own, interleaved with (not merged into) the Newton residual rows it
corresponds to one-for-one, so reading either meant skipping every other line. It also had no
way to show *why* the preconditioner was rebuilt, which is exactly what tuning
`hierarchyStalenessFactor`/`residualGrowthFactor` needs.

## What changed

- `LinearSolver` gains a small opt-in contract: `reportsSolveSummary`, `lastSolveSummary` (a new
  `LinearSolveSummary` dataclass: iterations, achieved residual, whether it met the requested
  tolerance, retries), and `identification`.
- `BlockAMGSolver` populates that summary instead of logging its own line, and reports which of
  five conditions triggered a rebuild (first solve, an AMR field/size change, a sparsity-pattern
  change, a detected new increment, or the staleness factor) -- captured at the point
  `mustRefresh` itself is decided, since that state is already overwritten by the time a summary
  would otherwise be built at the end of the call.
- `NonlinearSolverBase.checkConvergence` treats "linear solve" as one more field-column,
  alongside `displacement`/`nonlocal damage`/etc.: the header (already reprinted every increment)
  gains an `iters`/`‖r‖` pair, the row gains a matching cell, retries render as a superscript on
  the iteration count so `iters=65, retries=2` can never be misread as the plain number `652`.
- A solver's debug-level detail (rebuild reason, η, wall time) prints as extra lines confined to
  and right-aligned within the "linear solve" column's own width, not sprawling across the row.
- Also fixes a small pre-existing, unrelated bug this surfaced: `checkConvergence`'s row printed
  at Journal level 1 while its own header printed at level 2 -- an accidental two-character
  offset between label and value that happened to look consistent only because of how the two
  levels' template widths combined. Both now print at level 2.

No behavior outside logging changes.

## Test plan

- [x] `black --check`, `isort --check`, `flake8` clean on all four changed files
- [x] Rebased onto current `next_v26.11` (past #130/#131/#132/#133); cherry-picked cleanly
      around #133's unrelated addition to the same file (`nonlinearsolverbase.py`)
- [x] Manual run with `blockamg` `verbosity=debug`: all five rebuild reasons and the retries
      superscript render correctly; every emitted line checked programmatically at exactly the
      existing 100-column width
- [x] Full `edelweiss-only` regression suite (~60 cases): same single pre-existing, unrelated
      failure (`MeshPlot`'s LaTeX toolchain) as baseline; `CantileverBeamQuad4BlockAMG` (the one
      test that actually exercises `blockamg.py`) passes bit-identically to `U.ref`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
