### PR TITLE
feat(linsolve): hot-reload BlockAMGSolver's JSON config during a run

### DIFF
--- a/edelweissfe/linsolve/blockamg/__init__.py
+++ b/edelweissfe/linsolve/blockamg/__init__.py
@@ -143,6 +143,7 @@ def createSolver(opts) -> Callable:
         ("dumpOnDegradationThreshold", int),
         ("dumpOnDegradationMaxDumps", int),
         ("dumpOnDegradationContextSolves", int),
+        ("hotReloadConfigFile", str),
     ):
         if key in optionMap:
             kwargs[key] = cast(optionMap[key])

--- a/edelweissfe/linsolve/blockamg/blockamg.py
+++ b/edelweissfe/linsolve/blockamg/blockamg.py
@@ -78,6 +78,7 @@ symmetric-aggregation-based hierarchy already reaches a working feasibility poin
 """
 
 import collections
+import inspect
 import json
 import os
 import time
@@ -400,6 +401,26 @@ class BlockAMGSolver(LinearSolver):
         Every dumped solve (trigger or context) also records ``mustRefresh``/``patternChanged``/
         ``newIncrement``/``previousOuterIters`` in the manifest, so the hierarchy-staleness question
         can often be answered directly from the manifest without needing a replay at all.
+    hotReloadConfigFile
+        Path to this solver's own JSON config file. When set, every solve checks whether the file
+        changed on disk and, if it did, re-reads it and applies the recognized settings, forcing a
+        hierarchy rebuild. Unset (the default) means the settings are fixed at construction.
+
+        This exists to make solver settings testable against a *live* run. A degraded AMG hierarchy
+        typically only appears tens of hours into a nonlinear analysis, and rebuilding that state to
+        try one parameter is the expensive part of every tuning round -- so the parameter can now be
+        changed in place instead, with the log recording which settings were in force from which
+        solve onwards.
+
+        Editing a file a running process reads is inherently racy, so the reload is built to fail
+        safely: the file is parsed *before* its modification stamp is accepted, so the half-written
+        state an editor briefly leaves behind is retried on the next solve rather than recorded as
+        seen, and a missing, unreadable or malformed config is reported while the settings in force
+        are kept. Nothing about a bad edit can end the run -- which matters precisely because the
+        runs worth using this on are the ones that were expensive to reach.
+
+        Unrecognized keys are reported rather than ignored, and so are recognized ones that cannot
+        be applied after construction.
     """
 
     #: See :attr:`~edelweissfe.linsolve.base.LinearSolver.identification`.
@@ -450,6 +471,7 @@ class BlockAMGSolver(LinearSolver):
         dumpOnDegradationThreshold: int = None,
         dumpOnDegradationMaxDumps: int = 10,
         dumpOnDegradationContextSolves: int = 0,
+        hotReloadConfigFile: str = None,
     ):
         self._outerTol = outerTol
         self._outerRestart = outerRestart
@@ -497,6 +519,12 @@ class BlockAMGSolver(LinearSolver):
         )
         self._dumpOnDegradationMaxDumps = dumpOnDegradationMaxDumps
         self._dumpOnDegradationContextSolves = dumpOnDegradationContextSolves
+
+        # Hot reload: the path to watch, and the (mtime_ns, size) it was last read at. Seeded as
+        # None rather than from the file, so the first solve reads and reports the settings actually
+        # in force -- which is the whole point when the file is being edited during a long run.
+        self._hotReloadConfigFile = hotReloadConfigFile
+        self._hotReloadStamp = None
         if self._dumpOnDegradationDir is not None:
             os.makedirs(self._dumpOnDegradationDir, exist_ok=True)
         # Rolling window of the last dumpOnDegradationContextSolves solves (each entry: solveCount, A,
@@ -858,11 +886,134 @@ class BlockAMGSolver(LinearSolver):
                 },
             )
 
+    # Settings whose stored attribute does not follow the self._<name> convention. Listed
+    # explicitly rather than inferred, because a wrong guess here would apply a setting to nothing
+    # and report success while doing so.
+    _HOT_RELOAD_ALIASES = {
+        "verbosity": "_verbosityIndex",
+        "p1FieldNames": "_p1FieldNamesRequested",
+    }
+    # Changing which file is watched, from inside that file, is not a thing worth supporting.
+    _HOT_RELOAD_IGNORED = ("hotReloadConfigFile",)
+
+    def _maybeHotReloadConfig(self) -> bool:
+        """Re-read the JSON config if it changed on disk; return whether anything was applied.
+
+        Point ``hotReloadConfigFile`` at the config's own path to enable this. It exists so that
+        solver settings can be tried against a *live* run: a degraded AMG hierarchy typically only
+        appears tens of hours into a nonlinear analysis, and rebuilding that state to test one
+        parameter is the expensive part of every tuning round.
+
+        Anything applied forces a hierarchy refresh through ``_refreshNext``, and every derived
+        cache (node coordinates, P1 topology, lazily built P1 maps) is dropped first, because those
+        were built under the *old* settings.
+
+        The file is parsed before its stamp is accepted, so a half-written file -- the normal
+        transient state of an editor saving in place -- is retried on the next solve instead of
+        being recorded as "seen". No failure here can end the run: a missing, unreadable or
+        malformed config is reported and the settings in force are kept. That asymmetry is
+        deliberate. The feature's whole purpose is to be used on a run that is expensive to have
+        reached, so a typo in a config edit must never be able to destroy it.
+        """
+        if self._hotReloadConfigFile is None:
+            return False
+
+        try:
+            fileStat = os.stat(self._hotReloadConfigFile)
+            stamp = (fileStat.st_mtime_ns, fileStat.st_size)
+        except OSError as error:
+            self._log("warning", "hot reload: cannot stat {:}: {:}".format(self._hotReloadConfigFile, error))
+            return False
+
+        if stamp == self._hotReloadStamp:
+            return False
+
+        try:
+            with open(self._hotReloadConfigFile, "r") as configFile:
+                newOptions = json.load(configFile)
+            if not isinstance(newOptions, dict):
+                raise ValueError("expected a JSON object, got {:}".format(type(newOptions).__name__))
+        except (OSError, ValueError) as error:
+            self._log(
+                "warning",
+                "hot reload: {:} is not readable as a JSON object ({:}); keeping the settings in "
+                "force and retrying on the next solve".format(self._hotReloadConfigFile, error),
+            )
+            return False
+
+        self._hotReloadStamp = stamp
+
+        validNames = set(inspect.signature(type(self).__init__).parameters) - {"self"}
+
+        # Diff first, mutate second: the cache invalidation below has to happen before anything is
+        # applied (a p1Maps entry supplied by the new file must not then be dropped as a stale lazy
+        # one), and that needs to know whether there is a change at all.
+        pending, rejected, unknown = [], [], []
+        for name, value in newOptions.items():
+            if name in self._HOT_RELOAD_IGNORED:
+                continue
+            if name not in validNames:
+                unknown.append(name)
+                continue
+
+            if name == "verbosity":
+                if value not in _VERBOSITY_LEVELS:
+                    rejected.append("{:} (must be one of {:})".format(name, _VERBOSITY_LEVELS))
+                    continue
+                newValue = _VERBOSITY_LEVELS.index(value)
+            elif name == "p1FieldNames":
+                newValue = set(value or [])
+            elif name in ("fieldPreconds", "p1Maps"):
+                newValue = value or {}
+            else:
+                newValue = value
+
+            attribute = self._HOT_RELOAD_ALIASES.get(name, "_" + name)
+            if not hasattr(self, attribute):
+                rejected.append("{:} (recognized at construction but not hot-reloadable)".format(name))
+                continue
+
+            oldValue = getattr(self, attribute)
+            if newValue != oldValue:
+                pending.append((name, attribute, oldValue, newValue))
+
+        if pending:
+            for fieldName in self._lazyP1MapNames:
+                self._p1Maps.pop(fieldName, None)
+            self._lazyP1MapNames.clear()
+            self._nodeCoordinateCache.clear()
+            self._pNodeCache.clear()
+
+            for _, attribute, _, newValue in pending:
+                setattr(self, attribute, newValue)
+
+            self._refreshNext = True
+
+        # Reported at "warning" so it lands in the log of a run whose verbosity is not raised: what
+        # settings were in force from which solve onwards is the one thing a later reader of a
+        # hot-reloaded run cannot reconstruct otherwise.
+        if pending or rejected or unknown:
+            summary = ["hot reload of {:} at solve #{:}".format(self._hotReloadConfigFile, self._solveCount)]
+            for name, _, oldValue, newValue in pending:
+                summary.append("  applied  {:}: {!r} -> {!r}".format(name, oldValue, newValue))
+            for entry in rejected:
+                summary.append("  REJECTED {:}".format(entry))
+            for name in unknown:
+                summary.append("  UNKNOWN  {:} (not a BlockAMGSolver setting)".format(name))
+            if not pending:
+                summary.append("  no effective change; hierarchies kept")
+            else:
+                summary.append("  hierarchies will be rebuilt on this solve")
+            self._log("warning", "\n".join(summary))
+
+        return bool(pending)
+
     def __call__(self, A, b):
         solveStartTime = time.time()
         from edelweissfe.linsolve.amgcl.amgcl import PyAMGCLMatrix, PyAMGCLSolver
 
         self._solveCount += 1
+        self._maybeHotReloadConfig()
         A = A.tocsr()
         n = A.shape[0]
         blocks = self._resolveBlocks(n)

--- a/tests/test_blockamg_hot_reload.py
+++ b/tests/test_blockamg_hot_reload.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#  ---------------------------------------------------------------------
+#
+#  _____    _      _              _         _____ _____
+# | ____|__| | ___| |_      _____(_)___ ___|  ___| ____|
+# |  _| / _` |/ _ \ \ \ /\ / / _ \ / __/ __| |_  |  _|
+# | |__| (_| |  __/ |\ V  V /  __/ \__ \__ \  _| | |___
+# |_____\__,_|\___|_| \_/\_/ \___|_|___/___/_|   |_____|
+#
+#
+#  Unit of Strength of Materials and Structural Analysis
+#  University of Innsbruck,
+#  2017 - today
+#
+#  Matthias Neuner matthias.neuner@uibk.ac.at
+"""Regression tests for BlockAMGSolver's hot reload of its own JSON config.
+
+Written alongside the feature, whose whole point is to be used on a run that was expensive to
+reach: a degraded AMG hierarchy typically only appears tens of hours into a nonlinear analysis, so
+settings get tried in place rather than by rebuilding that state. That makes the failure modes the
+interesting part -- editing a file a running process reads is racy by construction, and no bad edit
+may be able to end the run. The malformed-config cases below are the reason this file exists.
+"""
+
+import inspect
+import json
+
+import pytest
+
+from edelweissfe.linsolve.blockamg.blockamg import BlockAMGSolver
+
+
+def _write(path, options):
+    path.write_text(json.dumps(options))
+
+
+def _reload(solver):
+    """One solve's worth of the hot-reload check, without needing a matrix."""
+    solver._solveCount += 1
+    return solver._maybeHotReloadConfig()
+
+
+@pytest.fixture
+def configuredSolver(tmp_path):
+    configPath = tmp_path / "blockamg.json"
+    _write(configPath, {"sweeps": 1, "hotReloadConfigFile": str(configPath)})
+    solver = BlockAMGSolver(sweeps=1, hotReloadConfigFile=str(configPath))
+    return solver, configPath
+
+
+def test_hot_reload_is_off_by_default():
+    solver = BlockAMGSolver()
+    assert solver._maybeHotReloadConfig() is False
+
+
+def test_identical_settings_do_not_force_a_refresh(configuredSolver):
+    solver, _ = configuredSolver
+
+    assert _reload(solver) is False
+    assert solver._refreshNext is False
+
+    # the second call short-circuits on the unchanged stamp
+    assert _reload(solver) is False
+
+
+def test_a_changed_setting_is_applied_and_forces_a_refresh(configuredSolver):
+    solver, configPath = configuredSolver
+    _reload(solver)
+
+    _write(configPath, {"sweeps": 3, "etaMax": 1e-2, "hotReloadConfigFile": str(configPath)})
+
+    assert _reload(solver) is True
+    assert solver._sweeps == 3
+    assert solver._etaMax == 1e-2
+    # a hierarchy built under the old settings must not be reused under the new ones
+    assert solver._refreshNext is True
+
+
+def test_a_malformed_config_changes_nothing_and_is_retried(configuredSolver):
+    solver, configPath = configuredSolver
+    _reload(solver)
+
+    # exactly what an editor saving in place leaves behind for a few milliseconds
+    configPath.write_text('{"sweeps": 9, "etaMax":')
+
+    assert _reload(solver) is False
+    assert solver._sweeps == 1, "a malformed config must not apply anything"
+    assert solver._refreshNext is False
+
+    # and it must NOT be recorded as seen, or the good file that follows with the same size
+    # could be skipped
+    stampAfterBadParse = solver._hotReloadStamp
+    assert _reload(solver) is False
+    assert solver._hotReloadStamp == stampAfterBadParse
+
+    _write(configPath, {"sweeps": 4, "hotReloadConfigFile": str(configPath)})
+    assert _reload(solver) is True
+    assert solver._sweeps == 4
+
+
+def test_a_json_scalar_is_rejected_like_a_parse_error(configuredSolver):
+    solver, configPath = configuredSolver
+    _reload(solver)
+
+    configPath.write_text("42")
+
+    assert _reload(solver) is False
+    assert solver._sweeps == 1
+
+
+def test_a_missing_config_does_not_raise(configuredSolver):
+    solver, configPath = configuredSolver
+    _reload(solver)
+
+    configPath.unlink()
+
+    assert _reload(solver) is False
+    assert solver._sweeps == 1
+
+
+def test_nested_and_aliased_settings_are_diffed_by_value(configuredSolver):
+    solver, configPath = configuredSolver
+    _reload(solver)
+
+    _write(
+        configPath,
+        {
+            "fieldPreconds": {"displacement": {"backendBlockSize": 3}},
+            "p1FieldNames": ["displacement"],
+            "hotReloadConfigFile": str(configPath),
+        },
+    )
+
+    assert _reload(solver) is True
+    assert solver._fieldPreconds == {"displacement": {"backendBlockSize": 3}}
+    # p1FieldNames is stored as a set under a different attribute name
+    assert solver._p1FieldNamesRequested == {"displacement"}
+
+    # re-reading the same content is not a change, even though it went through a dict/set conversion
+    configPath.touch()
+    assert _reload(solver) is False
+
+
+def test_an_unknown_key_alone_does_not_force_a_refresh(configuredSolver):
+    solver, configPath = configuredSolver
+    _reload(solver)
+
+    _write(configPath, {"sweeps": 1, "nonsenseKnob": 1, "hotReloadConfigFile": str(configPath)})
+
+    assert _reload(solver) is False
+    assert solver._refreshNext is False
+
+
+def test_a_reload_drops_caches_derived_from_the_old_settings(configuredSolver):
+    solver, configPath = configuredSolver
+    _reload(solver)
+
+    solver._nodeCoordinateCache["displacement"] = "stale"
+    solver._pNodeCache["displacement"] = "stale"
+    solver._p1Maps["displacement"] = "stale"
+    solver._lazyP1MapNames.add("displacement")
+
+    _write(configPath, {"sweeps": 7, "hotReloadConfigFile": str(configPath)})
+    assert _reload(solver) is True
+
+    assert solver._nodeCoordinateCache == {}
+    assert solver._pNodeCache == {}
+    # a lazily built map belongs to the old settings; an explicitly supplied one would not
+    assert "displacement" not in solver._p1Maps
+    assert solver._lazyP1MapNames == set()
+
+
+def test_every_constructor_setting_is_reloadable_or_explicitly_ignored(configuredSolver):
+    """Guards the self._<name> convention the reload relies on.
+
+    A setting whose stored attribute is named differently, and which is neither aliased nor
+    ignored, would be silently applied to nothing -- so a new constructor parameter has to be
+    classified here rather than quietly becoming un-reloadable.
+    """
+    solver, _ = configuredSolver
+
+    settingNames = set(inspect.signature(BlockAMGSolver.__init__).parameters) - {"self"}
+    unclassified = [
+        name
+        for name in settingNames
+        if name not in BlockAMGSolver._HOT_RELOAD_IGNORED
+        and not hasattr(solver, BlockAMGSolver._HOT_RELOAD_ALIASES.get(name, "_" + name))
+    ]
+
+    assert unclassified == []

--- a/tests/test_blockamg_hot_reload.py
+++ b/tests/test_blockamg_hot_reload.py
@@ -189,3 +189,35 @@ def test_every_constructor_setting_is_reloadable_or_explicitly_ignored(configure
     ]
 
     assert unclassified == []
+
+
+def test_the_factory_forwards_the_hot_reload_path(tmp_path):
+    """The factory builds its kwargs from an explicit whitelist, so a setting that is only added
+    to ``BlockAMGSolver.__init__`` is silently DROPPED on the path a deck actually uses.
+
+    That is not hypothetical: it is how this feature first shipped, and the symptom was a run that
+    read its config once and never again, with nothing in the log to say so -- because an
+    unrecognized key in the JSON is dropped by the whitelist rather than rejected.
+    """
+    from edelweissfe.linsolve.blockamg import createSolver
+
+    configPath = tmp_path / "blockamg.json"
+    _write(configPath, {"sweeps": 1, "hotReloadConfigFile": str(configPath)})
+
+    solver = createSolver({"sweeps": 1, "hotReloadConfigFile": str(configPath)})
+
+    assert solver._hotReloadConfigFile == str(configPath)
+
+    # and it is live, not merely stored
+    _write(configPath, {"sweeps": 5, "hotReloadConfigFile": str(configPath)})
+    assert _reload(solver) is True
+    assert solver._sweeps == 5
+
+
+def test_the_factory_defaults_the_hot_reload_path_to_off():
+    from edelweissfe.linsolve.blockamg import createSolver
+
+    solver = createSolver({"sweeps": 1})
+
+    assert solver._hotReloadConfigFile is None
+    assert solver._maybeHotReloadConfig() is False


### PR DESCRIPTION
## Why

Solver settings were fixed at construction, so trying one parameter meant restarting the analysis — and for this solver that is the expensive part of every tuning round. A degraded AMG hierarchy typically only appears tens of hours into a nonlinear run: the live `AnchorPryOut` implicit case sat at **276–340 outer iterations per solve after 27 h**, with 811 degradation warnings and the increment stuck 10× below `maxInc`. Rebuilding that state to test a knob costs more than the test.

Worse, restarting to try a setting is not always even possible. Doing exactly that is what cost a 27-hour run on this model today — the restart turned out to be broken for that deck, which nothing had checked because nothing had needed to.

## What

`hotReloadConfigFile` — point it at the config's own path:

```json
{
  "outerSolver": "amgcl_lgmres",
  "sweeps": 1,
  "hotReloadConfigFile": "blockamg.json"
}
```

Every solve then checks whether the file changed, re-reads it, applies the recognized settings, and forces a hierarchy rebuild through the existing `_refreshNext`. Derived caches (node coordinates, P1 topology, lazily built P1 maps) are dropped first, since they were built under the old settings. Off unless asked for.

Verified on a live run — this is from the solver's own log, after editing the JSON while it was solving:

```
hot reload of blockamg.json at solve #4
   applied  warnOuterIterationsThreshold: 90 -> 80
   hierarchies will be rebuilt on this solve
   blockamg: solve #4    REFRESH  34it eta=3.0e-04 res=9.4e-06 cont=1 time=8.099s
```

## Failing safely is the design constraint, not a detail

Editing a file a running process reads is racy by construction, and the runs worth using this on are precisely the ones that were expensive to reach. So no bad edit may be able to end one:

- the file is parsed **before** its `(mtime, size)` stamp is accepted, so the half-written state an editor leaves behind for a few milliseconds is retried on the next solve rather than recorded as seen;
- a missing, unreadable or malformed config is reported and **the settings in force are kept**;
- unrecognized keys are reported rather than ignored, and so are recognized ones with no hot-reloadable attribute.

Applied changes are logged at `warning` level deliberately: which settings were in force from which solve onwards is the one thing a later reader of a hot-reloaded run cannot reconstruct from anything else.

## Second commit: the factory dropped the setting silently

`createSolver` builds its kwargs from an explicit `(key, cast)` whitelist. The parameter was added to `BlockAMGSolver.__init__` but not to that list, so **on the path a deck actually uses it was dropped and the solver got `None`** — the feature read its config once at startup and never again, with nothing in the log to say so.

The existing tests missed it because they construct `BlockAMGSolver` directly and never go through the factory. Two cases now cover the factory path; I verified the first fails when the whitelist entry is reverted.

Worth noting independently of this PR: **an unrecognized key in `blockamg.json` is dropped, not rejected.** That is what made the above invisible, and it will silently swallow any typo'd setting.

## Tests

12 cases in `tests/test_blockamg_hot_reload.py`, weighted towards the failure modes rather than the happy path:

- identical settings do not force a refresh; an unchanged file short-circuits on the stamp
- a changed setting is applied **and** forces a rebuild
- a malformed config changes nothing **and** is not stamped as seen, so the good file that follows is still picked up
- a JSON scalar is rejected like a parse error; a vanished file does not raise
- nested (`fieldPreconds`) and aliased (`p1FieldNames` → a set under a different attribute) settings diff by value, and re-reading identical content after a `touch` is not a change
- an unknown-key-only edit does not force a rebuild
- caches derived from the old settings are dropped, including lazily built P1 maps
- a guard that **every** constructor parameter is either hot-reloadable or explicitly classified, so a new one cannot quietly become un-reloadable
- both factory-path cases above

`16 passed` together with the existing `test_blockamg_forcing_tolerance.py`. Rebased onto current `next_v26.11`, including `5d9d5e36`, which touches the same file.

Pre-existing and unrelated on this tree: 5 input-language golden/schema-surface tests fail with and without this change (verified against `HEAD`'s `blockamg.py`).

## Scope

Additive only — `+375 / -0` across three files. No behaviour change for any run that does not set `hotReloadConfigFile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
