### PR TITLE
fix(ci): pin pyvista below 0.49.0 to unbreak free-threaded builds

### DIFF
--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -1,5 +1,8 @@
 docutils
 matplotlib
 pyamg
-pyvista
+# pyvista>=0.49.0 pulls in pyvista-validation==0.2.2, whose sdist build hard-codes
+# py_limited_api='cp310', which setuptools rejects under free-threaded Python
+# (Py_GIL_DISABLED). Pin below that until pyvista-validation supports cp314t.
+pyvista<0.49.0
 vtk


### PR DESCRIPTION
## Summary
- `pyvista` 0.49.0 (released 2026-09-08) newly depends on `pyvista-validation==0.2.2`, whose sdist build hard-codes `py_limited_api='cp310'`.
- setuptools rejects that under free-threaded Python (`Py_GIL_DISABLED`), which our CI uses (`python-freethreading` 3.14t) — so `pip install -r pip_requirements.txt` now fails on every workflow (`run_tests_with_marmot`, `run_tests_without_marmot`, `sphinx`).
- Pin `pyvista<0.49.0` in `pip_requirements.txt` until `pyvista-validation` supports cp314t.

This is unrelated to any pending PR's diff — confirmed by comparing against the base branch's own last (green) CI run before today, and by the failure surfacing identically across otherwise-unrelated open PRs (e.g. #135).

## Test plan
- [x] Confirmed `pyvista==0.48.4` has no `pyvista-validation` dependency (verified against PyPI metadata)
- [ ] CI green on this PR